### PR TITLE
Fix typo in `ring::hmac::sign` documentation.

### DIFF
--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -271,7 +271,7 @@ impl SigningContext {
 
 /// Calculates the HMAC of `data` using the key `key` in one step.
 ///
-/// Use `SignignContext` to calculate HMACs where the input is in multiple
+/// Use `SigningContext` to calculate HMACs where the input is in multiple
 /// parts.
 ///
 /// It is generally not safe to implement HMAC verification by comparing the


### PR DESCRIPTION
I agree to license my contributions to each file under the
same terms given at the top of each file I changed.