### PR TITLE
Change "no_heap" feature to "use_heap"; enable by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,11 @@ rustc-serialize = "0.3.19"
 
 [features]
 # These features are documented in the top-level module's documentation.
+default = ["use_heap"]
 disable_dev_urandom_fallback = []
-no_heap = []
 slow_tests = []
 test_logging = []
+use_heap = []
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ In addition, we're always interested in these kinds of contributions:
 * More code simplification, especially eliminating dead code.
 * Replacing more C code with Rust code.
 * Improving the code size, execution speed, and/or memory footprint.
-* Making more features work in the `no_heap`/`#![no_std]` mode, by avoiding
-  uses of the heap.
+* Making more features work in the `#![no_std]`/non-`use_heap`` mode, by
+  avoiding uses of the heap.
 * Better IDE support for Windows (e.g. running the tests within the IDE) and
   Mac OS X (e.g. Xcode project files).
 * Support for more platforms in the continuous integration (e.g. Android, iOS,

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -79,7 +79,7 @@ use untrusted;
 
 pub use ec::PUBLIC_KEY_MAX_LEN;
 
-#[cfg(not(feature = "no_heap"))]
+#[cfg(feature = "use_heap")]
 pub use ec::suite_b::ecdh::{
     ECDH_P256,
     ECDH_P384,
@@ -256,7 +256,7 @@ mod tests {
         });
     }
 
-    #[cfg(not(feature = "no_heap"))]
+    #[cfg(feature = "use_heap")]
     fn alg_from_curve_name(curve_name: &str) -> Option<&'static Algorithm> {
         if curve_name == "P-256" {
             Some(&ECDH_P256)
@@ -269,7 +269,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "no_heap")]
+    #[cfg(not(feature = "use_heap"))]
     fn alg_from_curve_name(curve_name: &str) -> Option<&'static Algorithm> {
         if curve_name == "P-256" ||
            curve_name == "P-384" {

--- a/src/ec/ec.rs
+++ b/src/ec/ec.rs
@@ -100,14 +100,14 @@ impl PrivateKey {
 }
 
 
-// When the `no_heap` feature isn't being used, P-384 has the largest field
+// When the `use_heap` feature is enabled, P-384 has the largest field
 // element size.
-#[cfg(not(feature = "no_heap"))]
+#[cfg(feature = "use_heap")]
 const ELEM_MAX_BITS: usize = 384;
 
-// When the `no_heap` feature is used, P-384 and P-256 aren't available, so
+// When the `use_heap` feature is disabled, P-384 and P-256 aren't available, so
 // X25519 has the largest field element size.
-#[cfg(feature = "no_heap")]
+#[cfg(not(feature = "use_heap"))]
 const ELEM_MAX_BITS: usize = 256;
 
 pub const ELEM_MAX_BYTES: usize = (ELEM_MAX_BITS + 7) / 8;
@@ -115,14 +115,14 @@ pub const ELEM_MAX_BYTES: usize = (ELEM_MAX_BITS + 7) / 8;
 const SCALAR_MAX_BYTES: usize = ELEM_MAX_BYTES;
 
 /// The maximum length, in bytes, of an encoded public key. Note that the value
-/// depends on which algorithms are enabled (e.g. whether the `no_heap` feature
+/// depends on which algorithms are enabled (e.g. whether the `use_heap` feature
 /// is activated).
 pub const PUBLIC_KEY_MAX_LEN: usize = 1 + (2 * ELEM_MAX_BYTES);
 
 
 pub mod eddsa;
 
-#[cfg(not(feature = "no_heap"))]
+#[cfg(feature = "use_heap")]
 #[path = "suite_b/suite_b.rs"]
 pub mod suite_b;
 

--- a/src/ec/suite_b/ecdh.rs
+++ b/src/ec/suite_b/ecdh.rs
@@ -46,7 +46,7 @@ macro_rules! ecdh {
         /// verification. Soon, coordinates larger than *q* - 1 will be
         /// rejected.
         ///
-        /// Not available in `no_heap` mode.
+        /// Only available in `use_heap` mode.
         pub static $NAME: agreement::Algorithm = agreement::Algorithm {
             i: ec::AgreementAlgorithmImpl {
                 public_key_len: 1 + (2 * (($bits + 7) / 8)),

--- a/src/ec/suite_b/ecdsa.rs
+++ b/src/ec/suite_b/ecdsa.rs
@@ -20,14 +20,14 @@ use {bssl, c, der, digest, ec, signature, signature_impl};
 use super::{EC_GROUP, EC_GROUP_P256, EC_GROUP_P384};
 use untrusted;
 
-#[cfg(not(feature = "no_heap"))]
+#[cfg(feature = "use_heap")]
 struct ECDSA {
     digest_alg: &'static digest::Algorithm,
     ec_group: &'static EC_GROUP,
     elem_and_scalar_len: usize,
 }
 
-#[cfg(not(feature = "no_heap"))]
+#[cfg(feature = "use_heap")]
 impl signature_impl::VerificationAlgorithmImpl for ECDSA {
     fn verify(&self, public_key: untrusted::Input, msg: untrusted::Input,
               signature: untrusted::Input) -> Result<(), ()> {
@@ -60,7 +60,7 @@ impl signature_impl::VerificationAlgorithmImpl for ECDSA {
 macro_rules! ecdsa {
     ( $VERIFY_ALGORITHM:ident, $curve_name:expr, $curve_bits: expr,
       $ec_group:expr, $digest_alg_name:expr, $digest_alg:expr ) => {
-        #[cfg(not(feature = "no_heap"))]
+        #[cfg(feature = "use_heap")]
         #[doc="Verification of ECDSA signatures using the "]
         #[doc=$curve_name]
         #[doc=" curve and the "]
@@ -89,7 +89,7 @@ macro_rules! ecdsa {
         /// 2.2.3](https://tools.ietf.org/html/rfc3279#section-2.2.3). Both *r*
         /// and *s* are verified to be in the range [1, *n* - 1].
         ///
-        /// Not available in `no_heap` mode.
+        /// Only available in `use_heap` mode.
         pub static $VERIFY_ALGORITHM: signature::VerificationAlgorithm =
                 signature::VerificationAlgorithm {
             implementation: &ECDSA {
@@ -121,7 +121,7 @@ ecdsa!(ECDSA_P384_SHA512_VERIFY, "P-384 (secp384r1)", 384, &EC_GROUP_P384,
 
 
 extern {
-    #[cfg(not(feature = "no_heap"))]
+    #[cfg(feature = "use_heap")]
     fn ECDSA_verify_signed_digest(group: &EC_GROUP, hash_nid: c::int,
                                   digest: *const u8, digest_len: c::size_t,
                                   sig_r: *const u8, sig_r_len: c::size_t,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,13 @@
 //!         supported at runtime. When the `disable_dev_urandom_fallback`
 //!         feature is enabled, such fallback will not occur. See the
 //!         documentation for `rand::SystemRandom` for more details.
-//! <tr><td><code>no_heap</code>
-//!     <td>Disable all functionality that uses the heap. This is useful for
-//!         code running in kernel space and some embedded applications. The
-//!         goal is to enable as much functionality as is practical in
-//!         <code>no_heap</code> mode, but for now some RSA, ECDH, and ECDSA
-//!         functionality still uses the heap.
+//! <tr><td><code>use_heap</code>
+//!     <td>Enable functionality that uses the heap. This is on by default, but
+//!         disabling it is useful for code running in kernel space and some
+//!         embedded applications. The goal is to enable as much functionality
+//!         as is practical in without requiring <code>use_heap</code> mode,
+//!         but for now some RSA, ECDH, and ECDSA functionality still uses the
+//!         heap.
 //! <tr><td><code>slow_tests</code>
 //!     <td>Run additional tests that are too slow to run during a normal
 //!         edit-compile-test cycle.
@@ -135,7 +136,7 @@ mod init;
 pub mod pbkdf2;
 
 pub mod rand;
-#[cfg(not(feature = "no_heap"))] mod rsa;
+#[cfg(feature = "use_heap")] mod rsa;
 pub mod signature;
 mod signature_impl;
 

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -88,7 +88,7 @@ impl signature_impl::VerificationAlgorithmImpl for RSA_PKCS1 {
 macro_rules! rsa_pkcs1 {
     ( $VERIFY_ALGORITHM:ident, $min_bits:expr, $min_bits_str:expr,
       $digest_alg_name:expr, $digest_alg:expr, $digestinfo_prefix:expr ) => {
-        #[cfg(not(feature = "no_heap"))]
+        #[cfg(feature = "use_heap")]
         #[doc="Verification of RSA PKCS#1 1.5 signatures of "]
         #[doc=$min_bits_str]
         #[doc="-8192 bits "]
@@ -96,7 +96,7 @@ macro_rules! rsa_pkcs1 {
         #[doc=$digest_alg_name]
         #[doc=" digest algorithm."]
         ///
-        /// Not available in `no_heap` mode.
+        /// Only available in `use_heap` mode.
         pub static $VERIFY_ALGORITHM: signature::VerificationAlgorithm =
                 signature::VerificationAlgorithm {
             implementation: &RSA_PKCS1 {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -88,7 +88,7 @@
 use {init, signature_impl};
 use untrusted;
 
-#[cfg(not(feature = "no_heap"))]
+#[cfg(feature = "use_heap")]
 pub use ec::suite_b::ecdsa::{
     ECDSA_P256_SHA1_VERIFY,
     ECDSA_P256_SHA256_VERIFY,
@@ -103,7 +103,7 @@ pub use ec::suite_b::ecdsa::{
 
 pub use ec::eddsa::{ED25519_VERIFY, Ed25519KeyPair};
 
-#[cfg(not(feature = "no_heap"))]
+#[cfg(feature = "use_heap")]
 pub use rsa::{
     RSA_PKCS1_2048_8192_SHA1_VERIFY,
     RSA_PKCS1_2048_8192_SHA256_VERIFY,
@@ -170,7 +170,7 @@ pub struct VerificationAlgorithm {
 ///
 /// use ring::signature;
 ///
-/// # #[cfg(not(feature = "no_heap"))]
+/// # #[cfg(feature = "use_heap")]
 /// fn verify_rsa_pkcs1_sha256(public_key: untrusted::Input,
 ///                            msg: untrusted::Input, sig: untrusted::Input)
 ///                            -> Result<(), ()> {


### PR DESCRIPTION
Cargo features are additive - Cargo presumes that it is safe to
enable a feature if _any_ dependent requires it, and that doing
so will not break crates that do not require it. As a result,
features that reduce the API surface - as no_heap did - violate
Cargo's invariants and can cause spooky failures at a distance.

Converting to a use_heap feature that enables APIs that may
allocate, and enabling it by default, preserves the current
behavior for users who simply depend on *ring* while better
fitting in to the Cargo ecosystem.