### PR TITLE
Use `<[T]>::clone_from_slice()`.

### DIFF
--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -108,7 +108,7 @@ fn chacha20_poly1305_update_old(state: &mut [u8; POLY1305_STATE_LEN],
 
 /// Copies |key| into |ctx_buf|.
 pub fn init(ctx_buf: &mut [u8], key: &[u8]) -> Result<(), ()> {
-    polyfill::slice::fill_from_slice(&mut ctx_buf[..key.len()], key);
+    ctx_buf[..key.len()].clone_from_slice(key);
     Ok(())
 }
 

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -93,10 +93,8 @@ impl Context {
     /// C analog: `EVP_DigestUpdate`
     pub fn update(&mut self, data: &[u8]) {
         if data.len() < self.algorithm.block_len - self.num_pending {
-            polyfill::slice::fill_from_slice(
-                &mut self.pending[self.num_pending..
-                                  (self.num_pending + data.len())],
-                data);
+            self.pending[self.num_pending..
+                (self.num_pending + data.len())].clone_from_slice(data);
             self.num_pending += data.len();
             return;
         }
@@ -104,9 +102,8 @@ impl Context {
         let mut remaining = data;
         if self.num_pending > 0 {
             let to_copy = self.algorithm.block_len - self.num_pending;
-            polyfill::slice::fill_from_slice(
-                &mut self.pending[self.num_pending..self.algorithm.block_len],
-                &data[..to_copy]);
+            self.pending[self.num_pending..self.algorithm.block_len]
+                .clone_from_slice(&data[..to_copy]);
 
             unsafe {
                 (self.algorithm.block_data_order)(self.state.as_mut_ptr(),
@@ -132,8 +129,7 @@ impl Context {
                                           .unwrap();
         }
         if num_to_save_for_later > 0 {
-            polyfill::slice::fill_from_slice(
-                &mut self.pending[..num_to_save_for_later],
+            self.pending[..num_to_save_for_later].clone_from_slice(
                 &remaining[(remaining.len() - num_to_save_for_later)..]);
             self.num_pending = num_to_save_for_later;
         }

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -34,17 +34,6 @@ pub mod slice {
         }
     }
 
-    // https://github.com/rust-lang/rust/issues/27750
-    // https://internals.rust-lang.org/t/stabilizing-basic-functions-on-arrays-and-slices/2868
-    #[inline(always)]
-    pub fn fill_from_slice(dest: &mut [u8], src: &[u8]) {
-        assert_eq!(dest.len(), src.len());
-        unsafe {
-            core::ptr::copy_nonoverlapping(src.as_ptr(), dest.as_mut_ptr(),
-                                           src.len())
-        }
-    }
-
     // https://internals.rust-lang.org/t/safe-trasnsmute-for-slices-e-g-u64-u32-particularly-simd-types/2871
     #[inline(always)]
     pub fn u64_as_u8<'a>(src: &'a [u64]) -> &'a [u8] {


### PR DESCRIPTION
Replace all occurences of `ring::polyfill::fill_from_slice`.

Closes #136