### PR TITLE
Remove unused #define's related to md32_common.h

### DIFF
--- a/crypto/digest/md32_common.h
+++ b/crypto/digest/md32_common.h
@@ -57,15 +57,6 @@ extern "C" {
 #endif
 
 
-#if !defined(DATA_ORDER_IS_BIG_ENDIAN)
-#error "DATA_ORDER must be defined, and only big endian is supported.!"
-#endif
-
-#ifndef HASH_CBLOCK
-#error "HASH_CBLOCK must be defined!"
-#endif
-
-
 #if !defined(PEDANTIC) && defined(__GNUC__) && __GNUC__ >= 2 && \
     !defined(OPENSSL_NO_ASM)
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)

--- a/crypto/sha/sha1.c
+++ b/crypto/sha/sha1.c
@@ -57,9 +57,6 @@
 #include "openssl/base.h"
 
 
-#define DATA_ORDER_IS_BIG_ENDIAN /* Required by md32_common.h. */
-#define HASH_CBLOCK             64
-
 #define ROTATE(a, n) (((a) << (n)) | ((a) >> (32 - (n))))
 #define Xupdate(a, ix, ia, ib, ic, id) \
   ((a) = (ia ^ ib ^ ic ^ id), ix = (a) = ROTATE((a), 1))

--- a/crypto/sha/sha256.c
+++ b/crypto/sha/sha256.c
@@ -63,9 +63,6 @@
 #define SHA256_ASM
 #endif
 
-#define DATA_ORDER_IS_BIG_ENDIAN /* Required by md32_common.h */
-#define HASH_CBLOCK 64
-
 #include "../digest/md32_common.h"
 
 #ifndef SHA256_ASM


### PR DESCRIPTION
`HASH_CBLOCK` and `DATA_ORDER_IS_BIG_ENDIAN` were previously required by
'md32_common.h' as a part of a generic 32-bit "collector", but that has
been removed, so these are no longer used.