### PR TITLE
Enable testing on 32-bit GCC 4.9 on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -307,6 +307,34 @@ matrix:
       rust: stable
       os: linux
 
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+      rust: stable
+      os: linux
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+            - g++-4.9-multilib
+            - gcc-4.9
+            - gcc-4.9-multilib
+            - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+      rust: stable
+      os: linux
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+            - g++-4.9-multilib
+            - gcc-4.9
+            - gcc-4.9-multilib
+            - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
       rust: stable
       os: linux
@@ -653,6 +681,34 @@ matrix:
       rust: nightly
       os: linux
 
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+      rust: nightly
+      os: linux
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+            - g++-4.9-multilib
+            - gcc-4.9
+            - gcc-4.9-multilib
+            - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+      rust: nightly
+      os: linux
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+            - g++-4.9-multilib
+            - gcc-4.9
+            - gcc-4.9-multilib
+            - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
       rust: nightly
       os: linux
@@ -998,6 +1054,34 @@ matrix:
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang CXX_X=clang++ MODE_X=RELWITHDEBINFO
       rust: beta
       os: linux
+
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+      rust: beta
+      os: linux
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+            - g++-4.9-multilib
+            - gcc-4.9
+            - gcc-4.9-multilib
+            - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+      rust: beta
+      os: linux
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+            - g++-4.9-multilib
+            - gcc-4.9
+            - gcc-4.9-multilib
+            - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
       rust: beta

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -89,11 +89,7 @@ def format_entries():
                       for os in oss
                       for compiler in compilers[os]
                       for target in targets[os]
-                      for mode in modes
-                      # XXX: 32-bit GCC 4.9 does not work because Travis does
-                      # not have g++-4.9-multilib whitelisted for use.
-                      if (not (compiler == "gcc-4.9" and
-                               target == "i686-unknown-linux-gnu"))])
+                      for mode in modes])
 
 # We use alternative names (the "_X" suffix) so that, in mk/travis.sh, we can
 # enure that we set the specific variables we want and that no relevant


### PR DESCRIPTION
This was previously not done because `g++-4.9-multilib` was not
a whitelisted package on Travis. As of this PR, it is available:

https://github.com/travis-ci/apt-package-whitelist/pull/1117

I agree to license my contributions to each file under the terms given
at the top of each file I changed.