### PR TITLE
Rewrite SHA-1 in Rust.

### DIFF
--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -38,11 +38,11 @@ pub mod slice {
     use core;
 
     #[inline(always)]
-    pub fn u32_from_be_u8_at(buffer: &[u8], at: usize) -> u32 {
-        u32::from(buffer[at]) << 24 |
-        u32::from(buffer[at + 1]) << 16 |
-        u32::from(buffer[at + 2]) << 8 |
-        u32::from(buffer[at + 3])
+    pub fn u32_from_be_u8(buffer: &[u8; 4]) -> u32 {
+        u32::from(buffer[0]) << 24 |
+        u32::from(buffer[1]) << 16 |
+        u32::from(buffer[2]) << 8 |
+        u32::from(buffer[3])
     }
 
     // https://github.com/rust-lang/rust/issues/27750


### PR DESCRIPTION
Fix #60.

I found a number of SHA-1 implementations in Rust but none of them were in the public domain or under CC0 or ISC, so I wrote another one based on reading FIPS 180-4.

As discussed in #60 this does not optimize for speed but keeps the source code short and simple (for example without manual loop unrolling) as a first approximation of optimizing for machine code size.