### PR TITLE
Remove unnecessary lower bound when slicing in digest.

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -133,8 +133,7 @@ impl Context {
         }
         if num_to_save_for_later > 0 {
             polyfill::slice::fill_from_slice(
-                &mut self.pending[self.num_pending..
-                                  (self.num_pending + num_to_save_for_later)],
+                &mut self.pending[..num_to_save_for_later],
                 &remaining[(remaining.len() - num_to_save_for_later)..]);
             self.num_pending = num_to_save_for_later;
         }


### PR DESCRIPTION
At this point in the function, `num_pending` should always be `0`.

I agree to license my contributions to each file under the
same terms given at the top of each file I changed.