### PR TITLE
Replace usages of `PULL64` macro with `from_be_u64`.

### DIFF
--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -507,14 +507,14 @@ static inline uint64_t from_be_u64(const uint64_t data) {
 #elif OPENSSL_ENDIAN == OPENSSL_BIG_ENDIAN
   return data;
 #else
-  return (data[0] << 56) |
-         (data[1] << 48) |
-         (data[2] << 40) |
-         (data[3] << 32) |
-         (data[4] << 24) |
-         (data[5] << 16) |
-         (data[6] << 8) |
-         (data[7]);
+  return ((uint64_t)data[0] << 56) |
+         ((uint64_t)data[1] << 48) |
+         ((uint64_t)data[2] << 40) |
+         ((uint64_t)data[3] << 32) |
+         ((uint64_t)data[4] << 24) |
+         ((uint64_t)data[5] << 16) |
+         ((uint64_t)data[6] << 8) |
+         ((uint64_t)data[7]);
 #endif
 }
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -499,7 +499,8 @@ static inline uint32_t from_be_u32_ptr(const uint8_t *data) {
 #endif
 }
 
-/* from_be_u64 returns the 64-bit big-endian-encoded value |data|. */
+/* from_be_u64 returns the native representation of the 64-bit
+ * big-endian-encoded value |data|. */
 static inline uint64_t from_be_u64(const uint64_t data) {
 #if STRICT_ALIGNMENT == 0 && OPENSSL_ENDIAN == OPENSSL_LITTLE_ENDIAN && \
     defined(bswap_u64)

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -499,6 +499,25 @@ static inline uint32_t from_be_u32_ptr(const uint8_t *data) {
 #endif
 }
 
+/* from_be_u64 returns the 64-bit big-endian-encoded value |data|. */
+static inline uint64_t from_be_u64(const uint64_t data) {
+#if STRICT_ALIGNMENT == 0 && OPENSSL_ENDIAN == OPENSSL_LITTLE_ENDIAN && \
+    defined(bswap_u64)
+  return bswap_u64(data);
+#elif STRICT_ALIGNMENT == 0 && OPENSSL_ENDIAN == OPENSSL_BIG_ENDIAN
+  return data;
+#else
+  return (data[0] << 56) |
+         (data[1] << 48) |
+         (data[2] << 40) |
+         (data[3] << 32) |
+         (data[4] << 24) |
+         (data[5] << 16) |
+         (data[6] << 8) |
+         (data[7]);
+#endif
+}
+
 
 #if defined(__cplusplus)
 }  /* extern C */

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -502,10 +502,9 @@ static inline uint32_t from_be_u32_ptr(const uint8_t *data) {
 /* from_be_u64 returns the native representation of the 64-bit
  * big-endian-encoded value |data|. */
 static inline uint64_t from_be_u64(const uint64_t data) {
-#if STRICT_ALIGNMENT == 0 && OPENSSL_ENDIAN == OPENSSL_LITTLE_ENDIAN && \
-    defined(bswap_u64)
+#if OPENSSL_ENDIAN == OPENSSL_LITTLE_ENDIAN && defined(bswap_u64)
   return bswap_u64(data);
-#elif STRICT_ALIGNMENT == 0 && OPENSSL_ENDIAN == OPENSSL_BIG_ENDIAN
+#elif OPENSSL_ENDIAN == OPENSSL_BIG_ENDIAN
   return data;
 #else
   return (data[0] << 56) |

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -148,9 +148,6 @@ static const uint64_t K512[80] = {
 #pragma intrinsic(_rotr64)
 #define ROTR(a, n) _rotr64((a), n)
 #endif
-#if defined(_M_IX86) && !defined(OPENSSL_NO_ASM) && _MSC_VER <= 1200
-#pragma inline_depth(0)
-#endif
 #endif
 
 #ifndef ROTR


### PR DESCRIPTION
I agree to license my contributions to each file under the same terms
given at the top of each file I changed.