### PR TITLE
Clarify the bit shift in gfp_little_endian_bytes_from_scalar.

### DIFF
--- a/crypto/ec/ecp_nistz.c
+++ b/crypto/ec/ecp_nistz.c
@@ -40,14 +40,14 @@ void gfp_little_endian_bytes_from_scalar(uint8_t str[], size_t str_len,
     str[i + 0] = d & 0xff;
     str[i + 1] = (d >> 8) & 0xff;
     str[i + 2] = (d >> 16) & 0xff;
-    str[i + 3] = (d >>= 24) & 0xff;
-    if (BN_BYTES == 8) {
-      d >>= 8;
-      str[i + 4] = d & 0xff;
-      str[i + 5] = (d >> 8) & 0xff;
-      str[i + 6] = (d >> 16) & 0xff;
-      str[i + 7] = (d >> 24) & 0xff;
-    }
+    str[i + 3] = (d >> 24) & 0xff;
+#if BN_BYTES == 8
+    d >>= 32;
+    str[i + 4] = d & 0xff;
+    str[i + 5] = (d >> 8) & 0xff;
+    str[i + 6] = (d >> 16) & 0xff;
+    str[i + 7] = (d >> 24) & 0xff;
+#endif
   }
   for (; i < str_len; i++) {
     str[i] = 0;


### PR DESCRIPTION
The bitshift-assignment in the middle of an expression is
unneccesarily confusing, and in any case is not necessary if BN_BYTES
is not 8.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.