### PR TITLE
Build kcov on travis and send reports to coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -486,6 +486,10 @@ matrix:
             - linux-libc-dev:i386
           sources:
             - ubuntu-toolchain-r-test
+      after_success:
+        - mk/travis-install-kcov.sh
+        - ${HOME}/kcov/bin/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-path=/usr/include --include-pattern=ring/crypto,ring/src target/kcov target/$TARGET_X/debug/ring-*
+
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
@@ -515,6 +519,10 @@ matrix:
             - libelf-dev
           sources:
             - ubuntu-toolchain-r-test
+      after_success:
+        - mk/travis-install-kcov.sh
+        - ${HOME}/kcov/bin/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-path=/usr/include --include-pattern=ring/crypto,ring/src target/kcov target/$TARGET_X/debug/ring-*
+
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,28 @@ language: rust
 matrix:
   fast_finish: true
   include:
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ MODE_X=DEBUG
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ MODE_X=DEBUG KCOV=0
       rust: stable
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ MODE_X=DEBUG
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ MODE_X=DEBUG KCOV=0
       rust: nightly
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
 
-    - env: TARGET_X=arm-unknown-linux-gnueabi CC_X=arm-linux-gnueabi-gcc CXX_X=arm-linux-gnueabi-g++ MODE_X=DEBUG
+    - env: TARGET_X=arm-unknown-linux-gnueabi CC_X=arm-linux-gnueabi-gcc CXX_X=arm-linux-gnueabi-g++ MODE_X=DEBUG KCOV=0
       rust: stable
 
-    - env: TARGET_X=arm-unknown-linux-gnueabi CC_X=arm-linux-gnueabi-gcc CXX_X=arm-linux-gnueabi-g++ MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=arm-unknown-linux-gnueabi CC_X=arm-linux-gnueabi-gcc CXX_X=arm-linux-gnueabi-g++ MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
 
-    - env: TARGET_X=arm-unknown-linux-gnueabi CC_X=arm-linux-gnueabi-gcc CXX_X=arm-linux-gnueabi-g++ MODE_X=DEBUG
+    - env: TARGET_X=arm-unknown-linux-gnueabi CC_X=arm-linux-gnueabi-gcc CXX_X=arm-linux-gnueabi-g++ MODE_X=DEBUG KCOV=0
       rust: nightly
 
-    - env: TARGET_X=arm-unknown-linux-gnueabi CC_X=arm-linux-gnueabi-gcc CXX_X=arm-linux-gnueabi-g++ MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=arm-unknown-linux-gnueabi CC_X=arm-linux-gnueabi-gcc CXX_X=arm-linux-gnueabi-g++ MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
 
     # The lines from "# BEGIN GENERATED" through "# END GENERATED" are
@@ -33,17 +33,17 @@ matrix:
     #
     # BEGIN GENERATED
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=DEBUG
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=DEBUG KCOV=0
       rust: stable
       os: osx
       osx_image: xcode7.2
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: osx
       osx_image: xcode7.2
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -55,7 +55,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -67,15 +67,15 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -89,7 +89,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -103,7 +103,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -114,7 +114,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -125,7 +125,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -139,7 +139,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -153,7 +153,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -164,7 +164,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -175,7 +175,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -189,7 +189,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -203,7 +203,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -214,7 +214,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -225,7 +225,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -239,7 +239,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -253,7 +253,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -264,7 +264,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -275,7 +275,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -289,7 +289,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -303,7 +303,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -314,7 +314,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -325,7 +325,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -339,7 +339,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -353,7 +353,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -364,7 +364,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -375,17 +375,17 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=DEBUG
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=DEBUG KCOV=0
       rust: nightly
       os: osx
       osx_image: xcode7.2
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: osx
       osx_image: xcode7.2
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -397,7 +397,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -409,15 +409,15 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -431,7 +431,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -445,7 +445,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -456,7 +456,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -467,7 +467,27 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG KCOV=1
+      rust: nightly
+      os: linux
+      addons:
+        apt:
+          packages:
+            - g++-5
+            - g++-5-multilib
+            - gcc-5
+            - gcc-5-multilib
+            - libcurl3:i386
+            - libcurl4-openssl-dev:i386
+            - libdw-dev:i386
+            - libelf-dev:i386
+            - libkrb5-dev:i386
+            - libssl-dev:i386
+            - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -481,32 +501,22 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG KCOV=1
       rust: nightly
       os: linux
       addons:
         apt:
           packages:
+            - binutils-dev
             - g++-5
-            - g++-5-multilib
             - gcc-5
-            - gcc-5-multilib
-            - linux-libc-dev:i386
+            - libcurl4-openssl-dev
+            - libdw-dev
+            - libelf-dev
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG
-      rust: nightly
-      os: linux
-      addons:
-        apt:
-          packages:
-            - g++-5
-            - gcc-5
-          sources:
-            - ubuntu-toolchain-r-test
-
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -517,7 +527,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -531,7 +541,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -545,7 +555,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -556,7 +566,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -567,7 +577,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -581,7 +591,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -595,7 +605,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -606,7 +616,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -617,7 +627,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -631,7 +641,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -645,7 +655,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -656,7 +666,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -667,7 +677,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -681,7 +691,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -695,7 +705,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -706,7 +716,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -717,17 +727,17 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=DEBUG
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=DEBUG KCOV=0
       rust: beta
       os: osx
       osx_image: xcode7.2
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: osx
       osx_image: xcode7.2
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -739,7 +749,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -751,15 +761,15 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -773,7 +783,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -787,7 +797,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -798,7 +808,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -809,7 +819,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -823,7 +833,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -837,7 +847,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -848,7 +858,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -859,7 +869,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -873,7 +883,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -887,7 +897,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -898,7 +908,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.7 CXX_X=clang++-3.7 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -909,7 +919,7 @@ matrix:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -923,7 +933,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -937,7 +947,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -948,7 +958,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.5 CXX_X=clang++-3.5 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -959,7 +969,7 @@ matrix:
             - llvm-toolchain-precise-3.5
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -973,7 +983,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -987,7 +997,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -998,7 +1008,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.9 CXX_X=g++-4.9 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1009,7 +1019,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1023,7 +1033,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1037,7 +1047,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1048,7 +1058,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.8 CXX_X=g++-4.8 MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:

--- a/mk/travis-install-kcov.sh
+++ b/mk/travis-install-kcov.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2016 Pietro Monteiro
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+set -ex
+
+
+# kcov 26 or newer is needed when getting coverage information on rust
+# Using kcov 31 so `kcov --version` doesn't exit with status 1.
+KCOV_VERSION=${KCOV_VERSION:-31}
+
+curl -L https://github.com/SimonKagstrom/kcov/archive/v$KCOV_VERSION.tar.gz | tar -zxf -
+
+pushd kcov-$KCOV_VERSION
+
+mkdir build
+
+pushd build
+
+if [[  "$TARGET_X" == "i686-unknown-linux-gnu" ]]; then
+  # set PKG_CONFIG_PATH so the kcov build system uses the 32 bit libraries we installed.
+  # otherwise kcov will be linked with 64 bit libraries and won't work with 32 bit executables.
+  PKG_CONFIG_PATH="/usr/lib/i386-linux-gnu/pkgconfig" CFLAGS="-m32" CXXFLAGS="-m32" CC=$CC_X CXX=$CXX_X TARGET=$TARGET_X cmake -DCMAKE_INSTALL_PREFIX:PATH="${HOME}/kcov" ..
+else
+  CC=$CC_X CXX=$CXX_X TARGET=$TARGET_X cmake -DCMAKE_INSTALL_PREFIX:PATH="${HOME}/kcov" ..
+fi
+
+make
+make install
+
+$HOME/kcov/bin/kcov --version
+
+popd
+popd

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -64,17 +64,21 @@ rustc --version
 
 if [[ "$MODE_X" == "RELWITHDEBINFO" ]]; then mode=--release; fi
 
-CC=$CC_X CXX=$CXX_X cargo build -j2 ${mode-} --verbose --target=$TARGET_X
+if [[ "$KCOV" == "1" ]]; then
+  RUSTFLAGS_X="-C link-dead-code"
+fi
+
+CC=$CC_X CXX=$CXX_X RUSTFLAGS=${RUSTFLAGS_X-} cargo build -j2 ${mode-} --verbose --target=$TARGET_X
 
 case $TARGET_X in
 arm-unknown-linux-gnueabi|aarch64-unknown-linux-gnu)
   ;;
 *)
-  CC=$CC_X CXX=$CXX_X cargo test -j2 ${mode-} --verbose --target=$TARGET_X
-  CC=$CC_X CXX=$CXX_X cargo doc -j2 ${mode-} --verbose --target=$TARGET_X
+  CC=$CC_X CXX=$CXX_X RUSTFLAGS=${RUSTFLAGS_X-} cargo test -j2 ${mode-} --verbose --target=$TARGET_X
+  CC=$CC_X CXX=$CXX_X RUSTFLAGS=${RUSTFLAGS_X-} cargo doc -j2 ${mode-} --verbose --target=$TARGET_X
   ;;
 esac
 
-CC=$CC_X CXX=$CXX_X cargo clean --verbose
+CC=$CC_X CXX=$CXX_X RUSTFLAGS=${RUSTFLAGS_X-} cargo clean --verbose
 
 echo end of mk/travis.sh

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -79,6 +79,4 @@ arm-unknown-linux-gnueabi|aarch64-unknown-linux-gnu)
   ;;
 esac
 
-CC=$CC_X CXX=$CXX_X RUSTFLAGS=${RUSTFLAGS_X-} cargo clean --verbose
-
 echo end of mk/travis.sh

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -120,6 +120,12 @@ entry_sources_template = """
           sources:
             %(sources)s"""
 
+entry_after_success_kcov = """
+      after_success:
+        - mk/travis-install-kcov.sh
+        - ${HOME}/kcov/bin/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-path=/usr/include --include-pattern=ring/crypto,ring/src target/kcov target/$TARGET_X/debug/ring-*
+"""
+
 def format_entry(os, target, compiler, rust, mode):
     # NOTE: Kcov
     # Currently kcov only runs on linux.
@@ -155,6 +161,9 @@ def format_entry(os, target, compiler, rust, mode):
 
     if os == "osx":
         os += "\n" + entry_indent + "osx_image: xcode7.2"
+
+    if kcov == True:
+        template += entry_after_success_kcov
 
     return template % {
             "cc" : cc,

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -104,7 +104,7 @@ def format_entries():
 # directive here. Also, we keep these variable names short so that the env
 # line does not get cut off in the Travis CI UI.
 entry_template = """
-    - env: TARGET_X=%(target)s CC_X=%(cc)s CXX_X=%(cxx)s MODE_X=%(mode)s
+    - env: TARGET_X=%(target)s CC_X=%(cc)s CXX_X=%(cxx)s MODE_X=%(mode)s KCOV=%(kcov)s
       rust: %(rust)s
       os: %(os)s"""
 
@@ -121,6 +121,13 @@ entry_sources_template = """
             %(sources)s"""
 
 def format_entry(os, target, compiler, rust, mode):
+    # NOTE: Kcov
+    # Currently kcov only runs on linux.
+    # GCC 5 was picked arbitrarily to restrict coverage report to one build for efficiency reasons.
+    # Rust nightly is used inorder to be able to pass compiler flags via RUSTFLAGS when using cargo.
+    # DEBUG mode is needed because debug symbols are needed for coverage tracking.
+    kcov = os == "linux" and compiler == "gcc-5" and rust == "nightly" and mode == "DEBUG"
+
     target_words = target.split("-")
     arch = target_words[0]
     vendor = target_words[1]
@@ -132,7 +139,7 @@ def format_entry(os, target, compiler, rust, mode):
     template = entry_template
 
     if sys == "linux":
-        packages = sorted(get_linux_packages_to_install(compiler, arch))
+        packages = sorted(get_linux_packages_to_install(compiler, arch, kcov))
         sources_with_dups = sum([get_sources_for_package(p) for p in packages],[])
         sources = sorted(list(set(sources_with_dups)))
         if packages:
@@ -153,6 +160,7 @@ def format_entry(os, target, compiler, rust, mode):
             "cc" : cc,
             "cxx" : cxx,
             "mode" : mode,
+            "kcov": "1" if kcov == True else "0",
             "packages" : "\n            ".join(prefix_all("- ", packages)),
             "rust" : rust,
             "sources" : "\n            ".join(prefix_all("- ", sources)),
@@ -160,7 +168,7 @@ def format_entry(os, target, compiler, rust, mode):
             "os" : os,
             }
 
-def get_linux_packages_to_install(compiler, arch):
+def get_linux_packages_to_install(compiler, arch, kcov):
     if compiler in [linux_default_clang, linux_default_gcc]:
         packages = []
     elif compiler.startswith("clang-"):
@@ -171,6 +179,14 @@ def get_linux_packages_to_install(compiler, arch):
         raise ValueError("unexpected compiler: %s" % compiler)
 
     if arch == "i686":
+        if kcov == True:
+            packages += ["libcurl3:i386",
+                         "libcurl4-openssl-dev:i386",
+                         "libdw-dev:i386",
+                         "libelf-dev:i386",
+                         "libkrb5-dev:i386",
+                         "libssl-dev:i386"]
+
         if compiler.startswith("clang-") or compiler == linux_default_gcc:
             packages += ["libc6-dev-i386",
                          "gcc-multilib",
@@ -182,7 +198,11 @@ def get_linux_packages_to_install(compiler, arch):
         else:
             raise ValueError("unexpected compiler: %s" % compiler)
     elif arch == "x86_64":
-        pass
+        if kcov == True:
+            packages += ["libcurl4-openssl-dev",
+                         "libelf-dev",
+                         "libdw-dev",
+                         "binutils-dev"]
     else:
         raise ValueError("unexpected arch: %s" % arch)
 


### PR DESCRIPTION
Only tracking coverage for X86 and X86_64 Linux as discussed on #132.