### PR TITLE
Replace usages of `BN_with_flags` with flag assignment.

### DIFF
--- a/crypto/bn/bn.c
+++ b/crypto/bn/bn.c
@@ -144,12 +144,6 @@ const BIGNUM *BN_value_one(void) {
   return &kOne;
 }
 
-void BN_with_flags(BIGNUM *out, const BIGNUM *in, int flags) {
-  memcpy(out, in, sizeof(BIGNUM));
-  out->flags &= ~BN_FLG_MALLOCED;
-  out->flags |= BN_FLG_STATIC_DATA | flags;
-}
-
 /* BN_num_bits_word returns the minimum number of bits needed to represent the
  * value in |l|. */
 unsigned BN_num_bits_word(BN_ULONG l) {

--- a/crypto/bn/gcd.c
+++ b/crypto/bn/gcd.c
@@ -417,8 +417,6 @@ BIGNUM *BN_mod_inverse(BIGNUM *out, const BIGNUM *a, const BIGNUM *n,
 BIGNUM *BN_mod_inverse_no_branch(BIGNUM *out, int *out_no_inverse,
                                  const BIGNUM *a, const BIGNUM *n, BN_CTX *ctx) {
   BIGNUM *A, *B, *X, *Y, *M, *D, *T, *R = NULL;
-  BIGNUM local_A, local_B;
-  BIGNUM *pA, *pB;
   BIGNUM *ret = NULL;
   int sign;
 
@@ -452,12 +450,8 @@ BIGNUM *BN_mod_inverse_no_branch(BIGNUM *out, int *out_no_inverse,
   A->neg = 0;
 
   if (B->neg || (BN_ucmp(B, A) >= 0)) {
-    /* Turn BN_FLG_CONSTTIME flag on, so that when BN_div is invoked,
-     * BN_div_no_branch will be called eventually.
-     */
-    pB = &local_B;
-    BN_with_flags(pB, B, BN_FLG_CONSTTIME);
-    if (!BN_nnmod(B, pB, A, ctx)) {
+    BN_set_flags(B, BN_FLG_CONSTTIME);
+    if (!BN_nnmod(B, B, A, ctx)) {
       goto err;
     }
   }
@@ -478,14 +472,10 @@ BIGNUM *BN_mod_inverse_no_branch(BIGNUM *out, int *out_no_inverse,
      *      sign*Y*a  ==  A   (mod |n|)
      */
 
-    /* Turn BN_FLG_CONSTTIME flag on, so that when BN_div is invoked,
-     * BN_div_no_branch will be called eventually.
-     */
-    pA = &local_A;
-    BN_with_flags(pA, A, BN_FLG_CONSTTIME);
+    BN_set_flags(A, BN_FLG_CONSTTIME);
 
     /* (D, M) := (A/B, A%B) ... */
-    if (!BN_div(D, M, pA, B, ctx)) {
+    if (!BN_div(D, M, A, B, ctx)) {
       goto err;
     }
 

--- a/crypto/rsa/rsa.c
+++ b/crypto/rsa/rsa.c
@@ -120,24 +120,34 @@ int rsa_new_end(RSA *rsa, BN_CTX *ctx) {
   /* Make sure BN_mod_inverse in Montgomery intialization uses the
    * BN_FLG_CONSTTIME flag. */
 
+  assert(BN_get_flags(rsa->d, BN_FLG_CONSTTIME));
+
+  if (rsa->dmp1) {
+    assert(BN_get_flags(rsa->dmp1, BN_FLG_CONSTTIME));
+  }
+
+  if (rsa->dmq1) {
+    assert(BN_get_flags(rsa->dmq1, BN_FLG_CONSTTIME));
+  }
+
+  if (rsa->iqmp) {
+    assert(BN_get_flags(rsa->iqmp, BN_FLG_CONSTTIME));
+  }
+
   if (rsa->p) {
-    BIGNUM local_p;
-    BN_init(&local_p);
-    BN_with_flags(&local_p, rsa->p, BN_FLG_CONSTTIME);
+    assert(BN_get_flags(rsa->p, BN_FLG_CONSTTIME));
     rsa->mont_p = BN_MONT_CTX_new();
     if (rsa->mont_p == NULL ||
-        !BN_MONT_CTX_set(rsa->mont_p, &local_p, ctx)) {
+        !BN_MONT_CTX_set(rsa->mont_p, rsa->p, ctx)) {
       return 0;
     }
   }
 
   if (rsa->q) {
-    BIGNUM local_q;
-    BN_init(&local_q);
-    BN_with_flags(&local_q, rsa->q, BN_FLG_CONSTTIME);
+    assert(BN_get_flags(rsa->q, BN_FLG_CONSTTIME));
     rsa->mont_q = BN_MONT_CTX_new();
     if (rsa->mont_q == NULL ||
-        !BN_MONT_CTX_set(rsa->mont_q, &local_q, ctx)) {
+        !BN_MONT_CTX_set(rsa->mont_q, rsa->q, ctx)) {
       return 0;
     }
   }

--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -67,12 +67,13 @@
 #include "internal.h"
 
 
-static int parse_integer(CBS *cbs, BIGNUM **out) {
+static int parse_integer_consttime(CBS *cbs, BIGNUM **out) {
   assert(*out == NULL);
   *out = BN_new();
   if (*out == NULL) {
     return 0;
   }
+  BN_set_flags(*out, BN_FLG_CONSTTIME);
   return BN_parse_asn1_unsigned(cbs, *out);
 }
 
@@ -172,14 +173,14 @@ RSA *RSA_parse_private_key(CBS *cbs) {
     goto err;
   }
 
-  if (!parse_integer(&child, &ret->n) ||
-      !parse_integer(&child, &ret->e) ||
-      !parse_integer(&child, &ret->d) ||
-      !parse_integer(&child, &ret->p) ||
-      !parse_integer(&child, &ret->q) ||
-      !parse_integer(&child, &ret->dmp1) ||
-      !parse_integer(&child, &ret->dmq1) ||
-      !parse_integer(&child, &ret->iqmp)) {
+  if (!parse_integer_consttime(&child, &ret->n) ||
+      !parse_integer_consttime(&child, &ret->e) ||
+      !parse_integer_consttime(&child, &ret->d) ||
+      !parse_integer_consttime(&child, &ret->p) ||
+      !parse_integer_consttime(&child, &ret->q) ||
+      !parse_integer_consttime(&child, &ret->dmp1) ||
+      !parse_integer_consttime(&child, &ret->dmq1) ||
+      !parse_integer_consttime(&child, &ret->iqmp)) {
     goto err;
   }
 

--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -67,13 +67,13 @@
 #include "internal.h"
 
 
-static int parse_integer_consttime(CBS *cbs, BIGNUM **out) {
+static int parse_integer_with_flags(CBS *cbs, BIGNUM **out, int flags) {
   assert(*out == NULL);
   *out = BN_new();
   if (*out == NULL) {
     return 0;
   }
-  BN_set_flags(*out, BN_FLG_CONSTTIME);
+  BN_set_flags(*out, flags);
   return BN_parse_asn1_unsigned(cbs, *out);
 }
 
@@ -173,14 +173,14 @@ RSA *RSA_parse_private_key(CBS *cbs) {
     goto err;
   }
 
-  if (!parse_integer_consttime(&child, &ret->n) ||
-      !parse_integer_consttime(&child, &ret->e) ||
-      !parse_integer_consttime(&child, &ret->d) ||
-      !parse_integer_consttime(&child, &ret->p) ||
-      !parse_integer_consttime(&child, &ret->q) ||
-      !parse_integer_consttime(&child, &ret->dmp1) ||
-      !parse_integer_consttime(&child, &ret->dmq1) ||
-      !parse_integer_consttime(&child, &ret->iqmp)) {
+  if (!parse_integer_with_flags(&child, &ret->n, BN_FLG_CONSTTIME) ||
+      !parse_integer_with_flags(&child, &ret->e, BN_FLG_CONSTTIME) ||
+      !parse_integer_with_flags(&child, &ret->d, BN_FLG_CONSTTIME) ||
+      !parse_integer_with_flags(&child, &ret->p, BN_FLG_CONSTTIME) ||
+      !parse_integer_with_flags(&child, &ret->q, BN_FLG_CONSTTIME) ||
+      !parse_integer_with_flags(&child, &ret->dmp1, BN_FLG_CONSTTIME) ||
+      !parse_integer_with_flags(&child, &ret->dmq1, BN_FLG_CONSTTIME) ||
+      !parse_integer_with_flags(&child, &ret->iqmp, BN_FLG_CONSTTIME)) {
     goto err;
   }
 

--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -77,6 +77,10 @@ static int parse_integer_with_flags(CBS *cbs, BIGNUM **out, int flags) {
   return BN_parse_asn1_unsigned(cbs, *out);
 }
 
+static int parse_integer(CBS *cbs, BIGNUM **out) {
+  return parse_integer_with_flags(cbs, out, 0);
+}
+
 static int marshal_integer(CBB *cbb, BIGNUM *bn) {
   if (bn == NULL) {
     /* An RSA object may be missing some components. */
@@ -173,8 +177,8 @@ RSA *RSA_parse_private_key(CBS *cbs) {
     goto err;
   }
 
-  if (!parse_integer_with_flags(&child, &ret->n, BN_FLG_CONSTTIME) ||
-      !parse_integer_with_flags(&child, &ret->e, BN_FLG_CONSTTIME) ||
+  if (!parse_integer(&child, &ret->n) ||
+      !parse_integer(&child, &ret->e) ||
       !parse_integer_with_flags(&child, &ret->d, BN_FLG_CONSTTIME) ||
       !parse_integer_with_flags(&child, &ret->p, BN_FLG_CONSTTIME) ||
       !parse_integer_with_flags(&child, &ret->q, BN_FLG_CONSTTIME) ||

--- a/crypto/rsa/rsa_impl.c
+++ b/crypto/rsa/rsa_impl.c
@@ -635,8 +635,7 @@ static int mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx) {
     goto err;
   }
 
-  assert(BN_get_flags(r1, BN_FLG_CONSTTIME));
-
+  assert(BN_get_flags(rsa->p, BN_FLG_CONSTTIME));
   if (!BN_mod(r0, r1, rsa->p, ctx)) {
     goto err;
   }

--- a/crypto/rsa/rsa_impl.c
+++ b/crypto/rsa/rsa_impl.c
@@ -551,7 +551,6 @@ static int rsa_private_transform(RSA *rsa, uint8_t *out, const uint8_t *in,
     }
   } else {
     assert(BN_get_flags(rsa->d, BN_FLG_CONSTTIME));
-
     if (!BN_mod_exp_mont_consttime(result, f, rsa->d, rsa->n, ctx, rsa->mont_n)) {
       goto err;
     }

--- a/crypto/rsa/rsa_test.cc
+++ b/crypto/rsa/rsa_test.cc
@@ -359,9 +359,9 @@ static bool TestOnlyDGiven() {
   ScopedBN_CTX ctx(BN_CTX_new());
   // XXX TODO: |rsa_new_end| should fail because the complete key isn't provided.
   if (!key ||
-      !BN_hex2bn(&key->n, kN) ||
-      !BN_hex2bn(&key->e, kE) ||
-      !BN_hex2bn(&key->d, kD) ||
+      !BN_hex2bn_with_flags(&key->n, kN, BN_FLG_CONSTTIME) ||
+      !BN_hex2bn_with_flags(&key->e, kE, BN_FLG_CONSTTIME) ||
+      !BN_hex2bn_with_flags(&key->d, kD, BN_FLG_CONSTTIME) ||
       !rsa_new_end(key.get(), ctx.get()) ||
       RSA_size(key.get()) > sizeof(buf)) {
     return false;
@@ -403,8 +403,8 @@ static bool TestOnlyDGiven() {
   // XXX TODO: |rsa_new_end| should fail because the complete key isn't provided.
   ScopedRSA key2(rsa_new_begin());
   if (!key2 ||
-      !BN_hex2bn(&key2->n, kN) ||
-      !BN_hex2bn(&key2->d, kD) ||
+      !BN_hex2bn_with_flags(&key2->n, kN, BN_FLG_CONSTTIME) ||
+      !BN_hex2bn_with_flags(&key2->d, kD, BN_FLG_CONSTTIME) ||
       !rsa_new_end(key2.get(), ctx.get())) {
     return false;
   }
@@ -469,6 +469,7 @@ static bool TestRecoverCRTParams() {
     if (key2->n == nullptr || key2->e == nullptr || key2->d == nullptr) {
       return false;
     }
+    BN_set_flags(key2->d, BN_FLG_CONSTTIME);
     if (!rsa_new_end(key2.get(), ctx.get())) {
       return false;
     }

--- a/crypto/test/bn_test_convert.c
+++ b/crypto/test/bn_test_convert.c
@@ -223,6 +223,14 @@ int BN_hex2bn(BIGNUM **outp, const char *in) {
   return bn_x2bn(outp, in, decode_hex, isxdigit);
 }
 
+int BN_hex2bn_with_flags(BIGNUM **outp, const char *in, int flags) {
+  if (!BN_hex2bn(outp, in)) {
+    return 0;
+  }
+  BN_set_flags(*outp, flags);
+  return 1;
+}
+
 int BN_dec2bn(BIGNUM **outp, const char *in) {
   return bn_x2bn(outp, in, decode_dec, isdigit);
 }

--- a/crypto/test/bn_test_util.h
+++ b/crypto/test/bn_test_util.h
@@ -138,6 +138,8 @@ extern "C" {
  * error. */
 OPENSSL_EXPORT int BN_hex2bn(BIGNUM **outp, const char *in);
 
+OPENSSL_EXPORT int BN_hex2bn_with_flags(BIGNUM **outp, const char *in, int flags);
+
 /* BN_dec2bn parses the leading decimal number from |in|, which may be
  * proceeded by a '-' to indicate a negative number and may contain trailing,
  * non-decimal data. If |outp| is not NULL, it constructs a BIGNUM equal to the

--- a/crypto/test/bn_test_util.h
+++ b/crypto/test/bn_test_util.h
@@ -141,7 +141,8 @@ OPENSSL_EXPORT int BN_hex2bn(BIGNUM **outp, const char *in);
 /* BN_hex2bn_with_flags acts like |BN_hex2n|, but in addition, sets |flags| on
  * the resulting BIGNUM.
  */
-OPENSSL_EXPORT int BN_hex2bn_with_flags(BIGNUM **outp, const char *in, int flags);
+OPENSSL_EXPORT int BN_hex2bn_with_flags(BIGNUM **outp, const char *in,
+                                        int flags);
 
 /* BN_dec2bn parses the leading decimal number from |in|, which may be
  * proceeded by a '-' to indicate a negative number and may contain trailing,

--- a/crypto/test/bn_test_util.h
+++ b/crypto/test/bn_test_util.h
@@ -138,6 +138,9 @@ extern "C" {
  * error. */
 OPENSSL_EXPORT int BN_hex2bn(BIGNUM **outp, const char *in);
 
+/* BN_hex2bn_with_flags acts like |BN_hex2n|, but in addition, sets |flags| on
+ * the resulting BIGNUM.
+ */
 OPENSSL_EXPORT int BN_hex2bn_with_flags(BIGNUM **outp, const char *in, int flags);
 
 /* BN_dec2bn parses the leading decimal number from |in|, which may be

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -184,13 +184,6 @@ OPENSSL_EXPORT BIGNUM *BN_copy(BIGNUM *dest, const BIGNUM *src);
 /* BN_value_one returns a static BIGNUM with value 1. */
 OPENSSL_EXPORT const BIGNUM *BN_value_one(void);
 
-/* BN_with_flags initialises a stack allocated |BIGNUM| with pointers to the
- * contents of |in| but with |flags| ORed into the flags field.
- *
- * Note: the two BIGNUMs share state and so |out| should /not/ be passed to
- * |BN_free|. */
-OPENSSL_EXPORT void BN_with_flags(BIGNUM *out, const BIGNUM *in, int flags);
-
 
 /* Basic functions. */
 


### PR DESCRIPTION
Instead of using `BN_with_flags` (which relies on an extra allocated
`BIGNUM`), we'll make sure that all `BIGNUM`s we're working with have
the `BN_FLG_CONSTTIME` flag assigned at the time of creation.

Part of https://github.com/briansmith/ring/issues/99.

I agree to license my contributions to each file under the
same terms given at the top of each file I changed.