### PR TITLE
Extract SHA-1’s cast with `as` into a dedicated function.

### DIFF
--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -37,9 +37,7 @@ type W32 = Wrapping<u32>;
 pub unsafe extern fn block_data_order(state: &mut [u64; MAX_CHAINING_LEN / 8],
                                       data: *const u8,
                                       num: c::size_t) {
-    let data = data as *const [u8; BLOCK_LEN];
-    let blocks = core::slice::from_raw_parts(data, num);
-    block_data_order_safe(state, blocks)
+    block_data_order_safe(state, ptr_as_array_slice!(data, BLOCK_LEN, num))
 }
 
 fn block_data_order_safe(state: &mut [u64; MAX_CHAINING_LEN / 8],

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -146,3 +146,18 @@ macro_rules! slice_as_array_ref_mut {
         }
     }
 }
+
+/// Returns a slice of arrays starting at the given pointer.
+macro_rules! ptr_as_array_slice {
+    ($ptr:expr, $block_len:expr, $block_num:expr) => {
+        {
+            unsafe fn ptr_as_array_slice<'a, T>(ptr: *const T,
+                                                block_num: usize)
+                                                -> &'a [[T; $block_len]] {
+                let ptr = ptr as *const [T; $block_len];
+                core::slice::from_raw_parts(ptr, block_num)
+            }
+            ptr_as_array_slice($ptr, $block_num)
+        }
+    }
+}


### PR DESCRIPTION
See https://github.com/briansmith/ring/issues/31#issuecomment-202311233