### PR TITLE
[On Hold] Add support for builds without assembly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       os: osx
       osx_image: xcode7.3
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: osx
       osx_image: xcode7.3
@@ -32,7 +32,7 @@ matrix:
       os: osx
       osx_image: xcode7.3
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: osx
       osx_image: xcode7.3
@@ -50,7 +50,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -76,7 +76,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -93,7 +93,7 @@ matrix:
       rust: stable
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
 
@@ -101,7 +101,7 @@ matrix:
       rust: stable
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
 
@@ -116,7 +116,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -138,7 +138,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -160,7 +160,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -182,7 +182,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -204,7 +204,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -226,7 +226,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -251,7 +251,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -279,7 +279,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -305,7 +305,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -329,7 +329,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -355,7 +355,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -383,7 +383,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -411,7 +411,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -439,7 +439,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -467,7 +467,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       addons:
@@ -495,7 +495,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       addons:
@@ -523,7 +523,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -551,7 +551,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -565,12 +565,68 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust rsa_signing" MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust " MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust rsa_signing" MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust " MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
     - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: nightly
       os: osx
       osx_image: xcode7.3
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: osx
       osx_image: xcode7.3
@@ -580,7 +636,7 @@ matrix:
       os: osx
       osx_image: xcode7.3
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: osx
       osx_image: xcode7.3
@@ -598,7 +654,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -624,7 +680,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -641,7 +697,7 @@ matrix:
       rust: nightly
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
 
@@ -649,7 +705,7 @@ matrix:
       rust: nightly
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
 
@@ -664,7 +720,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -686,7 +742,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -712,7 +768,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=DEBUG KCOV=1
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=DEBUG KCOV=1
       rust: nightly
       os: linux
       addons:
@@ -738,7 +794,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -760,7 +816,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -782,7 +838,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -807,7 +863,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -835,7 +891,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -861,7 +917,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -885,7 +941,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -911,7 +967,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -939,7 +995,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -973,7 +1029,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=DEBUG KCOV=1
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=DEBUG KCOV=1
       rust: nightly
       os: linux
       addons:
@@ -1007,7 +1063,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -1035,7 +1091,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -1063,7 +1119,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       addons:
@@ -1091,7 +1147,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -1119,7 +1175,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -1133,12 +1189,68 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust rsa_signing" MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust " MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust rsa_signing" MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust " MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
     - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: beta
       os: osx
       osx_image: xcode7.3
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: osx
       osx_image: xcode7.3
@@ -1148,7 +1260,7 @@ matrix:
       os: osx
       osx_image: xcode7.3
 
-    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: osx
       osx_image: xcode7.3
@@ -1166,7 +1278,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1192,7 +1304,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1209,7 +1321,7 @@ matrix:
       rust: beta
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
 
@@ -1217,7 +1329,7 @@ matrix:
       rust: beta
       os: linux
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
 
@@ -1232,7 +1344,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1254,7 +1366,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1276,7 +1388,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1298,7 +1410,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1320,7 +1432,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1342,7 +1454,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1367,7 +1479,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1395,7 +1507,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1421,7 +1533,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1445,7 +1557,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1471,7 +1583,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1499,7 +1611,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=clang-3.8 CXX_X=clang++-3.8 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1527,7 +1639,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1555,7 +1667,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1583,7 +1695,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1611,7 +1723,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       addons:
@@ -1639,7 +1751,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X=--features= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1667,7 +1779,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X=--features= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1681,6 +1793,62 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust rsa_signing" MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust " MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust rsa_signing" MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc CXX_X=mipsel-linux-gnu-g++ FEATURES_X="--features=native_rust " MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - g++-mipsel-linux-gnu
+            - gcc-mipsel-linux-gnu
+            - libc6-dev-mipsel-cross
+          sources:
+            - debian-sid
+
     # END GENERATED
 
-script: if [[ "$TARGET_X" =~ ^a*.*linux-.*eabi ]]; then travis_wait 60 mk/travis.sh; else mk/travis.sh; fi
+script: if [[ "$TARGET_X" =~ ^(a*.*linux-.*eabi|mipsel) ]]; then travis_wait 60 mk/travis.sh; else mk/travis.sh; fi

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,6 +75,11 @@ benchmarks are only useful for people hacking on the implementation of *ring*.
 (The benchmarks for the *ring* API are in the
 [crypto-bench](https://github.com/briansmith/crypto-bench) project.)
 
+The `native_rust` feature attempts to use pure Rust code for algorithm
+implementations. This work is currently incomplete, and therefore some features
+do not yet have native Rust implementations, in which case *ring* will fallback
+to using the assembly version.
+
 The `slow_tests` feature runs additional tests that are too slow to run during
 a normal edit-compile-test cycle.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,6 +271,7 @@ lazy_static = "0.2.1"
 default = ["use_heap", "dev_urandom_fallback"]
 dev_urandom_fallback = []
 internal_benches = []
+native_rust = []
 rsa_signing = []
 slow_tests = []
 test_logging = []

--- a/examples/checkdigest.rs
+++ b/examples/checkdigest.rs
@@ -38,6 +38,9 @@ fn print_usage(program_name: &str) {
 
 fn run(digest_name: &str, expected_digest_hex: &str,
        file_path: &std::path::Path) -> Result<(), &'static str> {
+    if cfg!(feature = "native_rust") {
+        return Err("unsupported digest algorithm");
+    }
     let digest_alg = match digest_name {
         "sha256" => &digest::SHA256,
         "sha384" => &digest::SHA384,

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -34,11 +34,20 @@ arm-linux-androideabi)
   export PATH=$HOME/android/android-sdk-linux/platform-tools:$PATH
   export PATH=$HOME/android/android-sdk-linux/tools:$PATH
   ;;
+mipsel-unknown-linux-gnu)
+  export QEMU_LD_PREFIX=/usr/mipsel-linux-gnu
+  ;;
 *)
   ;;
 esac
 
-if [[ "$TARGET_X" =~ ^(arm|aarch64) && ! "$TARGET_X" =~ android ]]; then
+if [[ "$TARGET_X" =~ ^mipsel ]]; then
+  # Need to remove debian-sid as a source or subsequent update will attempt to
+  # install updated binutils from debian-sid
+  sudo sed -i '/debian/d' /etc/apt/sources.list
+fi
+
+if [[ "$TARGET_X" =~ ^(arm|aarch64|mipsel) && ! "$TARGET_X" =~ android ]]; then
   # We need a newer QEMU than Travis has.
   # sudo is needed until the PPA and its packages are whitelisted.
   # See https://github.com/travis-ci/apt-source-whitelist/issues/271

--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -288,6 +288,7 @@ fn check_per_nonce_max_bytes(in_out_len: usize)
 }
 
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use super::super::{aead, error, test};

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -107,7 +107,7 @@ extern {
                         ad: *const u8, ad_len: c::size_t) -> c::int;
 }
 
-
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use super::super::super::aead;

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -254,6 +254,7 @@ extern {
                            in_: *const u8, in_len: c::size_t);
 }
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {aead, c, polyfill, test};

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -221,7 +221,7 @@ pub fn agree_ephemeral<F, R, E>(my_private_key: EphemeralPrivateKey,
     kdf(shared_key)
 }
 
-
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {test, rand};

--- a/src/ec/eddsa.rs
+++ b/src/ec/eddsa.rs
@@ -162,7 +162,7 @@ extern  {
                           public_key: *const u8/*[32]*/) -> c::int;
 }
 
-
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {test, rand, signature};

--- a/src/ec/suite_b/ecdh.rs
+++ b/src/ec/suite_b/ecdh.rs
@@ -141,6 +141,7 @@ fn ecdh(private_key_ops: &PrivateKeyOps, public_key_ops: &PublicKeyOps,
 }
 
 
+#[cfg(not(feature = "native_rust"))]
 #[allow(unsafe_code)]
 #[cfg(test)]
 mod tests {

--- a/src/ec/suite_b/ecdsa.rs
+++ b/src/ec/suite_b/ecdsa.rs
@@ -248,7 +248,7 @@ ecdsa!(ECDSA_P384_SHA384_ASN1, &p384::PUBLIC_SCALAR_OPS, &digest::SHA384,
 ecdsa!(ECDSA_P384_SHA512_ASN1, &p384::PUBLIC_SCALAR_OPS, &digest::SHA512,
        "Verification of ECDSA signatures using the P-384 curve and SHA-512.");
 
-
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {digest, test, signature};

--- a/src/ec/suite_b/ops/ops.rs
+++ b/src/ec/suite_b/ops/ops.rs
@@ -541,7 +541,7 @@ extern {
                                            num_limbs: c::size_t);
 }
 
-
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {error, test};

--- a/src/ec/suite_b/private_key.rs
+++ b/src/ec/suite_b/private_key.rs
@@ -188,6 +188,7 @@ fn big_endian_from_limbs(out: &mut [u8], limbs: &[Limb]) {
     }
 }
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 pub mod test_util {
     use super::super::ops::Limb;

--- a/src/ec/suite_b/public_key.rs
+++ b/src/ec/suite_b/public_key.rs
@@ -66,7 +66,7 @@ pub fn parse_uncompressed_point(ops: &PublicKeyOps, input: untrusted::Input)
     Ok((x, y))
 }
 
-
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use test;

--- a/src/ec/x25519.rs
+++ b/src/ec/x25519.rs
@@ -96,6 +96,7 @@ extern {
         private_key: &[u8; X25519_ELEM_SCALAR_PUBLIC_KEY_LEN]);
 }
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {agreement, error, test};

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -130,6 +130,7 @@ pub fn expand(prk: &hmac::SigningKey, info: &[u8], out: &mut [u8]) {
     }
 }
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -78,7 +78,10 @@
 //! # Ok(())
 //! # }
 //! #
+//! # #[cfg(not(feature = "native_rust"))]
 //! # fn main() { main_with_result().unwrap() }
+//! # #[cfg(feature = "native_rust")]
+//! # fn main() { }
 //! ```
 //!
 //! ## Using the one-shot API:
@@ -107,7 +110,10 @@
 //! # Ok(())
 //! # }
 //! #
+//! # #[cfg(not(feature = "native_rust"))]
 //! # fn main() { main_with_result().unwrap() }
+//! # #[cfg(feature = "native_rust")]
+//! # fn main() { }
 //! ```
 //!
 //! ## Using the multi-part API:
@@ -143,7 +149,10 @@
 //! # Ok(())
 //! # }
 //! #
+//! # #[cfg(not(feature = "native_rust"))]
 //! # fn main() { main_with_result().unwrap() }
+//! # #[cfg(feature = "native_rust")]
+//! # fn main() { }
 //! ```
 //!
 //! [RFC 2104]: https://tools.ietf.org/html/rfc2104
@@ -343,6 +352,7 @@ pub fn verify_with_own_key(key: &SigningKey, data: &[u8], signature: &[u8])
     constant_time::verify_slices_are_equal(sign(key, data).as_ref(), signature)
 }
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {digest, error, hmac, rand, test};

--- a/src/init.rs
+++ b/src/init.rs
@@ -14,6 +14,8 @@
 
 #[allow(unsafe_code)]
 #[inline(always)]
+#[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "x86_64",
+          target_arch = "aarch64"))]
 #[cfg(not(all(target_arch = "aarch64", target_os = "ios")))]
 pub fn init_once() {
     extern crate std;
@@ -21,10 +23,15 @@ pub fn init_once() {
     INIT.call_once(|| unsafe { GFp_cpuid_setup() });
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "x86_64",
+          target_arch = "aarch64"))]
 #[cfg(not(all(target_arch = "aarch64", target_os = "ios")))]
 extern {
     fn GFp_cpuid_setup();
 }
 
-#[cfg(all(target_arch = "aarch64", target_os = "ios"))]
+
+#[cfg(any(not(any(target_arch = "x86", target_arch = "arm",
+              target_arch = "x86_64")),
+          all(target_arch = "aarch64", target_os = "ios")))]
 pub fn init_once() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,7 @@ mod private {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "native_rust"))]
     bssl_test_rng!(test_bn, bssl_bn_test_main);
     bssl_test!(test_constant_time, bssl_constant_time_test_main);
 }

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -88,6 +88,7 @@
 //!     }
 //! }
 //!
+//! # #[cfg(not(feature = "native_rust"))]
 //! fn main() {
 //!     // Normally these parameters would be loaded from a configuration file.
 //!     let mut db = PasswordDatabase {
@@ -111,6 +112,8 @@
 //!     // An attempt to log in with the right password succeeds.
 //!     assert!(db.verify_password("alice", "@74d7]404j|W}6u").is_ok());
 //! }
+//! # #[cfg(feature = "native_rust")]
+//! # fn main() { }
 
 use {constant_time, digest, error, hmac, polyfill};
 
@@ -263,6 +266,7 @@ pub static HMAC_SHA256: PRF = PRF { digest_alg: &digest::SHA256 };
 /// HMAC-SHA512.
 pub static HMAC_SHA512: PRF = PRF { digest_alg: &digest::SHA512 };
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {error, pbkdf2, test};

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -299,6 +299,7 @@ extern {
 }
 
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use rand;

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -130,6 +130,7 @@ extern {
                               max_bits: c::size_t) -> c::int;
 }
 
+#[cfg(not(feature = "native_rust"))]
 #[cfg(test)]
 mod tests {
     use {der, error, signature, test};

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -81,7 +81,10 @@
 //! # Ok(())
 //! # }
 //!
+//! # #[cfg(not(feature = "native_rust"))]
 //! # fn main() { sign_and_verify_ed25519().unwrap() }
+//! # #[cfg(feature = "native_rust")]
+//! # fn main() { }
 //! ```
 //!
 //! ## Signing and verifying with RSA (PKCS#1 1.5 padding)
@@ -95,7 +98,8 @@
 //!
 //! use ring::{rand, signature};
 //!
-//! # #[cfg(all(feature = "rsa_signing", feature = "use_heap"))]
+//! # #[cfg(all(feature = "rsa_signing", feature = "use_heap",
+//! #            not(feature = "native_rust")))]
 //! # fn sign_and_verify_rsa() -> Result<(), ring::error::Unspecified> {
 //!
 //! // Create an `RSAKeyPair` from the DER-encoded bytes. This example uses
@@ -129,7 +133,8 @@
 //! # Ok(())
 //! # }
 //! #
-//! # #[cfg(not(all(feature = "rsa_signing", feature = "use_heap")))]
+//! # #[cfg(not(all(feature = "rsa_signing", feature = "use_heap",
+//! #               not(feature = "native_rust"))))]
 //! # fn sign_and_verify_rsa() -> Result<(), ring::error::Unspecified> {
 //! #     Ok(())
 //! # }


### PR DESCRIPTION
Set feature "no_asm" to use. This currently disables use of
aead, ec, and rsa/signature modules due to missing code.

Also adds the mipsel-unknown-linux-gnu target to the travis
builds. These builds currently fail in anticipation of PR#199.
