### PR TITLE
Add AEAD tests that test all prefix length from 0-4096 bytes.

### DIFF
--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -295,9 +295,9 @@ mod tests {
                   "crypto/cipher/test/aes_128_gcm_tests.txt");
     }
 
+    #[cfg(not(debug_assertions))]
     #[test]
-    #[ignore]
-    pub fn test_aes_gcm_128_slow() {
+    pub fn test_aes_gcm_128_in_prefix_len_extra() {
         test_aead_slow(&aead::AES_128_GCM,
                   "crypto/cipher/test/aes_128_gcm_tests.txt");
     }
@@ -308,9 +308,9 @@ mod tests {
                   "crypto/cipher/test/aes_256_gcm_tests.txt");
     }
 
+    #[cfg(not(debug_assertions))]
     #[test]
-    #[ignore]
-    pub fn test_aes_gcm_256_slow() {
+    pub fn test_aes_gcm_256_in_prefix_len_extra() {
         test_aead_slow(&aead::AES_256_GCM,
                   "crypto/cipher/test/aes_256_gcm_tests.txt");
     }
@@ -321,9 +321,9 @@ mod tests {
                   "crypto/cipher/test/chacha20_poly1305_tests.txt");
     }
 
+    #[cfg(not(debug_assertions))]
     #[test]
-    #[ignore]
-    pub fn test_chacha20_poly1305_slow() {
+    pub fn test_chacha20_poly1305_in_prefix_len_extra() {
         test_aead_slow(&aead::CHACHA20_POLY1305,
                   "crypto/cipher/test/chacha20_poly1305_tests.txt");
     }
@@ -334,9 +334,9 @@ mod tests {
                   "crypto/cipher/test/chacha20_poly1305_old_tests.txt");
     }
 
+    #[cfg(not(debug_assertions))]
     #[test]
-    #[ignore]
-    pub fn test_chacha20_poly1305_old_slow() {
+    pub fn test_chacha20_poly1305_old_in_prefix_len_extra() {
         test_aead_slow(&aead::CHACHA20_POLY1305_OLD,
                   "crypto/cipher/test/chacha20_poly1305_old_tests.txt");
     }
@@ -459,6 +459,7 @@ mod tests {
         });
     }
 
+    #[cfg(not(debug_assertions))]
     fn test_aead_slow(aead_alg: &'static aead::Algorithm, file_path: &str) {
         file_test::run(file_path, |section, test_case| {
             const PREFIX: [u8; 4096] = [123; 4096];

--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -286,6 +286,7 @@ fn check_per_nonce_max_bytes(in_out_len: usize) -> Result<(), ()> {
 
 #[cfg(test)]
 mod tests {
+    use std::string::String;
     use super::super::{aead, file_test};
     use std::vec::Vec;
 
@@ -296,8 +297,22 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    pub fn test_aes_gcm_128_slow() {
+        test_aead_slow(&aead::AES_128_GCM,
+                  "crypto/cipher/test/aes_128_gcm_tests.txt");
+    }
+
+    #[test]
     pub fn test_aes_gcm_256() {
         test_aead(&aead::AES_256_GCM,
+                  "crypto/cipher/test/aes_256_gcm_tests.txt");
+    }
+
+    #[test]
+    #[ignore]
+    pub fn test_aes_gcm_256_slow() {
+        test_aead_slow(&aead::AES_256_GCM,
                   "crypto/cipher/test/aes_256_gcm_tests.txt");
     }
 
@@ -308,8 +323,22 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    pub fn test_chacha20_poly1305_slow() {
+        test_aead_slow(&aead::CHACHA20_POLY1305,
+                  "crypto/cipher/test/chacha20_poly1305_tests.txt");
+    }
+
+    #[test]
     pub fn test_chacha20_poly1305_old() {
         test_aead(&aead::CHACHA20_POLY1305_OLD,
+                  "crypto/cipher/test/chacha20_poly1305_old_tests.txt");
+    }
+
+    #[test]
+    #[ignore]
+    pub fn test_chacha20_poly1305_old_slow() {
+        test_aead_slow(&aead::CHACHA20_POLY1305_OLD,
                   "crypto/cipher/test/chacha20_poly1305_old_tests.txt");
     }
 
@@ -396,38 +425,29 @@ mod tests {
             ];
 
             for in_prefix in IN_PREFIXES.iter() {
-                let max_overhead_len = aead_alg.max_overhead_len();
-                let mut s_in_out = plaintext.clone();
-                for _ in 0..max_overhead_len {
-                    s_in_out.push(0);
-                }
-                let s_key = aead::SealingKey::new(aead_alg, &key_bytes).unwrap();
-                let s_result = aead::seal_in_place(&s_key, &nonce,
-                                                   &mut s_in_out[..],
-                                                   max_overhead_len, &ad);
+                test_aead_inner(aead_alg, &key_bytes, &nonce, &plaintext,
+                                &ad, &ct, &error, in_prefix)
+            }
+        });
+    }
 
-                let mut o_in_out = Vec::from(*in_prefix);
-                o_in_out.extend_from_slice(&ct[..]);
-                let o_key = aead::OpeningKey::new(aead_alg, &key_bytes).unwrap();
-                let o_result = aead::open_in_place(&o_key, &nonce,
-                                                   in_prefix.len(),
-                                                   &mut o_in_out[..], &ad);
+    fn test_aead_slow(aead_alg: &'static aead::Algorithm, file_path: &str) {
+        file_test::run(file_path, |section, test_case| {
+            assert_eq!(section, "");
+            let key_bytes = test_case.consume_bytes("KEY");
+            let nonce = test_case.consume_bytes("NONCE");
+            let plaintext = test_case.consume_bytes("IN");
+            let ad = test_case.consume_bytes("AD");
+            let mut ct = test_case.consume_bytes("CT");
+            let tag = test_case.consume_bytes("TAG");
+            let error = test_case.consume_optional_string("FAILS");
 
-                match error {
-                    None => {
-                        assert_eq!(Ok(ct.len()), s_result);
-                        assert_eq!(&ct[..], &s_in_out[..ct.len()]);
-                        assert_eq!(Ok(plaintext.len()), o_result);
-                        assert_eq!(&plaintext[..], &o_in_out[..plaintext.len()]);
-                    },
-                    Some(ref error) if error == "WRONG_NONCE_LENGTH" => {
-                        assert_eq!(Err(()), s_result);
-                        assert_eq!(Err(()), o_result);
-                    },
-                    Some(error) => {
-                        unreachable!("Unexpected error test case: {}", error);
-                    }
-                };
+            ct.extend(tag);
+
+            for in_prefix_len in 0..4096 {
+                let in_prefix = &vec![123; in_prefix_len][..];
+                test_aead_inner(aead_alg, &key_bytes, &nonce, &plaintext,
+                                &ad, &ct, &error, in_prefix)
             }
         });
     }
@@ -612,5 +632,47 @@ mod tests {
             assert!(aead::open_in_place(&o_key, &nonce[..16], prefix_len,
                                         &mut in_out, &ad).is_err());
         }
+    }
+
+    fn test_aead_inner(aead_alg: &'static aead::Algorithm,
+                       key_bytes: &[u8],
+                       nonce: &[u8],
+                       plaintext: &Vec<u8>,
+                       ad: &[u8],
+                       ct: &[u8],
+                       error: &Option<String>,
+                       in_prefix: &[u8]) {
+        let max_overhead_len = aead_alg.max_overhead_len();
+        let mut s_in_out = plaintext.clone();
+        for _ in 0..max_overhead_len {
+            s_in_out.push(0);
+        }
+        let s_key = aead::SealingKey::new(aead_alg, key_bytes).unwrap();
+        let s_result = aead::seal_in_place(&s_key, nonce,
+                                           &mut s_in_out[..],
+                                           max_overhead_len, &ad);
+
+        let mut o_in_out = Vec::from(in_prefix);
+        o_in_out.extend_from_slice(&ct[..]);
+        let o_key = aead::OpeningKey::new(aead_alg, key_bytes).unwrap();
+        let o_result = aead::open_in_place(&o_key, nonce,
+                                           in_prefix.len(),
+                                           &mut o_in_out[..], &ad);
+
+        match *error {
+            None => {
+                assert_eq!(Ok(ct.len()), s_result);
+                assert_eq!(&ct[..], &s_in_out[..ct.len()]);
+                assert_eq!(Ok(plaintext.len()), o_result);
+                assert_eq!(&plaintext[..], &o_in_out[..plaintext.len()]);
+            },
+            Some(ref error) if *error == "WRONG_NONCE_LENGTH" => {
+                assert_eq!(Err(()), s_result);
+                assert_eq!(Err(()), o_result);
+            },
+            Some(ref error) => {
+                unreachable!("Unexpected error test case: {}", error);
+            }
+        };
     }
 }

--- a/src/digest/digest.rs
+++ b/src/digest/digest.rs
@@ -615,8 +615,8 @@ mod tests {
     /// This is not run in dev (debug) builds because it is too slow.
     macro_rules! test_i_u_f {
         ( $test_name:ident, $alg:expr) => {
+            #[cfg(not(debug_assertions))]
             #[test]
-            #[ignore]
             fn $test_name() {
                 let mut input = vec![0u8; $alg.block_len * 2];
                 for i in 0..input.len() {

--- a/src/digest/digest.rs
+++ b/src/digest/digest.rs
@@ -615,8 +615,8 @@ mod tests {
     /// This is not run in dev (debug) builds because it is too slow.
     macro_rules! test_i_u_f {
         ( $test_name:ident, $alg:expr) => {
-            #[cfg(not(debug_assertions))]
             #[test]
+            #[ignore]
             fn $test_name() {
                 let mut input = vec![0u8; $alg.block_len * 2];
                 for i in 0..input.len() {


### PR DESCRIPTION
The new tests are optional. To run them use `cargo test -- --ignored`.

Partially fixes #127.