### PR TITLE
Remove MSVC conditional checks for now-unsupported versions

### DIFF
--- a/crypto/bn/internal.h
+++ b/crypto/bn/internal.h
@@ -125,7 +125,7 @@
 
 #include <openssl/base.h>
 
-#if defined(OPENSSL_X86_64) && defined(_MSC_VER) && _MSC_VER >= 1400
+#if defined(OPENSSL_X86_64) && defined(_MSC_VER)
 #pragma warning(push, 3)
 #include <intrin.h>
 #pragma warning(pop)
@@ -303,7 +303,7 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
 		: "=a"(low),"=d"(high)	\
 		: "a"(a),"g"(b)		\
 		: "cc");
-# elif defined(_MSC_VER) && _MSC_VER >= 1400
+# elif defined(_MSC_VER)
 #  define BN_UMULT_HIGH(a, b) __umulh((a), (b))
 #  define BN_UMULT_LOHI(low, high, a, b) ((low) = _umul128((a), (b), &(high)))
 # endif

--- a/crypto/modes/internal.h
+++ b/crypto/modes/internal.h
@@ -116,20 +116,12 @@ extern "C" {
   })
 #endif
 #elif defined(_MSC_VER)
-#if _MSC_VER >= 1300
 #pragma warning(push, 3)
 #include <intrin.h>
 #pragma warning(pop)
 #pragma intrinsic(_byteswap_uint64, _byteswap_ulong)
 #define BSWAP8(x) _byteswap_uint64((uint64_t)(x))
 #define BSWAP4(x) _byteswap_ulong((uint32_t)(x))
-#elif defined(OPENSSL_X86)
-__inline uint32_t _bswap4(uint32_t val) {
-  _asm mov eax, val
-  _asm bswap eax
-}
-#define BSWAP4(x) _bswap4(x)
-#endif
 #endif
 #endif
 


### PR DESCRIPTION
According to @briansmith, Ring doesn't support any version lower than
1700, which makes these version checks obsolete.

I agree to license my contributions to each file under the same terms
given at the top of each file I changed.