### PR TITLE
WIP: Reuse `BN_BLINDING` multiple times in RSA signing

### DIFF
--- a/crypto/rsa/blinding.c
+++ b/crypto/rsa/blinding.c
@@ -122,10 +122,11 @@
 
 const uint32_t GFp_BN_BLINDING_COUNTER = BN_BLINDING_COUNTER;
 
+/* Needs to be kept in sync with `struct BN_BLINDING` (in `src/rsa.rs`). */
 struct bn_blinding_st {
   BIGNUM *A; /* The base blinding factor, Montgomery-encoded. */
   BIGNUM *Ai; /* The inverse of the blinding factor, Montgomery-encoded. */
-  unsigned counter;
+  uint32_t counter;
 };
 
 static int bn_blinding_create_param(BN_BLINDING *b, const RSA *rsa, RAND *rng,

--- a/crypto/rsa/blinding.c
+++ b/crypto/rsa/blinding.c
@@ -120,6 +120,8 @@
 
 #define BN_BLINDING_COUNTER 32
 
+const uint32_t GFp_BN_BLINDING_COUNTER = BN_BLINDING_COUNTER;
+
 struct bn_blinding_st {
   BIGNUM *A; /* The base blinding factor, Montgomery-encoded. */
   BIGNUM *Ai; /* The inverse of the blinding factor, Montgomery-encoded. */

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -430,9 +430,15 @@ impl Drop for PositiveInteger {
 #[cfg(feature = "rsa_signing")]
 enum BIGNUM {}
 
+/// Needs to be kept in sync with `struct bn_blinding_st` (in `crypto/rsa/blinding.c`).
 #[cfg(feature = "rsa_signing")]
 #[allow(non_camel_case_types)]
-enum BN_BLINDING {}
+#[repr(C)]
+struct BN_BLINDING {
+    a: *mut BIGNUM,
+    ai: *mut BIGNUM,
+    counter: u32,
+}
 
 #[cfg(feature = "rsa_signing")]
 #[allow(non_camel_case_types)]

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -344,14 +344,12 @@ impl RSAKeyPair {
         try!(padding_alg.pad(msg, signature));
         let mut rand = rand::RAND::new(rng);
         bssl::map_result(unsafe {
-            let blinding = BN_BLINDING_new();
-            let ret =
-                GFp_rsa_private_transform(self.rsa.as_ref(),
-                                          signature.as_mut_ptr(),
-                                          signature.len(), blinding,
-                                          &mut rand);
-            BN_BLINDING_free(blinding);
-            ret
+            let blinding = *(self.blinding.lock().unwrap());
+
+            GFp_rsa_private_transform(self.rsa.as_ref(),
+                                      signature.as_mut_ptr(),
+                                      signature.len(), blinding,
+                                      &mut rand)
         })
     }
 }
@@ -505,6 +503,9 @@ mod tests {
     use super::*;
     use untrusted;
 
+    #[cfg(feature = "rsa_signing")]
+    extern { static GFp_BN_BLINDING_COUNTER: u32; }
+
     #[test]
     fn test_signature_rsa_pkcs1_verify() {
         test::from_file("src/rsa_pkcs1_verify_tests.txt", |section, test_case| {
@@ -627,5 +628,38 @@ mod tests {
         signature.push(0);
         assert!(key_pair.sign(&RSA_PKCS1_SHA256, &rng, MESSAGE,
                               &mut signature).is_err());
+    }
+
+    // Once the `BN_BLINDING` in an `RSAKeyPair` has been used
+    // `GFp_BN_BLINDING_COUNTER` times, a new blinding should be created.
+    #[cfg(feature = "rsa_signing")]
+    #[test]
+    fn test_signature_rsa_pkcs1_sign_blinding_reuse() {
+        const MESSAGE: &'static [u8] = b"hello, world";
+        let rng = rand::SystemRandom::new();
+
+        const PRIVATE_KEY_DER: &'static [u8] =
+            include_bytes!("signature_rsa_example_private_key.der");
+        let key_bytes_der = untrusted::Input::from(PRIVATE_KEY_DER);
+        let key_pair = RSAKeyPair::from_der(key_bytes_der).unwrap();
+
+        let mut signature = vec![0; key_pair.public_modulus_len()];
+
+        for _ in 0 .. GFp_BN_BLINDING_COUNTER + 1 {
+            let prev_counter = unsafe {
+                let blinding = *(key_pair.blinding.lock().unwrap());
+                (*blinding).counter
+            };
+
+            let _ = key_pair.sign(&RSA_PKCS1_SHA256, &rng, MESSAGE,
+                                  &mut signature);
+
+            let counter = unsafe {
+                let blinding = *(key_pair.blinding.lock().unwrap());
+                (*blinding).counter
+            };
+
+            assert_eq!(counter, (prev_counter + 1) % GFp_BN_BLINDING_COUNTER);
+        }
     }
 }


### PR DESCRIPTION
Closes #234.

**Todo**:
- [x] Save a `Mutex`-wrapped pointer to `BN_BLINDING` in `RSAKeyPair`
- [x] Export `BN_BLINDING_COUNTER` as an extern `GFp_BN_BLINDING_COUNTER`
- [x] Create a test that uses the same `BN_BLINDING` at least `GFp_BN_BLINDING_COUNTER` +1 times, to exercise all the code paths in blinding.c
- [x]  Create a test that is similar to `test_agreement_suite_b_ecdh_generate`, where the `RAND` returns unusable values forever, to test the logic where the blinding gives up after a bunch of tries.
- [ ] Ensure `BN_BLINDING` coverage via coveralls report

**Questions**:
- ~~How do we want to handle a poisoned `Mutex`? Right now this work just propagates a panic with `unwrap()`.~~ 

We agreed that a poisoned mutex warrants a panic.

- ~~Right now the blinding reuse test is inadequate— it only checks that the `BN_BLINDING` counter is updated. Ideally we'd check that the actual `A` and `Ai` blinding values have been regenerated when the counter is reset. What's the "cheapest" way to do this, wrt minimizing extraneous FFI work in this PR?~~ 

We are accepting the committed `BN_BLINDING` sync burden in exchange for the level of assurance offered by checking the counter, and stopping there for now.

- ~~There is a function-local `extern` (for `GFp_BN_BLINDING_COUNTER`) and `use` (for `BN_BLINDING`) in `test_signature_rsa_pkcs1_sign_blinding_reuse`. We should make sure we're happy with that code style.~~

Reverted to module-level imports.