### PR TITLE
Test on '1.9.0' instead of 'stable' channel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,27 +18,27 @@ matrix:
     # BEGIN GENERATED
 
     - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: osx
       osx_image: xcode7.3
 
     - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: osx
       osx_image: xcode7.3
 
     - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: osx
       osx_image: xcode7.3
 
     - env: TARGET_X=x86_64-apple-darwin CC_X=clang CXX_X=clang++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: osx
       osx_image: xcode7.3
 
     - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -51,7 +51,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -64,7 +64,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -77,7 +77,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -90,23 +90,23 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -117,7 +117,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -128,7 +128,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -139,7 +139,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -150,7 +150,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -161,7 +161,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -172,7 +172,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -183,7 +183,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -194,7 +194,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -208,7 +208,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -222,7 +222,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -236,7 +236,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc CXX_X=aarch64-linux-gnu-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -250,7 +250,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -262,7 +262,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -274,7 +274,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -286,7 +286,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-4.6 CXX_X=g++-4.6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -298,7 +298,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -312,7 +312,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -326,7 +326,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -340,7 +340,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-5 CXX_X=g++-5 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -354,7 +354,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -368,7 +368,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -382,7 +382,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -396,7 +396,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=i686-unknown-linux-gnu CC_X=gcc-6 CXX_X=g++-6 FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       addons:
         apt:
@@ -410,7 +410,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -424,7 +424,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -438,7 +438,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required
@@ -452,7 +452,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc CXX_X=arm-linux-gnueabihf-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
-      rust: stable
+      rust: 1.9.0
       os: linux
       dist: trusty
       sudo: required

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -20,7 +20,7 @@ import shutil
 latest_clang = "clang-3.9"
 
 rusts = [
-    "stable",
+    "1.9.0",
     "nightly",
     "beta",
 ]


### PR DESCRIPTION
This will make it easier to track what minimum version of Rust
*ring* requires.

I agree to license my contributions to each file under the terms
given at the top of each file I changed.