### PR TITLE
Replace usages of `ROTR` macro with `rotate_right_u64`.

### DIFF
--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -519,12 +519,12 @@ static inline uint64_t from_be_u64(const uint64_t data) {
 #endif
 }
 
-/* rotate_right_u64 returns the |data| with its bits rotated |n| bits to the
+/* rotate_right_u64 returns the value |x| with its bits rotated |n| bits to the
    right */
-static inline uint64_t rotate_right_u64(uint64_t data, int n) {
+static inline uint64_t rotate_right_u64(uint64_t x, int n) {
     assert(n > 0);
     assert(n < 64);
-    return (data >> n) | (data << (64 - n));
+    return (x >> n) | (x << (64 - n));
 }
 
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -521,8 +521,7 @@ static inline uint64_t from_be_u64(const uint64_t data) {
 /* rotate_right_u64 returns the |data| with its bits rotated |n| bits to the
    right */
 static inline uint64_t rotate_right_u64(const uint64_t data, int n) {
-    return (data >> n) |
-           (data << (64 - n));
+    return (data >> n) | (data << (64 - n));
 }
 
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -518,7 +518,6 @@ static inline uint64_t from_be_u64(const uint64_t data) {
 #endif
 }
 
-
 /* rotate_right_u64 returns the |data| with its bits rotated |n| bits to the
    right */
 static inline uint64_t rotate_right_u64(const uint64_t data, int n) {

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -521,7 +521,7 @@ static inline uint64_t from_be_u64(const uint64_t data) {
 
 /* rotate_right_u64 returns the |data| with its bits rotated |n| bits to the
    right */
-static inline uint64_t rotate_right_u64(const uint64_t data, int n) {
+static inline uint64_t rotate_right_u64(uint64_t data, int n) {
     assert(n > 0);
     assert(n < 64);
     return (data >> n) | (data << (64 - n));

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -519,6 +519,14 @@ static inline uint64_t from_be_u64(const uint64_t data) {
 }
 
 
+/* rotate_right_u64 returns the |data| with its bits rotated |n| bits to the
+   right */
+static inline uint64_t rotate_right_u64(const uint64_t data, int n) {
+    return (data >> n) |
+           (data << (64 - n));
+}
+
+
 #if defined(__cplusplus)
 }  /* extern C */
 #endif

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -109,6 +109,7 @@
 #ifndef OPENSSL_HEADER_CRYPTO_INTERNAL_H
 #define OPENSSL_HEADER_CRYPTO_INTERNAL_H
 
+#include <assert.h>
 #include <openssl/base.h>
 #include <openssl/thread.h>
 
@@ -521,6 +522,8 @@ static inline uint64_t from_be_u64(const uint64_t data) {
 /* rotate_right_u64 returns the |data| with its bits rotated |n| bits to the
    right */
 static inline uint64_t rotate_right_u64(const uint64_t data, int n) {
+    assert(n > 0);
+    assert(n < 64);
     return (data >> n) | (data << (64 - n));
 }
 

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -120,44 +120,21 @@ static const uint64_t K512[80] = {
     UINT64_C(0x5fcb6fab3ad6faec), UINT64_C(0x6c44198c4a475817),
 };
 
-#if defined(__GNUC__) && __GNUC__ >= 2 && !defined(OPENSSL_NO_ASM)
-#if defined(__x86_64) || defined(__x86_64__)
-#define ROTR(a, n)                                              \
-  ({                                                            \
-    uint64_t ret;                                               \
-    __asm__("rorq %1, %0" : "=r"(ret) : "J"(n), "0"(a) : "cc"); \
-    ret;                                                        \
-  })
-#elif(defined(_ARCH_PPC) && defined(__64BIT__)) || defined(_ARCH_PPC64)
-#define ROTR(a, n)                                             \
-  ({                                                           \
-    uint64_t ret;                                              \
-    __asm__("rotrdi %0, %1, %2" : "=r"(ret) : "r"(a), "K"(n)); \
-    ret;                                                       \
-  })
-#elif defined(__aarch64__)
-#define ROTR(a, n)                                          \
-  ({                                                        \
-    uint64_t ret;                                           \
-    __asm__("ror %0, %1, %2" : "=r"(ret) : "r"(a), "I"(n)); \
-    ret;                                                    \
-  })
-#endif
-#elif defined(_MSC_VER)
-#if defined(_WIN64) /* applies to both IA-64 and AMD64 */
-#pragma intrinsic(_rotr64)
-#define ROTR(a, n) _rotr64((a), n)
-#endif
-#endif
+#define Sigma0(x) (rotate_right_u64((x), 28) ^ \
+                   rotate_right_u64((x), 34) ^ \
+                   rotate_right_u64((x), 39))
 
-#ifndef ROTR
-#define ROTR(x, s) (((x) >> s) | (x) << (64 - s))
-#endif
+#define Sigma1(x) (rotate_right_u64((x), 14) ^ \
+                   rotate_right_u64((x), 18) ^ \
+                   rotate_right_u64((x), 41))
 
-#define Sigma0(x) (ROTR((x), 28) ^ ROTR((x), 34) ^ ROTR((x), 39))
-#define Sigma1(x) (ROTR((x), 14) ^ ROTR((x), 18) ^ ROTR((x), 41))
-#define sigma0(x) (ROTR((x), 1) ^ ROTR((x), 8) ^ ((x) >> 7))
-#define sigma1(x) (ROTR((x), 19) ^ ROTR((x), 61) ^ ((x) >> 6))
+#define sigma0(x) (rotate_right_u64((x), 1) ^ \
+                   rotate_right_u64((x), 8) ^ \
+                   ((x) >> 7))
+
+#define sigma1(x) (rotate_right_u64((x), 19) ^ \
+                   rotate_right_u64((x), 61) ^ \
+                   ((x) >> 6))
 
 #define Ch(x, y, z) (((x) & (y)) ^ ((~(x)) & (z)))
 #define Maj(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))


### PR DESCRIPTION
I agree to license my contributions to each file under the same terms
given at the top of each file I changed.