### PR TITLE
Rename *ring* internals to avoid conflicts with OpenSSL.

### DIFF
--- a/crypto/aes/aes.c
+++ b/crypto/aes/aes.c
@@ -286,7 +286,8 @@ static const uint32_t rcon[] = {
     /* for 128-bit blocks, Rijndael never uses more than 10 rcon values */
 };
 
-int AES_set_encrypt_key(const uint8_t *key, unsigned bits, AES_KEY *aeskey) {
+int GFp_AES_set_encrypt_key(const uint8_t *key, unsigned bits,
+                            AES_KEY *aeskey) {
   uint32_t *rk;
   int i = 0;
   uint32_t temp;
@@ -360,7 +361,7 @@ int AES_set_encrypt_key(const uint8_t *key, unsigned bits, AES_KEY *aeskey) {
   return 0;
 }
 
-void AES_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key) {
+void GFp_AES_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key) {
   const uint32_t *rk;
   uint32_t s0, s1, s2, s3, t0, t1, t2, t3;
 #ifndef FULL_UNROLL
@@ -554,14 +555,14 @@ void AES_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key) {
 
 #define HWAES
 static int hwaes_capable(void) {
-  return CRYPTO_is_ARMv8_AES_capable();
+  return GFp_is_ARMv8_AES_capable();
 }
 
-int aes_v8_set_encrypt_key(const uint8_t *user_key, const int bits,
-                           AES_KEY *key);
-int aes_v8_set_decrypt_key(const uint8_t *user_key, const int bits,
-                           AES_KEY *key);
-void aes_v8_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key);
+int GFp_aes_v8_set_encrypt_key(const uint8_t *user_key, const int bits,
+                               AES_KEY *key);
+int GFp_aes_v8_set_decrypt_key(const uint8_t *user_key, const int bits,
+                               AES_KEY *key);
+void GFp_aes_v8_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key);
 
 #endif
 
@@ -570,25 +571,27 @@ void aes_v8_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key);
  * always hidden and wrapped by these C functions, which can be so
  * controlled. */
 
-void asm_AES_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key);
-void AES_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key) {
+void GFp_asm_AES_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key);
+void GFp_AES_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key) {
 #if defined(HWAES)
   if (hwaes_capable()) {
-    aes_v8_encrypt(in, out, key);
+    GFp_aes_v8_encrypt(in, out, key);
     return;
   }
 #endif
-  asm_AES_encrypt(in, out, key);
+  GFp_asm_AES_encrypt(in, out, key);
 }
 
-int asm_AES_set_encrypt_key(const uint8_t *key, unsigned bits, AES_KEY *aeskey);
-int AES_set_encrypt_key(const uint8_t *key, unsigned bits, AES_KEY *aeskey) {
+int GFp_asm_AES_set_encrypt_key(const uint8_t *key, unsigned bits,
+                                AES_KEY *aeskey);
+int GFp_AES_set_encrypt_key(const uint8_t *key, unsigned bits,
+                            AES_KEY *aeskey) {
 #if defined(HWAES)
   if (hwaes_capable()) {
-    return aes_v8_set_encrypt_key(key, bits, aeskey);
+    return GFp_aes_v8_set_encrypt_key(key, bits, aeskey);
   }
 #endif
-  return asm_AES_set_encrypt_key(key, bits, aeskey);
+  return GFp_asm_AES_set_encrypt_key(key, bits, aeskey);
 }
 
 #endif  /* OPENSSL_NO_ASM || (!OPENSSL_X86 && !OPENSSL_X86_64 && !OPENSSL_ARM) */

--- a/crypto/aes/aes_test.cc
+++ b/crypto/aes/aes_test.cc
@@ -24,22 +24,22 @@ static bool TestAES(const uint8_t *key, size_t key_len,
                     const uint8_t plaintext[AES_BLOCK_SIZE],
                     const uint8_t ciphertext[AES_BLOCK_SIZE]) {
   AES_KEY aes_key;
-  if (AES_set_encrypt_key(key, key_len * 8, &aes_key) != 0) {
-    fprintf(stderr, "AES_set_encrypt_key failed\n");
+  if (GFp_AES_set_encrypt_key(key, key_len * 8, &aes_key) != 0) {
+    fprintf(stderr, "GFp_AES_set_encrypt_key failed\n");
     return false;
   }
 
   // Test encryption.
   uint8_t block[AES_BLOCK_SIZE];
-  AES_encrypt(plaintext, block, &aes_key);
+  GFp_AES_encrypt(plaintext, block, &aes_key);
   if (memcmp(block, ciphertext, AES_BLOCK_SIZE) != 0) {
-    fprintf(stderr, "AES_encrypt gave the wrong output\n");
+    fprintf(stderr, "GFp_AES_encrypt gave the wrong output\n");
     return false;
   }
 
   // Test in-place encryption.
   memcpy(block, plaintext, AES_BLOCK_SIZE);
-  AES_encrypt(block, block, &aes_key);
+  GFp_AES_encrypt(block, block, &aes_key);
   if (memcmp(block, ciphertext, AES_BLOCK_SIZE) != 0) {
     fprintf(stderr, "AES_encrypt gave the wrong output\n");
     return false;

--- a/crypto/aes/asm/aes-586.pl
+++ b/crypto/aes/asm/aes-586.pl
@@ -1183,7 +1183,7 @@ sub enclast()
 	&call   (&label("pic_point"));          # make it PIC!
 	&set_label("pic_point");
 	&blindpop($tbl);
-	&picmeup($s0,"OPENSSL_ia32cap_P",$tbl,&label("pic_point")) if (!$x86only);
+	&picmeup($s0,"GFp_ia32cap_P",$tbl,&label("pic_point")) if (!$x86only);
 	&lea    ($tbl,&DWP(&label("AES_Te")."-".&label("pic_point"),$tbl));
 
 	# pick Te4 copy which can't "overlap" with stack frame or key schedule

--- a/crypto/aes/asm/aes-586.pl
+++ b/crypto/aes/asm/aes-586.pl
@@ -1162,8 +1162,8 @@ sub enclast()
 	&data_word(0x00000000, 0x00000000, 0x00000000, 0x00000000);
 &function_end_B("_x86_AES_encrypt");
 
-# void asm_AES_encrypt (const void *inp,void *out,const AES_KEY *key);
-&function_begin("asm_AES_encrypt");
+# void GFp_asm_AES_encrypt (const void *inp,void *out,const AES_KEY *key);
+&function_begin("GFp_asm_AES_encrypt");
 	&mov	($acc,&wparam(0));		# load inp
 	&mov	($key,&wparam(2));		# load key
 
@@ -1219,7 +1219,7 @@ sub enclast()
 	&mov	(&DWP(4,$acc),$s1);
 	&mov	(&DWP(8,$acc),$s2);
 	&mov	(&DWP(12,$acc),$s3);
-&function_end("asm_AES_encrypt");
+&function_end("GFp_asm_AES_encrypt");
 
 #--------------------------------------------------------------------#
 
@@ -1592,10 +1592,10 @@ sub enckey()
 
 # int asm_AES_set_encrypt_key(const unsigned char *userKey, const int bits,
 #                             AES_KEY *key)
-&function_begin_B("asm_AES_set_encrypt_key");
+&function_begin_B("GFp_asm_AES_set_encrypt_key");
 	&call	("_x86_AES_set_encrypt_key");
 	&ret	();
-&function_end_B("asm_AES_set_encrypt_key");
+&function_end_B("GFp_asm_AES_set_encrypt_key");
 
 &asciz("AES for x86, CRYPTOGAMS by <appro\@openssl.org>");
 

--- a/crypto/aes/asm/aes-armv4.pl
+++ b/crypto/aes/asm/aes-armv4.pl
@@ -184,22 +184,22 @@ AES_Te:
 .word	0x1B000000, 0x36000000, 0, 0, 0, 0, 0, 0
 .size	AES_Te,.-AES_Te
 
-@ void asm_AES_encrypt(const unsigned char *in, unsigned char *out,
-@ 		       const AES_KEY *key) {
-.global asm_AES_encrypt
-.type   asm_AES_encrypt,%function
+@ void GFp_asm_AES_encrypt(const unsigned char *in, unsigned char *out,
+@ 		                   const AES_KEY *key) {
+.global GFp_asm_AES_encrypt
+.type   GFp_asm_AES_encrypt,%function
 .align	5
-asm_AES_encrypt:
+GFp_asm_AES_encrypt:
 #ifndef	__thumb2__
-	sub	r3,pc,#8		@ asm_AES_encrypt
+	sub	r3,pc,#8		@ GFp_asm_AES_encrypt
 #else
-	adr	r3,asm_AES_encrypt
+	adr	r3,GFp_asm_AES_encrypt
 #endif
 	stmdb   sp!,{r1,r4-r12,lr}
 #ifdef	__APPLE__
 	adr	$tbl,AES_Te
 #else
-	sub	$tbl,r3,#asm_AES_encrypt-AES_Te	@ Te
+	sub	$tbl,r3,#GFp_asm_AES_encrypt-AES_Te	@ Te
 #endif
 	mov	$rounds,r0		@ inp
 	mov	$key,r2
@@ -296,7 +296,7 @@ asm_AES_encrypt:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	asm_AES_encrypt,.-asm_AES_encrypt
+.size	GFp_asm_AES_encrypt,.-GFp_asm_AES_encrypt
 
 .type   _armv4_AES_encrypt,%function
 .align	2
@@ -435,15 +435,15 @@ _armv4_AES_encrypt:
 	ldr	pc,[sp],#4		@ pop and return
 .size	_armv4_AES_encrypt,.-_armv4_AES_encrypt
 
-.global asm_AES_set_encrypt_key
-.type   asm_AES_set_encrypt_key,%function
+.global GFp_asm_AES_set_encrypt_key
+.type   GFp_asm_AES_set_encrypt_key,%function
 .align	5
-asm_AES_set_encrypt_key:
+GFp_asm_AES_set_encrypt_key:
 _armv4_AES_set_encrypt_key:
 #ifndef	__thumb2__
-	sub	r3,pc,#8		@ asm_AES_set_encrypt_key
+	sub	r3,pc,#8		@ GFp_asm_AES_set_encrypt_key
 #else
-	adr	r3,asm_AES_set_encrypt_key
+	adr	r3,GFp_asm_AES_set_encrypt_key
 #endif
 	teq	r0,#0
 #ifdef	__thumb2__
@@ -691,7 +691,7 @@ _armv4_AES_set_encrypt_key:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	asm_AES_set_encrypt_key,.-asm_AES_set_encrypt_key
+.size	GFp_asm_AES_set_encrypt_key,.-GFp_asm_AES_set_encrypt_key
 
 .asciz	"AES for ARMv4, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2

--- a/crypto/aes/asm/aes-x86_64.pl
+++ b/crypto/aes/asm/aes-x86_64.pl
@@ -583,13 +583,13 @@ $code.=<<___;
 .size	_x86_64_AES_encrypt_compact,.-_x86_64_AES_encrypt_compact
 ___
 
-# void asm_AES_encrypt (const void *inp,void *out,const AES_KEY *key);
+# void GFp_asm_AES_encrypt (const void *inp,void *out,const AES_KEY *key);
 $code.=<<___;
 .align	16
-.globl	asm_AES_encrypt
-.type	asm_AES_encrypt,\@function,3
-.hidden	asm_AES_encrypt
-asm_AES_encrypt:
+.globl	GFp_asm_AES_encrypt
+.type	GFp_asm_AES_encrypt,\@function,3
+.hidden	GFp_asm_AES_encrypt
+GFp_asm_AES_encrypt:
 	push	%rbx
 	push	%rbp
 	push	%r12
@@ -649,7 +649,7 @@ asm_AES_encrypt:
 	lea	48(%rsi),%rsp
 .Lenc_epilogue:
 	ret
-.size	asm_AES_encrypt,.-asm_AES_encrypt
+.size	GFp_asm_AES_encrypt,.-GFp_asm_AES_encrypt
 ___
 
 #------------------------------------------------------------------#
@@ -681,12 +681,13 @@ $code.=<<___;
 ___
 }
 
-# int asm_AES_set_encrypt_key(const unsigned char *userKey, const int bits, AES_KEY *key)
+# int GFp_asm_AES_set_encrypt_key(const unsigned char *userKey, const int bits,
+#                                 AES_KEY *key)
 $code.=<<___;
 .align	16
-.globl asm_AES_set_encrypt_key
-.type  asm_AES_set_encrypt_key,\@function,3
-asm_AES_set_encrypt_key:
+.globl GFp_asm_AES_set_encrypt_key
+.type  GFp_asm_AES_set_encrypt_key,\@function,3
+GFp_asm_AES_set_encrypt_key:
 	push	%rbx
 	push	%rbp
 	push	%r12			# redundant, but allows to share 
@@ -703,7 +704,7 @@ asm_AES_set_encrypt_key:
 	add	\$56,%rsp
 .Lenc_key_epilogue:
 	ret
-.size asm_AES_set_encrypt_key,.-asm_AES_set_encrypt_key
+.size GFp_asm_AES_set_encrypt_key,.-GFp_asm_AES_set_encrypt_key
 
 .type	_x86_64_AES_set_encrypt_key,\@abi-omnipotent
 .align	16
@@ -1219,21 +1220,21 @@ key_se_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_asm_AES_encrypt
-	.rva	.LSEH_end_asm_AES_encrypt
-	.rva	.LSEH_info_asm_AES_encrypt
+	.rva	.LSEH_begin_GFp_asm_AES_encrypt
+	.rva	.LSEH_end_GFp_asm_AES_encrypt
+	.rva	.LSEH_info_GFp_asm_AES_encrypt
 
-	.rva	.LSEH_begin_asm_AES_set_encrypt_key
-	.rva	.LSEH_end_asm_AES_set_encrypt_key
-	.rva	.LSEH_info_asm_AES_set_encrypt_key
+	.rva	.LSEH_begin_GFp_asm_AES_set_encrypt_key
+	.rva	.LSEH_end_GFp_asm_AES_set_encrypt_key
+	.rva	.LSEH_info_GFp_asm_AES_set_encrypt_key
 
 .section	.xdata
 .align	8
-.LSEH_info_asm_AES_encrypt:
+.LSEH_info_GFp_asm_AES_encrypt:
 	.byte	9,0,0,0
 	.rva	block_se_handler
 	.rva	.Lenc_prologue,.Lenc_epilogue	# HandlerData[]
-.LSEH_info_asm_AES_set_encrypt_key:
+.LSEH_info_GFp_asm_AES_set_encrypt_key:
 	.byte	9,0,0,0
 	.rva	key_se_handler
 	.rva	.Lenc_key_prologue,.Lenc_key_epilogue	# HandlerData[]

--- a/crypto/aes/asm/aesni-x86.pl
+++ b/crypto/aes/asm/aesni-x86.pl
@@ -69,7 +69,7 @@ open OUT,">$output";
 
 &asm_init($ARGV[0],$0);
 
-&external_label("OPENSSL_ia32cap_P");
+&external_label("GFp_ia32cap_P");
 &static_label("key_const");
 
 if ($PREFIX eq "aesni")	{ $movekey=\&movups; }
@@ -673,7 +673,7 @@ if ($PREFIX eq "aesni") {
 	&blindpop("ebx");
 	&lea	("ebx",&DWP(&label("key_const")."-".&label("pic"),"ebx"));
 
-	&picmeup("ebp","OPENSSL_ia32cap_P","ebx",&label("key_const"));
+	&picmeup("ebp","GFp_ia32cap_P","ebx",&label("key_const"));
 	&movups	("xmm0",&QWP(0,"eax"));	# pull first 128 bits of *userKey
 	&xorps	("xmm4","xmm4");	# low dword of xmm4 is assumed 0
 	&mov	("ebp",&DWP(4,"ebp"));

--- a/crypto/aes/asm/aesni-x86.pl
+++ b/crypto/aes/asm/aesni-x86.pl
@@ -176,7 +176,7 @@ sub aesni_generate1	# fully unrolled loop
 
 # void $PREFIX_encrypt (const void *inp,void *out,const AES_KEY *key);
 &aesni_generate1("enc") if (!$inline);
-&function_begin_B("${PREFIX}_encrypt");
+&function_begin_B("GFp_${PREFIX}_encrypt");
 	&mov	("eax",&wparam(0));
 	&mov	($key,&wparam(2));
 	&movups	($inout0,&QWP(0,"eax"));
@@ -191,7 +191,7 @@ sub aesni_generate1	# fully unrolled loop
 	&movups	(&QWP(0,"eax"),$inout0);
 	&pxor	($inout0,$inout0);
 	&ret	();
-&function_end_B("${PREFIX}_encrypt");
+&function_end_B("GFp_${PREFIX}_encrypt");
 
 # _aesni_[en|de]cryptN are private interfaces, N denotes interleave
 # factor. Why 3x subroutine were originally used in loops? Even though
@@ -388,9 +388,9 @@ sub aesni_generate6
 if ($PREFIX eq "aesni") {
 
 ######################################################################
-# void aesni_ctr32_encrypt_blocks (const void *in, void *out,
-#                         size_t blocks, const AES_KEY *key,
-#                         const char *ivec);
+# void GFp_aesni_ctr32_encrypt_blocks (const void *in, void *out,
+#                                      size_t blocks, const AES_KEY *key,
+#                                      const char *ivec);
 #
 # Handles only complete blocks, operates on 32-bit counter and
 # does not update *ivec! (see crypto/modes/ctr128.c for details)
@@ -403,7 +403,7 @@ if ($PREFIX eq "aesni") {
 #	64	2nd triplet of counter vector
 #	80	saved %esp
 
-&function_begin("aesni_ctr32_encrypt_blocks");
+&function_begin("GFp_aesni_ctr32_encrypt_blocks");
 	&mov	($inp,&wparam(0));
 	&mov	($out,&wparam(1));
 	&mov	($len,&wparam(2));
@@ -645,7 +645,7 @@ if ($PREFIX eq "aesni") {
 	&movdqa	(&QWP(64,"esp"),"xmm0");
 	&pxor	("xmm7","xmm7");
 	&mov	("esp",&DWP(80,"esp"));
-&function_end("aesni_ctr32_encrypt_blocks");
+&function_end("GFp_aesni_ctr32_encrypt_blocks");
 }
 
 ######################################################################
@@ -1030,13 +1030,13 @@ if ($PREFIX eq "aesni") {
 
 # int $PREFIX_set_encrypt_key (const unsigned char *userKey, int bits,
 #                              AES_KEY *key)
-&function_begin_B("${PREFIX}_set_encrypt_key");
+&function_begin_B("GFp_${PREFIX}_set_encrypt_key");
 	&mov	("eax",&wparam(0));
 	&mov	($rounds,&wparam(1));
 	&mov	($key,&wparam(2));
 	&call	("_aesni_set_encrypt_key");
 	&ret	();
-&function_end_B("${PREFIX}_set_encrypt_key");
+&function_end_B("GFp_${PREFIX}_set_encrypt_key");
 
 &set_label("key_const",64);
 &data_word(0x0c0f0e0d,0x0c0f0e0d,0x0c0f0e0d,0x0c0f0e0d);

--- a/crypto/aes/asm/aesni-x86_64.pl
+++ b/crypto/aes/asm/aesni-x86_64.pl
@@ -195,7 +195,7 @@ $movkey = $PREFIX eq "aesni" ? "movups" : "movups";
 		("%rdi","%rsi","%rdx","%rcx");	# Unix order
 
 $code=".text\n";
-$code.=".extern	OPENSSL_ia32cap_P\n";
+$code.=".extern	GFp_ia32cap_P\n";
 
 $rounds="%eax";	# input to and changed by aesni_[en|de]cryptN !!!
 # this is natural Unix argument order for public $PREFIX_[ecb|cbc]_encrypt ...
@@ -667,7 +667,7 @@ $code.=<<___;
 	lea	7($ctr),%r9
 	 mov	%r10d,0x60+12(%rsp)
 	bswap	%r9d
-	 mov	OPENSSL_ia32cap_P+4(%rip),%r10d 
+	 mov	GFp_ia32cap_P+4(%rip),%r10d 
 	xor	$key0,%r9d
 	 and	\$`1<<26|1<<22`,%r10d		# isolate XSAVE+MOVBE
 	mov	%r9d,0x70+12(%rsp)
@@ -1169,7 +1169,7 @@ __aesni_set_encrypt_key:
 	mov	\$`1<<28|1<<11`,%r10d	# AVX and XOP bits
 	movups	($inp),%xmm0		# pull first 128 bits of *userKey
 	xorps	%xmm4,%xmm4		# low dword of xmm4 is assumed 0
-	and	OPENSSL_ia32cap_P+4(%rip),%r10d
+	and	GFp_ia32cap_P+4(%rip),%r10d
 	lea	16($key),%rax		# %rax is used as modifiable copy of $key
 	cmp	\$256,$bits
 	je	.L14rounds

--- a/crypto/aes/asm/aesni-x86_64.pl
+++ b/crypto/aes/asm/aesni-x86_64.pl
@@ -254,10 +254,10 @@ ___
 { my ($inp,$out,$key) = @_4args;
 
 $code.=<<___;
-.globl	${PREFIX}_encrypt
-.type	${PREFIX}_encrypt,\@abi-omnipotent
+.globl	GFp_${PREFIX}_encrypt
+.type	GFp_${PREFIX}_encrypt,\@abi-omnipotent
 .align	16
-${PREFIX}_encrypt:
+GFp_${PREFIX}_encrypt:
 	movups	($inp),$inout0		# load input
 	mov	240($key),$rounds	# key->rounds
 ___
@@ -268,7 +268,7 @@ $code.=<<___;
 	movups	$inout0,($out)		# output
 	 pxor	$inout0,$inout0
 	ret
-.size	${PREFIX}_encrypt,.-${PREFIX}_encrypt
+.size	GFp_${PREFIX}_encrypt,.-GFp_${PREFIX}_encrypt
 ___
 }
 
@@ -554,9 +554,9 @@ ___
 if ($PREFIX eq "aesni") {
 {
 ######################################################################
-# void aesni_ctr32_encrypt_blocks (const void *in, void *out,
-#                         size_t blocks, const AES_KEY *key,
-#                         const char *ivec);
+# void GFp_aesni_ctr32_encrypt_blocks (const void *in, void *out,
+#                                      size_t blocks, const AES_KEY *key,
+#                                      const char *ivec);
 #
 # Handles only complete blocks, operates on 32-bit counter and
 # does not update *ivec! (see crypto/modes/ctr128.c for details)
@@ -571,10 +571,10 @@ my ($key0,$ctr)=("${key_}d","${ivp}d");
 my $frame_size = 0x80 + ($win64?160:0);
 
 $code.=<<___;
-.globl	aesni_ctr32_encrypt_blocks
-.type	aesni_ctr32_encrypt_blocks,\@function,5
+.globl	GFp_aesni_ctr32_encrypt_blocks
+.type	GFp_aesni_ctr32_encrypt_blocks,\@function,5
 .align	16
-aesni_ctr32_encrypt_blocks:
+GFp_aesni_ctr32_encrypt_blocks:
 	cmp	\$1,$len
 	jne	.Lctr32_bulk
 
@@ -1121,7 +1121,7 @@ $code.=<<___;
 	pop	%rbp
 .Lctr32_epilogue:
 	ret
-.size	aesni_ctr32_encrypt_blocks,.-aesni_ctr32_encrypt_blocks
+.size	GFp_aesni_ctr32_encrypt_blocks,.-GFp_aesni_ctr32_encrypt_blocks
 ___
 } }}
 
@@ -1137,8 +1137,8 @@ ___
 # Agressively optimized in respect to aeskeygenassist's critical path
 # and is contained in %xmm0-5 to meet Win64 ABI requirement.
 #
-# int ${PREFIX}_set_encrypt_key(const unsigned char *inp,
-#				int bits, AES_KEY * const key);
+# int GFp_${PREFIX}_set_encrypt_key(const unsigned char *inp,
+#				                    int bits, AES_KEY * const key);
 #
 # input:	$inp	user-supplied key
 #		$bits	$inp length in bits
@@ -1154,10 +1154,10 @@ ___
 # amount of volatile registers is smaller on Windows.
 #
 $code.=<<___;
-.globl	${PREFIX}_set_encrypt_key
-.type	${PREFIX}_set_encrypt_key,\@abi-omnipotent
+.globl	GFp_${PREFIX}_set_encrypt_key
+.type	GFp_${PREFIX}_set_encrypt_key,\@abi-omnipotent
 .align	16
-${PREFIX}_set_encrypt_key:
+GFp_${PREFIX}_set_encrypt_key:
 __aesni_set_encrypt_key:
 	.byte	0x48,0x83,0xEC,0x08	# sub rsp,8
 	mov	\$-1,%rax
@@ -1453,7 +1453,7 @@ __aesni_set_encrypt_key:
 	pxor	%xmm5,%xmm5
 	add	\$8,%rsp
 	ret
-.LSEH_end_set_encrypt_key:
+.LSEH_end_GFp_set_encrypt_key:
 
 .align	16
 .Lkey_expansion_128:
@@ -1523,7 +1523,7 @@ __aesni_set_encrypt_key:
 	shufps	\$0b10101010,%xmm1,%xmm1	# critical path
 	xorps	%xmm1,%xmm2
 	ret
-.size	${PREFIX}_set_encrypt_key,.-${PREFIX}_set_encrypt_key
+.size	GFp_${PREFIX}_set_encrypt_key,.-GFp_${PREFIX}_set_encrypt_key
 .size	__aesni_set_encrypt_key,.-__aesni_set_encrypt_key
 ___
 }
@@ -1650,25 +1650,25 @@ ctr_se_handler:
 .align	4
 ___
 $code.=<<___ if ($PREFIX eq "aesni");
-	.rva	.LSEH_begin_aesni_ctr32_encrypt_blocks
-	.rva	.LSEH_end_aesni_ctr32_encrypt_blocks
-	.rva	.LSEH_info_ctr32
+	.rva	.LSEH_begin_GFp_aesni_ctr32_encrypt_blocks
+	.rva	.LSEH_end_GFp_aesni_ctr32_encrypt_blocks
+	.rva	.LSEH_info_GFp_ctr32
 ___
 $code.=<<___;
-	.rva	${PREFIX}_set_encrypt_key
-	.rva	.LSEH_end_set_encrypt_key
-	.rva	.LSEH_info_key
+	.rva	GFp_${PREFIX}_set_encrypt_key
+	.rva	.LSEH_end_GFp_set_encrypt_key
+	.rva	.LSEH_info_GFp_key
 .section	.xdata
 .align	8
 ___
 $code.=<<___ if ($PREFIX eq "aesni");
-.LSEH_info_ctr32:
+.LSEH_info_GFp_ctr32:
 	.byte	9,0,0,0
 	.rva	ctr_se_handler
 	.rva	.Lctr32_body,.Lctr32_epilogue		# HandlerData[]
 ___
 $code.=<<___;
-.LSEH_info_key:
+.LSEH_info_GFp_key:
 	.byte	0x01,0x04,0x01,0x00
 	.byte	0x04,0x02,0x00,0x00	# sub rsp,8
 ___

--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -77,10 +77,10 @@ $code.=<<___;
 .long	0x0c0f0e0d,0x0c0f0e0d,0x0c0f0e0d,0x0c0f0e0d	// rotate-n-splat
 .long	0x1b,0x1b,0x1b,0x1b
 
-.globl	${prefix}_set_encrypt_key
-.type	${prefix}_set_encrypt_key,%function
+.globl	GFp_${prefix}_set_encrypt_key
+.type	GFp_${prefix}_set_encrypt_key,%function
 .align	5
-${prefix}_set_encrypt_key:
+GFp_${prefix}_set_encrypt_key:
 .Lenc_key:
 ___
 $code.=<<___	if ($flavour =~ /64/);
@@ -246,7 +246,7 @@ $code.=<<___;
 	mov	x0,$ptr			// return value
 	`"ldr	x29,[sp],#16"		if ($flavour =~ /64/)`
 	ret
-.size	${prefix}_set_encrypt_key,.-${prefix}_set_encrypt_key
+.size	GFp_${prefix}_set_encrypt_key,.-GFp_${prefix}_set_encrypt_key
 ___
 }}}
 {{{
@@ -258,10 +258,10 @@ my $rounds="w3";
 my ($rndkey0,$rndkey1,$inout)=map("q$_",(0..3));
 
 $code.=<<___;
-.globl	${prefix}_${dir}crypt
-.type	${prefix}_${dir}crypt,%function
+.globl	GFp_${prefix}_${dir}crypt
+.type	GFp_${prefix}_${dir}crypt,%function
 .align	5
-${prefix}_${dir}crypt:
+GFp_${prefix}_${dir}crypt:
 	ldr	$rounds,[$key,#240]
 	vld1.32	{$rndkey0},[$key],#16
 	vld1.8	{$inout},[$inp]
@@ -286,7 +286,7 @@ ${prefix}_${dir}crypt:
 
 	vst1.8	{$inout},[$out]
 	ret
-.size	${prefix}_${dir}crypt,.-${prefix}_${dir}crypt
+.size	GFp_${prefix}_${dir}crypt,.-GFp_${prefix}_${dir}crypt
 ___
 }
 &gen_block("en");
@@ -306,10 +306,10 @@ my ($dat,$tmp)=($dat0,$tmp0);
 ### q8-q15	preloaded key schedule
 
 $code.=<<___;
-.globl	${prefix}_ctr32_encrypt_blocks
-.type	${prefix}_ctr32_encrypt_blocks,%function
+.globl	GFp_${prefix}_ctr32_encrypt_blocks
+.type	GFp_${prefix}_ctr32_encrypt_blocks,%function
 .align	5
-${prefix}_ctr32_encrypt_blocks:
+GFp_${prefix}_ctr32_encrypt_blocks:
 ___
 $code.=<<___	if ($flavour =~ /64/);
 	stp		x29,x30,[sp,#-16]!
@@ -504,7 +504,7 @@ $code.=<<___	if ($flavour =~ /64/);
 	ret
 ___
 $code.=<<___;
-.size	${prefix}_ctr32_encrypt_blocks,.-${prefix}_ctr32_encrypt_blocks
+.size	GFp_${prefix}_ctr32_encrypt_blocks,.-GFp_${prefix}_ctr32_encrypt_blocks
 ___
 }}}
 $code.=<<___;

--- a/crypto/aes/asm/bsaes-armv7.pl
+++ b/crypto/aes/asm/bsaes-armv7.pl
@@ -926,58 +926,6 @@ _bsaes_key_convert:
 ___
 }
 
-if (0) {		# following four functions are unsupported interface
-			# used for benchmarking...
-$code.=<<___;
-.globl	bsaes_enc_key_convert
-.type	bsaes_enc_key_convert,%function
-.align	4
-bsaes_enc_key_convert:
-	stmdb	sp!,{r4-r6,lr}
-	vstmdb	sp!,{d8-d15}		@ ABI specification says so
-
-	ldr	r5,[$inp,#240]			@ pass rounds
-	mov	r4,$inp				@ pass key
-	mov	r12,$out			@ pass key schedule
-	bl	_bsaes_key_convert
-	veor	@XMM[7],@XMM[7],@XMM[15]	@ fix up last round key
-	vstmia	r12, {@XMM[7]}			@ save last round key
-
-	vldmia	sp!,{d8-d15}
-	ldmia	sp!,{r4-r6,pc}
-.size	bsaes_enc_key_convert,.-bsaes_enc_key_convert
-
-.globl	bsaes_encrypt_128
-.type	bsaes_encrypt_128,%function
-.align	4
-bsaes_encrypt_128:
-	stmdb	sp!,{r4-r6,lr}
-	vstmdb	sp!,{d8-d15}		@ ABI specification says so
-.Lenc128_loop:
-	vld1.8	{@XMM[0]-@XMM[1]}, [$inp]!	@ load input
-	vld1.8	{@XMM[2]-@XMM[3]}, [$inp]!
-	mov	r4,$key				@ pass the key
-	vld1.8	{@XMM[4]-@XMM[5]}, [$inp]!
-	mov	r5,#10				@ pass rounds
-	vld1.8	{@XMM[6]-@XMM[7]}, [$inp]!
-
-	bl	_bsaes_encrypt8
-
-	vst1.8	{@XMM[0]-@XMM[1]}, [$out]!	@ write output
-	vst1.8	{@XMM[4]}, [$out]!
-	vst1.8	{@XMM[6]}, [$out]!
-	vst1.8	{@XMM[3]}, [$out]!
-	vst1.8	{@XMM[7]}, [$out]!
-	vst1.8	{@XMM[2]}, [$out]!
-	subs	$len,$len,#0x80
-	vst1.8	{@XMM[5]}, [$out]!
-	bhi	.Lenc128_loop
-
-	vldmia	sp!,{d8-d15}
-	ldmia	sp!,{r4-r6,pc}
-.size	bsaes_encrypt_128,.-bsaes_encrypt_128
-___
-}
 {
 my ($inp,$out,$len,$key, $ctr,$fp,$rounds)=(map("r$_",(0..3,8..10)));
 my $const = "r6";	# shared with _bsaes_encrypt8_alt

--- a/crypto/aes/asm/bsaes-armv7.pl
+++ b/crypto/aes/asm/bsaes-armv7.pl
@@ -932,11 +932,11 @@ my $const = "r6";	# shared with _bsaes_encrypt8_alt
 my $keysched = "sp";
 
 $code.=<<___;
-.extern	AES_encrypt
-.global	bsaes_ctr32_encrypt_blocks
-.type	bsaes_ctr32_encrypt_blocks,%function
+.extern	GFp_AES_encrypt
+.global	GFp_bsaes_ctr32_encrypt_blocks
+.type	GFp_bsaes_ctr32_encrypt_blocks,%function
 .align	5
-bsaes_ctr32_encrypt_blocks:
+GFp_bsaes_ctr32_encrypt_blocks:
 	cmp	$len, #8			@ use plain AES for
 	blo	.Lctr_enc_short			@ small sizes
 
@@ -1138,7 +1138,7 @@ bsaes_ctr32_encrypt_blocks:
 	mov	r1, sp			@ output on the stack
 	mov	r2, r7			@ key
 
-	bl	AES_encrypt
+	bl	GFp_AES_encrypt
 
 	vld1.8	{@XMM[0]}, [r4]!	@ load input
 	vld1.8	{@XMM[1]}, [sp]		@ load encrypted counter
@@ -1159,7 +1159,7 @@ bsaes_ctr32_encrypt_blocks:
 	vstmia		sp!, {q0-q1}
 
 	ldmia	sp!, {r4-r8, pc}
-.size	bsaes_ctr32_encrypt_blocks,.-bsaes_ctr32_encrypt_blocks
+.size	GFp_bsaes_ctr32_encrypt_blocks,.-GFp_bsaes_ctr32_encrypt_blocks
 ___
 }
 $code.=<<___;

--- a/crypto/aes/asm/bsaes-x86_64.pl
+++ b/crypto/aes/asm/bsaes-x86_64.pl
@@ -800,7 +800,7 @@ ___
 $code.=<<___;
 .text
 
-.extern	asm_AES_encrypt
+.extern	GFp_asm_AES_encrypt
 
 .type	_bsaes_encrypt8,\@abi-omnipotent
 .align	64
@@ -990,10 +990,10 @@ my ($arg1,$arg2,$arg3,$arg4,$arg5,$arg6)=$win64	? ("%rcx","%rdx","%r8","%r9","%r
 my ($inp,$out,$len,$key)=("%r12","%r13","%r14","%r15");
 
 $code.=<<___;
-.globl	bsaes_ctr32_encrypt_blocks
-.type	bsaes_ctr32_encrypt_blocks,\@abi-omnipotent
+.globl	GFp_bsaes_ctr32_encrypt_blocks
+.type	GFp_bsaes_ctr32_encrypt_blocks,\@abi-omnipotent
 .align	16
-bsaes_ctr32_encrypt_blocks:
+GFp_bsaes_ctr32_encrypt_blocks:
 	mov	%rsp, %rax
 .Lctr_enc_prologue:
 	push	%rbp
@@ -1170,7 +1170,7 @@ $code.=<<___;
 	lea	0x20(%rbp), $arg1
 	lea	0x30(%rbp), $arg2
 	lea	($key), $arg3
-	call	asm_AES_encrypt
+	call	GFp_asm_AES_encrypt
 	movdqu	($inp), @XMM[1]
 	lea	16($inp), $inp
 	mov	0x2c(%rbp), %eax	# load 32-bit counter
@@ -1220,7 +1220,7 @@ $code.=<<___;
 	mov	%rax, %rbp
 .Lctr_enc_epilogue:
 	ret
-.size	bsaes_ctr32_encrypt_blocks,.-bsaes_ctr32_encrypt_blocks
+.size	GFp_bsaes_ctr32_encrypt_blocks,.-GFp_bsaes_ctr32_encrypt_blocks
 ___
 }
 $code.=<<___;

--- a/crypto/aes/asm/bsaes-x86_64.pl
+++ b/crypto/aes/asm/bsaes-x86_64.pl
@@ -980,56 +980,6 @@ _bsaes_key_convert:
 ___
 }
 
-if (0 && !$win64) {	# following four functions are unsupported interface
-			# used for benchmarking...
-$code.=<<___;
-.globl	bsaes_enc_key_convert
-.type	bsaes_enc_key_convert,\@function,2
-.align	16
-bsaes_enc_key_convert:
-	mov	240($inp),%r10d		# pass rounds
-	mov	$inp,%rcx		# pass key
-	mov	$out,%rax		# pass key schedule
-	call	_bsaes_key_convert
-	pxor	%xmm6,%xmm7		# fix up last round key
-	movdqa	%xmm7,(%rax)		# save last round key
-	ret
-.size	bsaes_enc_key_convert,.-bsaes_enc_key_convert
-
-.globl	bsaes_encrypt_128
-.type	bsaes_encrypt_128,\@function,4
-.align	16
-bsaes_encrypt_128:
-.Lenc128_loop:
-	movdqu	0x00($inp), @XMM[0]	# load input
-	movdqu	0x10($inp), @XMM[1]
-	movdqu	0x20($inp), @XMM[2]
-	movdqu	0x30($inp), @XMM[3]
-	movdqu	0x40($inp), @XMM[4]
-	movdqu	0x50($inp), @XMM[5]
-	movdqu	0x60($inp), @XMM[6]
-	movdqu	0x70($inp), @XMM[7]
-	mov	$key, %rax		# pass the $key
-	lea	0x80($inp), $inp
-	mov	\$10,%r10d
-
-	call	_bsaes_encrypt8
-
-	movdqu	@XMM[0], 0x00($out)	# write output
-	movdqu	@XMM[1], 0x10($out)
-	movdqu	@XMM[4], 0x20($out)
-	movdqu	@XMM[6], 0x30($out)
-	movdqu	@XMM[3], 0x40($out)
-	movdqu	@XMM[7], 0x50($out)
-	movdqu	@XMM[2], 0x60($out)
-	movdqu	@XMM[5], 0x70($out)
-	lea	0x80($out), $out
-	sub	\$0x80,$len
-	ja	.Lenc128_loop
-	ret
-.size	bsaes_encrypt_128,.-bsaes_encrypt_128
-___
-}
 {
 ######################################################################
 #

--- a/crypto/aes/asm/vpaes-x86.pl
+++ b/crypto/aes/asm/vpaes-x86.pl
@@ -609,7 +609,7 @@ $k_deskew=0x180;	# deskew tables: inverts the sbox's "skew"
 #
 # Interface to OpenSSL
 #
-&function_begin("${PREFIX}_set_encrypt_key");
+&function_begin("GFp_${PREFIX}_set_encrypt_key");
 	&mov	($inp,&wparam(0));		# inp
 	&lea	($base,&DWP(-56,"esp"));
 	&mov	($round,&wparam(1));		# bits
@@ -631,9 +631,9 @@ $k_deskew=0x180;	# deskew tables: inverts the sbox's "skew"
 
 	&mov	("esp",&DWP(48,"esp"));
 	&xor	("eax","eax");
-&function_end("${PREFIX}_set_encrypt_key");
+&function_end("GFp_${PREFIX}_set_encrypt_key");
 
-&function_begin("${PREFIX}_encrypt");
+&function_begin("GFp_${PREFIX}_encrypt");
 	&lea	($const,&DWP(&label("_vpaes_consts")."+0x30-".&label("pic_point")));
 	&call	("_vpaes_preheat");
 &set_label("pic_point");
@@ -650,7 +650,7 @@ $k_deskew=0x180;	# deskew tables: inverts the sbox's "skew"
 	&movdqu	(&QWP(0,$out),"xmm0");
 
 	&mov	("esp",&DWP(48,"esp"));
-&function_end("${PREFIX}_encrypt");
+&function_end("GFp_${PREFIX}_encrypt");
 
 &asm_finish();
 

--- a/crypto/aes/asm/vpaes-x86_64.pl
+++ b/crypto/aes/asm/vpaes-x86_64.pl
@@ -505,10 +505,10 @@ _vpaes_schedule_mangle:
 #
 # Interface to OpenSSL
 #
-.globl	${PREFIX}_set_encrypt_key
-.type	${PREFIX}_set_encrypt_key,\@function,3
+.globl	GFp_${PREFIX}_set_encrypt_key
+.type	GFp_${PREFIX}_set_encrypt_key,\@function,3
 .align	16
-${PREFIX}_set_encrypt_key:
+GFp_${PREFIX}_set_encrypt_key:
 ___
 $code.=<<___ if ($win64);
 	lea	-0xb8(%rsp),%rsp
@@ -551,12 +551,12 @@ ___
 $code.=<<___;
 	xor	%eax,%eax
 	ret
-.size	${PREFIX}_set_encrypt_key,.-${PREFIX}_set_encrypt_key
+.size	GFp_${PREFIX}_set_encrypt_key,.-GFp_${PREFIX}_set_encrypt_key
 
-.globl	${PREFIX}_encrypt
-.type	${PREFIX}_encrypt,\@function,3
+.globl	GFp_${PREFIX}_encrypt
+.type	GFp_${PREFIX}_encrypt,\@function,3
 .align	16
-${PREFIX}_encrypt:
+GFp_${PREFIX}_encrypt:
 ___
 $code.=<<___ if ($win64);
 	lea	-0xb8(%rsp),%rsp
@@ -594,7 +594,7 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	ret
-.size	${PREFIX}_encrypt,.-${PREFIX}_encrypt
+.size	GFp_${PREFIX}_encrypt,.-GFp_${PREFIX}_encrypt
 ___
 $code.=<<___;
 ##
@@ -768,21 +768,21 @@ se_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_${PREFIX}_set_encrypt_key
-	.rva	.LSEH_end_${PREFIX}_set_encrypt_key
-	.rva	.LSEH_info_${PREFIX}_set_encrypt_key
+	.rva	.LSEH_begin_GFp_${PREFIX}_set_encrypt_key
+	.rva	.LSEH_end_GFp_${PREFIX}_set_encrypt_key
+	.rva	.LSEH_info_GFp_${PREFIX}_set_encrypt_key
 
-	.rva	.LSEH_begin_${PREFIX}_encrypt
-	.rva	.LSEH_end_${PREFIX}_encrypt
-	.rva	.LSEH_info_${PREFIX}_encrypt
+	.rva	.LSEH_begin_GFp_${PREFIX}_encrypt
+	.rva	.LSEH_end_GFp_${PREFIX}_encrypt
+	.rva	.LSEH_info_GFp_${PREFIX}_encrypt
 
 .section	.xdata
 .align	8
-.LSEH_info_${PREFIX}_set_encrypt_key:
+.LSEH_info_GFp_${PREFIX}_set_encrypt_key:
 	.byte	9,0,0,0
 	.rva	se_handler
 	.rva	.Lenc_key_body,.Lenc_key_epilogue	# HandlerData[]
-.LSEH_info_${PREFIX}_encrypt:
+.LSEH_info_GFp_${PREFIX}_encrypt:
 	.byte	9,0,0,0
 	.rva	se_handler
 	.rva	.Lenc_body,.Lenc_epilogue		# HandlerData[]

--- a/crypto/bn/add.c
+++ b/crypto/bn/add.c
@@ -64,7 +64,7 @@
 #include "internal.h"
 
 
-int BN_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
+int GFp_BN_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   const BIGNUM *tmp;
   int a_neg = a->neg, ret;
 
@@ -82,13 +82,13 @@ int BN_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
     }
 
     /* we are now a - b */
-    if (BN_ucmp(a, b) < 0) {
-      if (!BN_usub_unchecked(r, b, a)) {
+    if (GFp_BN_ucmp(a, b) < 0) {
+      if (!GFp_BN_usub_unchecked(r, b, a)) {
         return 0;
       }
       r->neg = 1;
     } else {
-      if (!BN_usub_unchecked(r, a, b)) {
+      if (!GFp_BN_usub_unchecked(r, a, b)) {
         return 0;
       }
       r->neg = 0;
@@ -96,12 +96,12 @@ int BN_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
     return 1;
   }
 
-  ret = BN_uadd(r, a, b);
+  ret = GFp_BN_uadd(r, a, b);
   r->neg = a_neg;
   return ret;
 }
 
-int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
+int GFp_BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   int max, min, dif;
   BN_ULONG *ap, *bp, *rp, carry, t1, t2;
   const BIGNUM *tmp;
@@ -115,7 +115,7 @@ int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   min = b->top;
   dif = max - min;
 
-  if (bn_wexpand(r, max + 1) == NULL) {
+  if (GFp_bn_wexpand(r, max + 1) == NULL) {
     return 0;
   }
 
@@ -125,7 +125,7 @@ int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   bp = b->d;
   rp = r->d;
 
-  carry = bn_add_words(rp, ap, bp, min);
+  carry = GFp_bn_add_words(rp, ap, bp, min);
   rp += min;
   ap += min;
   bp += min;
@@ -159,7 +159,7 @@ int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   return 1;
 }
 
-int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
+int GFp_BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   int max;
   int add = 0, neg = 0;
   const BIGNUM *tmp;
@@ -186,7 +186,7 @@ int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   }
 
   if (add) {
-    if (!BN_uadd(r, a, b)) {
+    if (!GFp_BN_uadd(r, a, b)) {
       return 0;
     }
 
@@ -197,17 +197,17 @@ int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   /* We are actually doing a - b :-) */
 
   max = (a->top > b->top) ? a->top : b->top;
-  if (bn_wexpand(r, max) == NULL) {
+  if (GFp_bn_wexpand(r, max) == NULL) {
     return 0;
   }
 
-  if (BN_ucmp(a, b) < 0) {
-    if (!BN_usub_unchecked(r, b, a)) {
+  if (GFp_BN_ucmp(a, b) < 0) {
+    if (!GFp_BN_usub_unchecked(r, b, a)) {
       return 0;
     }
     r->neg = 1;
   } else {
-    if (!BN_usub_unchecked(r, a, b)) {
+    if (!GFp_BN_usub_unchecked(r, a, b)) {
       return 0;
     }
     r->neg = 0;
@@ -216,15 +216,15 @@ int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   return 1;
 }
 
-int BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
-  assert(!BN_is_negative(a));
-  assert(!BN_is_negative(b));
-  assert(BN_cmp(a, b) >= 0);
-  return BN_usub_unchecked(r, a, b);
+int GFp_BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
+  assert(!GFp_BN_is_negative(a));
+  assert(!GFp_BN_is_negative(b));
+  assert(GFp_BN_cmp(a, b) >= 0);
+  return GFp_BN_usub_unchecked(r, a, b);
 }
 
 
-int BN_usub_unchecked(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
+int GFp_BN_usub_unchecked(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   int max, min, dif;
   register BN_ULONG t1, t2, *ap, *bp, *rp;
   int i, carry;
@@ -239,7 +239,7 @@ int BN_usub_unchecked(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
     return 0;
   }
 
-  if (bn_wexpand(r, max) == NULL) {
+  if (GFp_bn_wexpand(r, max) == NULL) {
     return 0;
   }
 
@@ -285,7 +285,7 @@ int BN_usub_unchecked(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
 
   r->top = max;
   r->neg = 0;
-  bn_correct_top(r);
+  GFp_bn_correct_top(r);
 
   return 1;
 }

--- a/crypto/bn/asm/armv4-mont.pl
+++ b/crypto/bn/asm/armv4-mont.pl
@@ -101,7 +101,7 @@ $code=<<___;
 #if __ARM_MAX_ARCH__>=7
 .align	5
 .LOPENSSL_armcap:
-.word	OPENSSL_armcap_P-.Lbn_mul_mont
+.word	GFp_armcap_P-.Lbn_mul_mont
 #endif
 
 .global	GFp_bn_mul_mont
@@ -732,8 +732,8 @@ $code.=<<___;
 .asciz	"Montgomery multiplication for ARMv4/NEON, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if __ARM_MAX_ARCH__>=7
-.comm	OPENSSL_armcap_P,4,4
-.hidden	OPENSSL_armcap_P
+.comm	GFp_armcap_P,4,4
+.hidden	GFp_armcap_P
 #endif
 ___
 

--- a/crypto/bn/asm/armv4-mont.pl
+++ b/crypto/bn/asm/armv4-mont.pl
@@ -104,11 +104,11 @@ $code=<<___;
 .word	OPENSSL_armcap_P-.Lbn_mul_mont
 #endif
 
-.global	bn_mul_mont
-.type	bn_mul_mont,%function
+.global	GFp_bn_mul_mont
+.type	GFp_bn_mul_mont,%function
 
 .align	5
-bn_mul_mont:
+GFp_bn_mul_mont:
 .Lbn_mul_mont:
 	ldr	ip,[sp,#4]		@ load num
 	stmdb	sp!,{r0,r2}		@ sp points at argument block
@@ -278,7 +278,7 @@ bn_mul_mont:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	bn_mul_mont,.-bn_mul_mont
+.size	GFp_bn_mul_mont,.-GFp_bn_mul_mont
 ___
 {
 my ($A0,$A1,$A2,$A3)=map("d$_",(0..3));

--- a/crypto/bn/asm/armv8-mont.pl
+++ b/crypto/bn/asm/armv8-mont.pl
@@ -48,7 +48,7 @@ open OUT,"| \"$^X\" $xlate $flavour $output";
  $lo1,$hi1,$nj,$m1,$nlo,$nhi,
  $ovf, $i,$j,$tp,$tj) = map("x$_",6..17,19..24);
 
-# int bn_mul_mont(
+# int GFp_bn_mul_mont(
 $rp="x0";	# BN_ULONG *rp,
 $ap="x1";	# const BN_ULONG *ap,
 $bp="x2";	# const BN_ULONG *bp,
@@ -59,10 +59,10 @@ $num="x5";	# int num);
 $code.=<<___;
 .text
 
-.globl	bn_mul_mont
-.type	bn_mul_mont,%function
+.globl	GFp_bn_mul_mont
+.type	GFp_bn_mul_mont,%function
 .align	5
-bn_mul_mont:
+GFp_bn_mul_mont:
 	tst	$num,#7
 	b.eq	__bn_sqr8x_mont
 	tst	$num,#3
@@ -261,7 +261,7 @@ bn_mul_mont:
 	ldp	x23,x24,[x29,#48]
 	ldr	x29,[sp],#64
 	ret
-.size	bn_mul_mont,.-bn_mul_mont
+.size	GFp_bn_mul_mont,.-GFp_bn_mul_mont
 ___
 {
 ########################################################################

--- a/crypto/bn/asm/rsaz-avx2.pl
+++ b/crypto/bn/asm/rsaz-avx2.pl
@@ -141,10 +141,10 @@ $np="%r13";			# reassigned argument
 $code.=<<___;
 .text
 
-.globl	rsaz_1024_sqr_avx2
-.type	rsaz_1024_sqr_avx2,\@function,5
+.globl	GFp_rsaz_1024_sqr_avx2
+.type	GFp_rsaz_1024_sqr_avx2,\@function,5
 .align	64
-rsaz_1024_sqr_avx2:		# 702 cycles, 14% faster than rsaz_1024_mul_avx2
+GFp_rsaz_1024_sqr_avx2:		# 702 cycles, 14% faster than rsaz_1024_mul_avx2
 	lea	(%rsp), %rax
 	push	%rbx
 	push	%rbp
@@ -825,7 +825,7 @@ $code.=<<___;
 	lea	(%rax),%rsp		# restore %rsp
 .Lsqr_1024_epilogue:
 	ret
-.size	rsaz_1024_sqr_avx2,.-rsaz_1024_sqr_avx2
+.size	GFp_rsaz_1024_sqr_avx2,.-GFp_rsaz_1024_sqr_avx2
 ___
 }
 
@@ -873,10 +873,10 @@ my $tmp="%r15";
 $bp="%r13";	# reassigned argument
 
 $code.=<<___;
-.globl	rsaz_1024_mul_avx2
-.type	rsaz_1024_mul_avx2,\@function,5
+.globl	GFp_rsaz_1024_mul_avx2
+.type	GFp_rsaz_1024_mul_avx2,\@function,5
 .align	64
-rsaz_1024_mul_avx2:
+GFp_rsaz_1024_mul_avx2:
 	lea	(%rsp), %rax
 	push	%rbx
 	push	%rbp
@@ -1458,7 +1458,7 @@ $code.=<<___;
 	lea	(%rax),%rsp		# restore %rsp
 .Lmul_1024_epilogue:
 	ret
-.size	rsaz_1024_mul_avx2,.-rsaz_1024_mul_avx2
+.size	GFp_rsaz_1024_mul_avx2,.-GFp_rsaz_1024_mul_avx2
 ___
 }
 {
@@ -1466,10 +1466,10 @@ my ($out,$inp) = $win64 ? ("%rcx","%rdx") : ("%rdi","%rsi");
 my @T = map("%r$_",(8..11));
 
 $code.=<<___;
-.globl	rsaz_1024_red2norm_avx2
-.type	rsaz_1024_red2norm_avx2,\@abi-omnipotent
+.globl	GFp_rsaz_1024_red2norm_avx2
+.type	GFp_rsaz_1024_red2norm_avx2,\@abi-omnipotent
 .align	32
-rsaz_1024_red2norm_avx2:
+GFp_rsaz_1024_red2norm_avx2:
 	sub	\$-128,$inp	# size optimization
 	xor	%rax,%rax
 ___
@@ -1503,12 +1503,12 @@ ___
 }
 $code.=<<___;
 	ret
-.size	rsaz_1024_red2norm_avx2,.-rsaz_1024_red2norm_avx2
+.size	GFp_rsaz_1024_red2norm_avx2,.-GFp_rsaz_1024_red2norm_avx2
 
-.globl	rsaz_1024_norm2red_avx2
-.type	rsaz_1024_norm2red_avx2,\@abi-omnipotent
+.globl	GFp_rsaz_1024_norm2red_avx2
+.type	GFp_rsaz_1024_norm2red_avx2,\@abi-omnipotent
 .align	32
-rsaz_1024_norm2red_avx2:
+GFp_rsaz_1024_norm2red_avx2:
 	sub	\$-128,$out	# size optimization
 	mov	($inp),@T[0]
 	mov	\$0x1fffffff,%eax
@@ -1540,17 +1540,17 @@ $code.=<<___;
 	mov	@T[0],`8*($j+2)-128`($out)
 	mov	@T[0],`8*($j+3)-128`($out)
 	ret
-.size	rsaz_1024_norm2red_avx2,.-rsaz_1024_norm2red_avx2
+.size	GFp_rsaz_1024_norm2red_avx2,.-GFp_rsaz_1024_norm2red_avx2
 ___
 }
 {
 my ($out,$inp,$power) = $win64 ? ("%rcx","%rdx","%r8d") : ("%rdi","%rsi","%edx");
 
 $code.=<<___;
-.globl	rsaz_1024_scatter5_avx2
-.type	rsaz_1024_scatter5_avx2,\@abi-omnipotent
+.globl	GFp_rsaz_1024_scatter5_avx2
+.type	GFp_rsaz_1024_scatter5_avx2,\@abi-omnipotent
 .align	32
-rsaz_1024_scatter5_avx2:
+GFp_rsaz_1024_scatter5_avx2:
 	vzeroupper
 	vmovdqu	.Lscatter_permd(%rip),%ymm5
 	shl	\$4,$power
@@ -1570,18 +1570,18 @@ rsaz_1024_scatter5_avx2:
 
 	vzeroupper
 	ret
-.size	rsaz_1024_scatter5_avx2,.-rsaz_1024_scatter5_avx2
+.size	GFp_rsaz_1024_scatter5_avx2,.-GFp_rsaz_1024_scatter5_avx2
 
-.globl	rsaz_1024_gather5_avx2
-.type	rsaz_1024_gather5_avx2,\@abi-omnipotent
+.globl	GFp_rsaz_1024_gather5_avx2
+.type	GFp_rsaz_1024_gather5_avx2,\@abi-omnipotent
 .align	32
-rsaz_1024_gather5_avx2:
+GFp_rsaz_1024_gather5_avx2:
 	vzeroupper
 	mov	%rsp,%r11
 ___
 $code.=<<___ if ($win64);
 	lea	-0x88(%rsp),%rax
-.LSEH_begin_rsaz_1024_gather5:
+.LSEH_begin_GFp_rsaz_1024_gather5:
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x48,0x8d,0x60,0xe0		# lea	-0x20(%rax),%rsp
 	.byte	0xc5,0xf8,0x29,0x70,0xe0	# vmovaps %xmm6,-0x20(%rax)
@@ -1715,21 +1715,21 @@ $code.=<<___ if ($win64);
 	movaps	-0x38(%r11),%xmm13
 	movaps	-0x28(%r11),%xmm14
 	movaps	-0x18(%r11),%xmm15
-.LSEH_end_rsaz_1024_gather5:
+.LSEH_end_GFp_rsaz_1024_gather5:
 ___
 $code.=<<___;
 	lea	(%r11),%rsp
 	ret
-.size	rsaz_1024_gather5_avx2,.-rsaz_1024_gather5_avx2
+.size	GFp_rsaz_1024_gather5_avx2,.-GFp_rsaz_1024_gather5_avx2
 ___
 }
 
 $code.=<<___;
 .extern	GFp_ia32cap_P
-.globl	rsaz_avx2_eligible
-.type	rsaz_avx2_eligible,\@abi-omnipotent
+.globl	GFp_rsaz_avx2_eligible
+.type	GFp_rsaz_avx2_eligible,\@abi-omnipotent
 .align	32
-rsaz_avx2_eligible:
+GFp_rsaz_avx2_eligible:
 	mov	GFp_ia32cap_P+8(%rip),%eax
 ___
 $code.=<<___	if ($addx);
@@ -1743,7 +1743,7 @@ $code.=<<___;
 	and	\$`1<<5`,%eax
 	shr	\$5,%eax
 	ret
-.size	rsaz_avx2_eligible,.-rsaz_avx2_eligible
+.size	GFp_rsaz_avx2_eligible,.-GFp_rsaz_avx2_eligible
 
 .align	64
 .Land_mask:
@@ -1861,28 +1861,28 @@ rsaz_se_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_rsaz_1024_sqr_avx2
-	.rva	.LSEH_end_rsaz_1024_sqr_avx2
-	.rva	.LSEH_info_rsaz_1024_sqr_avx2
+	.rva	.LSEH_begin_GFp_rsaz_1024_sqr_avx2
+	.rva	.LSEH_end_GFp_rsaz_1024_sqr_avx2
+	.rva	.LSEH_info_GFp_rsaz_1024_sqr_avx2
 
-	.rva	.LSEH_begin_rsaz_1024_mul_avx2
-	.rva	.LSEH_end_rsaz_1024_mul_avx2
-	.rva	.LSEH_info_rsaz_1024_mul_avx2
+	.rva	.LSEH_begin_GFp_rsaz_1024_mul_avx2
+	.rva	.LSEH_end_GFp_rsaz_1024_mul_avx2
+	.rva	.LSEH_info_GFp_rsaz_1024_mul_avx2
 
-	.rva	.LSEH_begin_rsaz_1024_gather5
-	.rva	.LSEH_end_rsaz_1024_gather5
-	.rva	.LSEH_info_rsaz_1024_gather5
+	.rva	.LSEH_begin_GFp_rsaz_1024_gather5
+	.rva	.LSEH_end_GFp_rsaz_1024_gather5
+	.rva	.LSEH_info_GFp_rsaz_1024_gather5
 .section	.xdata
 .align	8
-.LSEH_info_rsaz_1024_sqr_avx2:
+.LSEH_info_GFp_rsaz_1024_sqr_avx2:
 	.byte	9,0,0,0
 	.rva	rsaz_se_handler
 	.rva	.Lsqr_1024_body,.Lsqr_1024_epilogue
-.LSEH_info_rsaz_1024_mul_avx2:
+.LSEH_info_GFp_rsaz_1024_mul_avx2:
 	.byte	9,0,0,0
 	.rva	rsaz_se_handler
 	.rva	.Lmul_1024_body,.Lmul_1024_epilogue
-.LSEH_info_rsaz_1024_gather5:
+.LSEH_info_GFp_rsaz_1024_gather5:
 	.byte	0x01,0x36,0x17,0x0b
 	.byte	0x36,0xf8,0x09,0x00	# vmovaps 0x90(rsp),xmm15
 	.byte	0x31,0xe8,0x08,0x00	# vmovaps 0x80(rsp),xmm14
@@ -1916,29 +1916,29 @@ foreach (split("\n",$code)) {
 print <<___;	# assembler is too old
 .text
 
-.globl	rsaz_avx2_eligible
-.type	rsaz_avx2_eligible,\@abi-omnipotent
-rsaz_avx2_eligible:
+.globl	GFp_rsaz_avx2_eligible
+.type	GFp_rsaz_avx2_eligible,\@abi-omnipotent
+GFp_rsaz_avx2_eligible:
 	xor	%eax,%eax
 	ret
-.size	rsaz_avx2_eligible,.-rsaz_avx2_eligible
+.size	GFp_rsaz_avx2_eligible,.-GFp_rsaz_avx2_eligible
 
-.globl	rsaz_1024_sqr_avx2
-.globl	rsaz_1024_mul_avx2
-.globl	rsaz_1024_norm2red_avx2
-.globl	rsaz_1024_red2norm_avx2
-.globl	rsaz_1024_scatter5_avx2
-.globl	rsaz_1024_gather5_avx2
-.type	rsaz_1024_sqr_avx2,\@abi-omnipotent
-rsaz_1024_sqr_avx2:
-rsaz_1024_mul_avx2:
-rsaz_1024_norm2red_avx2:
-rsaz_1024_red2norm_avx2:
-rsaz_1024_scatter5_avx2:
-rsaz_1024_gather5_avx2:
+.globl	GFp_rsaz_1024_sqr_avx2
+.globl	GFp_rsaz_1024_mul_avx2
+.globl	GFp_rsaz_1024_norm2red_avx2
+.globl	GFp_rsaz_1024_red2norm_avx2
+.globl	GFp_rsaz_1024_scatter5_avx2
+.globl	GFp_rsaz_1024_gather5_avx2
+.type	GFp_rsaz_1024_sqr_avx2,\@abi-omnipotent
+GFp_rsaz_1024_sqr_avx2:
+GFp_rsaz_1024_mul_avx2:
+GFp_rsaz_1024_norm2red_avx2:
+GFp_rsaz_1024_red2norm_avx2:
+GFp_rsaz_1024_scatter5_avx2:
+GFp_rsaz_1024_gather5_avx2:
 	.byte	0x0f,0x0b	# ud2
 	ret
-.size	rsaz_1024_sqr_avx2,.-rsaz_1024_sqr_avx2
+.size	GFp_rsaz_1024_sqr_avx2,.-GFp_rsaz_1024_sqr_avx2
 ___
 }}}
 

--- a/crypto/bn/asm/rsaz-avx2.pl
+++ b/crypto/bn/asm/rsaz-avx2.pl
@@ -1725,12 +1725,12 @@ ___
 }
 
 $code.=<<___;
-.extern	OPENSSL_ia32cap_P
+.extern	GFp_ia32cap_P
 .globl	rsaz_avx2_eligible
 .type	rsaz_avx2_eligible,\@abi-omnipotent
 .align	32
 rsaz_avx2_eligible:
-	mov	OPENSSL_ia32cap_P+8(%rip),%eax
+	mov	GFp_ia32cap_P+8(%rip),%eax
 ___
 $code.=<<___	if ($addx);
 	mov	\$`1<<8|1<<19`,%ecx

--- a/crypto/bn/asm/x86-mont.pl
+++ b/crypto/bn/asm/x86-mont.pl
@@ -40,7 +40,7 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 
 &external_label("OPENSSL_ia32cap_P") if ($sse2);
 
-&function_begin("bn_mul_mont");
+&function_begin("GFp_bn_mul_mont");
 
 $i="edx";
 $j="ecx";
@@ -575,7 +575,7 @@ $sbit=$num;
 
 	&mov	("esp",$_sp);		# pull saved stack pointer
 	&mov	("eax",1);
-&function_end("bn_mul_mont");
+&function_end("GFp_bn_mul_mont");
 
 &asciz("Montgomery Multiplication for x86, CRYPTOGAMS by <appro\@openssl.org>");
 

--- a/crypto/bn/asm/x86-mont.pl
+++ b/crypto/bn/asm/x86-mont.pl
@@ -38,7 +38,7 @@ open STDOUT,">$output";
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 
-&external_label("OPENSSL_ia32cap_P") if ($sse2);
+&external_label("GFp_ia32cap_P") if ($sse2);
 
 &function_begin("GFp_bn_mul_mont");
 
@@ -114,7 +114,7 @@ $mul1="mm5";
 $temp="mm6";
 $mask="mm7";
 
-	&picmeup("eax","OPENSSL_ia32cap_P");
+	&picmeup("eax","GFp_ia32cap_P");
 	&bt	(&DWP(0,"eax"),26);
 	&jnc	(&label("non_sse2"));
 

--- a/crypto/bn/asm/x86_64-mont.pl
+++ b/crypto/bn/asm/x86_64-mont.pl
@@ -60,7 +60,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 # TODO(davidben): Enable this option after testing. $addx goes up to 1.
 $addx = 0;
 
-# void bn_mul_mont(
+# void GFp_bn_mul_mont(
 $rp="%rdi";	# BN_ULONG *rp,
 $ap="%rsi";	# const BN_ULONG *ap,
 $bp="%rdx";	# const BN_ULONG *bp,
@@ -80,10 +80,10 @@ $code=<<___;
 
 .extern	OPENSSL_ia32cap_P
 
-.globl	bn_mul_mont
-.type	bn_mul_mont,\@function,6
+.globl	GFp_bn_mul_mont
+.type	GFp_bn_mul_mont,\@function,6
 .align	16
-bn_mul_mont:
+GFp_bn_mul_mont:
 	test	\$3,${num}d
 	jnz	.Lmul_enter
 	cmp	\$8,${num}d
@@ -295,7 +295,7 @@ $code.=<<___;
 	lea	48(%rsi),%rsp
 .Lmul_epilogue:
 	ret
-.size	bn_mul_mont,.-bn_mul_mont
+.size	GFp_bn_mul_mont,.-GFp_bn_mul_mont
 ___
 {{{
 my @A=("%r10","%r11");
@@ -734,10 +734,10 @@ my @A1=("%r12","%r13");
 my ($a0,$a1,$ai)=("%r14","%r15","%rbx");
 
 $code.=<<___	if ($addx);
-.extern	bn_sqrx8x_internal		# see x86_64-mont5 module
+.extern	GFp_bn_sqrx8x_internal		# see x86_64-mont5 module
 ___
 $code.=<<___;
-.extern	bn_sqr8x_internal		# see x86_64-mont5 module
+.extern	GFp_bn_sqr8x_internal		# see x86_64-mont5 module
 
 .type	bn_sqr8x_mont,\@function,6
 .align	32
@@ -799,7 +799,7 @@ $code.=<<___ if ($addx);
 	cmp	\$0x80100,%eax
 	jne	.Lsqr8x_nox
 
-	call	bn_sqrx8x_internal	# see x86_64-mont5 module
+	call	GFp_bn_sqrx8x_internal	# see x86_64-mont5 module
 					# %rax	top-most carry
 					# %rbp	nptr
 					# %rcx	-8*num
@@ -815,7 +815,7 @@ $code.=<<___ if ($addx);
 .Lsqr8x_nox:
 ___
 $code.=<<___;
-	call	bn_sqr8x_internal	# see x86_64-mont5 module
+	call	GFp_bn_sqr8x_internal	# see x86_64-mont5 module
 					# %rax	top-most carry
 					# %rbp	nptr
 					# %r8	-8*num
@@ -1385,9 +1385,9 @@ sqr_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_bn_mul_mont
-	.rva	.LSEH_end_bn_mul_mont
-	.rva	.LSEH_info_bn_mul_mont
+	.rva	.LSEH_begin_GFp_bn_mul_mont
+	.rva	.LSEH_end_GFp_bn_mul_mont
+	.rva	.LSEH_info_GFp_bn_mul_mont
 
 	.rva	.LSEH_begin_bn_mul4x_mont
 	.rva	.LSEH_end_bn_mul4x_mont
@@ -1405,7 +1405,7 @@ ___
 $code.=<<___;
 .section	.xdata
 .align	8
-.LSEH_info_bn_mul_mont:
+.LSEH_info_GFp_bn_mul_mont:
 	.byte	9,0,0,0
 	.rva	mul_handler
 	.rva	.Lmul_body,.Lmul_epilogue	# HandlerData[]

--- a/crypto/bn/asm/x86_64-mont.pl
+++ b/crypto/bn/asm/x86_64-mont.pl
@@ -78,7 +78,7 @@ $m1="%rbp";
 $code=<<___;
 .text
 
-.extern	OPENSSL_ia32cap_P
+.extern	GFp_ia32cap_P
 
 .globl	GFp_bn_mul_mont
 .type	GFp_bn_mul_mont,\@function,6
@@ -90,7 +90,7 @@ GFp_bn_mul_mont:
 	jb	.Lmul_enter
 ___
 $code.=<<___ if ($addx);
-	mov	OPENSSL_ia32cap_P+8(%rip),%r11d
+	mov	GFp_ia32cap_P+8(%rip),%r11d
 ___
 $code.=<<___;
 	cmp	$ap,$bp
@@ -794,7 +794,7 @@ bn_sqr8x_mont:
 	movq	%r10, %xmm3		# -$num
 ___
 $code.=<<___ if ($addx);
-	mov	OPENSSL_ia32cap_P+8(%rip),%eax
+	mov	GFp_ia32cap_P+8(%rip),%eax
 	and	\$0x80100,%eax
 	cmp	\$0x80100,%eax
 	jne	.Lsqr8x_nox

--- a/crypto/bn/asm/x86_64-mont5.pl
+++ b/crypto/bn/asm/x86_64-mont5.pl
@@ -45,7 +45,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 # TODO(davidben): Enable this after testing. $addx goes up to 1.
 $addx = 0;
 
-# int bn_mul_mont_gather5(
+# int GFp_bn_mul_mont_gather5(
 $rp="%rdi";	# BN_ULONG *rp,
 $ap="%rsi";	# const BN_ULONG *ap,
 $bp="%rdx";	# const BN_ULONG *bp,
@@ -69,10 +69,10 @@ $code=<<___;
 
 .extern	OPENSSL_ia32cap_P
 
-.globl	bn_mul_mont_gather5
-.type	bn_mul_mont_gather5,\@function,6
+.globl	GFp_bn_mul_mont_gather5
+.type	GFp_bn_mul_mont_gather5,\@function,6
 .align	64
-bn_mul_mont_gather5:
+GFp_bn_mul_mont_gather5:
 	test	\$7,${num}d
 	jnz	.Lmul_enter
 ___
@@ -396,7 +396,7 @@ $code.=<<___;
 	lea	(%rsi),%rsp
 .Lmul_epilogue:
 	ret
-.size	bn_mul_mont_gather5,.-bn_mul_mont_gather5
+.size	GFp_bn_mul_mont_gather5,.-GFp_bn_mul_mont_gather5
 ___
 {{{
 my @A=("%r10","%r11");
@@ -432,7 +432,7 @@ $code.=<<___;
 	# modulo 4096, which covers ret[num], am[num] and n[num]
 	# (see bn_exp.c). This is done to allow memory disambiguation
 	# logic do its magic. [Extra [num] is allocated in order
-	# to align with bn_power5's frame, which is cleansed after
+	# to align with GFp_bn_power5's frame, which is cleansed after
 	# completing exponentiation. Extra 256 bytes is for power mask
 	# calculated from 7th argument, the index.]
 	#
@@ -978,7 +978,7 @@ ___
 }}}
 {{{
 ######################################################################
-# void bn_power5(
+# void GFp_bn_power5(
 my $rptr="%rdi";	# BN_ULONG *rptr,
 my $aptr="%rsi";	# const BN_ULONG *aptr,
 my $bptr="%rdx";	# const void *table,
@@ -993,10 +993,10 @@ my @A1=("%r12","%r13");
 my ($a0,$a1,$ai)=("%r14","%r15","%rbx");
 
 $code.=<<___;
-.globl	bn_power5
-.type	bn_power5,\@function,6
+.globl	GFp_bn_power5
+.type	GFp_bn_power5,\@function,6
 .align	32
-bn_power5:
+GFp_bn_power5:
 ___
 $code.=<<___ if ($addx);
 	mov	OPENSSL_ia32cap_P+8(%rip),%r11d
@@ -1094,13 +1094,13 @@ $code.=<<___;
 	lea	(%rsi),%rsp
 .Lpower5_epilogue:
 	ret
-.size	bn_power5,.-bn_power5
+.size	GFp_bn_power5,.-GFp_bn_power5
 
-.globl	bn_sqr8x_internal
-.hidden	bn_sqr8x_internal
-.type	bn_sqr8x_internal,\@abi-omnipotent
+.globl	GFp_bn_sqr8x_internal
+.hidden	GFp_bn_sqr8x_internal
+.type	GFp_bn_sqr8x_internal,\@abi-omnipotent
 .align	32
-bn_sqr8x_internal:
+GFp_bn_sqr8x_internal:
 __bn_sqr8x_internal:
 	##############################################################
 	# Squaring part:
@@ -1894,7 +1894,7 @@ __bn_sqr8x_reduction:
 	cmp	%rdx,$tptr		# end of t[]?
 	jb	.L8x_reduction_loop
 	ret
-.size	bn_sqr8x_internal,.-bn_sqr8x_internal
+.size	GFp_bn_sqr8x_internal,.-GFp_bn_sqr8x_internal
 ___
 }
 ##############################################################
@@ -1961,15 +1961,15 @@ ___
 }
 {
 $code.=<<___;
-.globl	bn_from_montgomery
-.type	bn_from_montgomery,\@abi-omnipotent
+.globl	GFp_bn_from_montgomery
+.type	GFp_bn_from_montgomery,\@abi-omnipotent
 .align	32
-bn_from_montgomery:
+GFp_bn_from_montgomery:
 	testl	\$7,`($win64?"48(%rsp)":"%r9d")`
 	jz	bn_from_mont8x
 	xor	%eax,%eax
 	ret
-.size	bn_from_montgomery,.-bn_from_montgomery
+.size	GFp_bn_from_montgomery,.-GFp_bn_from_montgomery
 
 .type	bn_from_mont8x,\@function,6
 .align	32
@@ -1992,7 +1992,7 @@ bn_from_mont8x:
 	# Ensure that stack frame doesn't alias with $rptr+3*$num
 	# modulo 4096, which covers ret[num], am[num] and n[num]
 	# (see bn_exp.c). The stack is allocated to aligned with
-	# bn_power5's frame, and as bn_from_montgomery happens to be
+	# GFp_bn_power5's frame, and as GFp_bn_from_montgomery happens to be
 	# last operation, we use the opportunity to cleanse it.
 	#
 	lea	-320(%rsp,$num,2),%r11
@@ -2137,7 +2137,7 @@ bn_mulx4x_mont_gather5:
 	# modulo 4096, which covers ret[num], am[num] and n[num]
 	# (see bn_exp.c). This is done to allow memory disambiguation
 	# logic do its magic. [Extra [num] is allocated in order
-	# to align with bn_power5's frame, which is cleansed after
+	# to align with GFp_bn_power5's frame, which is cleansed after
 	# completing exponentiation. Extra 256 bytes is for power mask
 	# calculated from 7th argument, the index.]
 	#
@@ -2547,7 +2547,7 @@ $code.=<<___;
 ___
 }{
 ######################################################################
-# void bn_power5(
+# void GFp_bn_power5(
 my $rptr="%rdi";	# BN_ULONG *rptr,
 my $aptr="%rsi";	# const BN_ULONG *aptr,
 my $bptr="%rdx";	# const void *table,
@@ -2661,11 +2661,10 @@ bn_powerx5:
 	ret
 .size	bn_powerx5,.-bn_powerx5
 
-.globl	bn_sqrx8x_internal
-.hidden	bn_sqrx8x_internal
-.type	bn_sqrx8x_internal,\@abi-omnipotent
+.hidden	GFp_bn_sqrx8x_internal
+.type	GFp_bn_sqrx8x_internal,\@abi-omnipotent
 .align	32
-bn_sqrx8x_internal:
+GFp_bn_sqrx8x_internal:
 __bn_sqrx8x_internal:
 	##################################################################
 	# Squaring part:
@@ -3292,7 +3291,7 @@ __bn_sqrx8x_reduction:
 	cmp	8+8(%rsp),%r8		# end of t[]?
 	jb	.Lsqrx8x_reduction_loop
 	ret
-.size	bn_sqrx8x_internal,.-bn_sqrx8x_internal
+.size	GFp_bn_sqrx8x_internal,.-GFp_bn_sqrx8x_internal
 ___
 }
 ##############################################################
@@ -3362,10 +3361,10 @@ my $STRIDE=2**5*8;
 my $N=$STRIDE/4;
 
 $code.=<<___;
-.globl	bn_scatter5
-.type	bn_scatter5,\@abi-omnipotent
+.globl	GFp_bn_scatter5
+.type	GFp_bn_scatter5,\@abi-omnipotent
 .align	16
-bn_scatter5:
+GFp_bn_scatter5:
 	cmp	\$0, $num
 	jz	.Lscatter_epilogue
 	lea	($tbl,$idx,8),$tbl
@@ -3378,13 +3377,13 @@ bn_scatter5:
 	jnz	.Lscatter
 .Lscatter_epilogue:
 	ret
-.size	bn_scatter5,.-bn_scatter5
+.size	GFp_bn_scatter5,.-GFp_bn_scatter5
 
-.globl	bn_gather5
-.type	bn_gather5,\@abi-omnipotent
+.globl	GFp_bn_gather5
+.type	GFp_bn_gather5,\@abi-omnipotent
 .align	32
-bn_gather5:
-.LSEH_begin_bn_gather5:			# Win64 thing, but harmless in other cases
+GFp_bn_gather5:
+.LSEH_begin_GFp_bn_gather5:			# Win64 thing, but harmless in other cases
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x4c,0x8d,0x14,0x24			#lea    (%rsp),%r10
 	.byte	0x48,0x81,0xec,0x08,0x01,0x00,0x00	#sub	$0x108,%rsp
@@ -3468,8 +3467,8 @@ $code.=<<___;
 
 	lea	(%r10),%rsp
 	ret
-.LSEH_end_bn_gather5:
-.size	bn_gather5,.-bn_gather5
+.LSEH_end_GFp_bn_gather5:
+.size	GFp_bn_gather5,.-GFp_bn_gather5
 ___
 }
 $code.=<<___;
@@ -3589,17 +3588,17 @@ mul_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_bn_mul_mont_gather5
-	.rva	.LSEH_end_bn_mul_mont_gather5
-	.rva	.LSEH_info_bn_mul_mont_gather5
+	.rva	.LSEH_begin_GFp_bn_mul_mont_gather5
+	.rva	.LSEH_end_GFp_bn_mul_mont_gather5
+	.rva	.LSEH_info_GFp_bn_mul_mont_gather5
 
 	.rva	.LSEH_begin_bn_mul4x_mont_gather5
 	.rva	.LSEH_end_bn_mul4x_mont_gather5
 	.rva	.LSEH_info_bn_mul4x_mont_gather5
 
-	.rva	.LSEH_begin_bn_power5
-	.rva	.LSEH_end_bn_power5
-	.rva	.LSEH_info_bn_power5
+	.rva	.LSEH_begin_GFp_bn_power5
+	.rva	.LSEH_end_GFp_bn_power5
+	.rva	.LSEH_info_GFp_bn_power5
 
 	.rva	.LSEH_begin_bn_from_mont8x
 	.rva	.LSEH_end_bn_from_mont8x
@@ -3615,13 +3614,13 @@ $code.=<<___ if ($addx);
 	.rva	.LSEH_info_bn_powerx5
 ___
 $code.=<<___;
-	.rva	.LSEH_begin_bn_gather5
-	.rva	.LSEH_end_bn_gather5
-	.rva	.LSEH_info_bn_gather5
+	.rva	.LSEH_begin_GFp_bn_gather5
+	.rva	.LSEH_end_GFp_bn_gather5
+	.rva	.LSEH_info_GFp_bn_gather5
 
 .section	.xdata
 .align	8
-.LSEH_info_bn_mul_mont_gather5:
+.LSEH_info_GFp_bn_mul_mont_gather5:
 	.byte	9,0,0,0
 	.rva	mul_handler
 	.rva	.Lmul_body,.Lmul_epilogue		# HandlerData[]
@@ -3631,7 +3630,7 @@ $code.=<<___;
 	.rva	mul_handler
 	.rva	.Lmul4x_body,.Lmul4x_epilogue		# HandlerData[]
 .align	8
-.LSEH_info_bn_power5:
+.LSEH_info_GFp_bn_power5:
 	.byte	9,0,0,0
 	.rva	mul_handler
 	.rva	.Lpower5_body,.Lpower5_epilogue		# HandlerData[]
@@ -3648,14 +3647,14 @@ $code.=<<___ if ($addx);
 	.rva	mul_handler
 	.rva	.Lmulx4x_body,.Lmulx4x_epilogue		# HandlerData[]
 .align	8
-.LSEH_info_bn_powerx5:
+.LSEH_info_GFp_bn_powerx5:
 	.byte	9,0,0,0
 	.rva	mul_handler
 	.rva	.Lpowerx5_body,.Lpowerx5_epilogue	# HandlerData[]
 ___
 $code.=<<___;
 .align	8
-.LSEH_info_bn_gather5:
+.LSEH_info_GFp_bn_gather5:
 	.byte	0x01,0x0b,0x03,0x0a
 	.byte	0x0b,0x01,0x21,0x00	# sub	rsp,0x108
 	.byte	0x04,0xa3,0x00,0x00	# lea	r10,(rsp)

--- a/crypto/bn/asm/x86_64-mont5.pl
+++ b/crypto/bn/asm/x86_64-mont5.pl
@@ -67,7 +67,7 @@ $m1="%rbp";
 $code=<<___;
 .text
 
-.extern	OPENSSL_ia32cap_P
+.extern	GFp_ia32cap_P
 
 .globl	GFp_bn_mul_mont_gather5
 .type	GFp_bn_mul_mont_gather5,\@function,6
@@ -77,7 +77,7 @@ GFp_bn_mul_mont_gather5:
 	jnz	.Lmul_enter
 ___
 $code.=<<___ if ($addx);
-	mov	OPENSSL_ia32cap_P+8(%rip),%r11d
+	mov	GFp_ia32cap_P+8(%rip),%r11d
 ___
 $code.=<<___;
 	jmp	.Lmul4x_enter
@@ -999,7 +999,7 @@ $code.=<<___;
 GFp_bn_power5:
 ___
 $code.=<<___ if ($addx);
-	mov	OPENSSL_ia32cap_P+8(%rip),%r11d
+	mov	GFp_ia32cap_P+8(%rip),%r11d
 	and	\$0x80108,%r11d
 	cmp	\$0x80108,%r11d		# check for AD*X+BMI2+BMI1
 	je	.Lpowerx5_enter
@@ -2060,7 +2060,7 @@ bn_from_mont8x:
 	movq	%r10, %xmm3		# -num
 ___
 $code.=<<___ if ($addx);
-	mov	OPENSSL_ia32cap_P+8(%rip),%r11d
+	mov	GFp_ia32cap_P+8(%rip),%r11d
 	and	\$0x80108,%r11d
 	cmp	\$0x80108,%r11d		# check for AD*X+BMI2+BMI1
 	jne	.Lfrom_mont_nox

--- a/crypto/bn/bn.c
+++ b/crypto/bn/bn.c
@@ -65,7 +65,7 @@
 #include "internal.h"
 
 
-BIGNUM *BN_new(void) {
+BIGNUM *GFp_BN_new(void) {
   BIGNUM *bn = OPENSSL_malloc(sizeof(BIGNUM));
 
   if (bn == NULL) {
@@ -79,11 +79,11 @@ BIGNUM *BN_new(void) {
   return bn;
 }
 
-void BN_init(BIGNUM *bn) {
+void GFp_BN_init(BIGNUM *bn) {
   memset(bn, 0, sizeof(BIGNUM));
 }
 
-void BN_free(BIGNUM *bn) {
+void GFp_BN_free(BIGNUM *bn) {
   if (bn == NULL) {
     return;
   }
@@ -99,12 +99,12 @@ void BN_free(BIGNUM *bn) {
   }
 }
 
-BIGNUM *BN_copy(BIGNUM *dest, const BIGNUM *src) {
+BIGNUM *GFp_BN_copy(BIGNUM *dest, const BIGNUM *src) {
   if (src == dest) {
     return dest;
   }
 
-  if (bn_wexpand(dest, src->top) == NULL) {
+  if (GFp_bn_wexpand(dest, src->top) == NULL) {
     return NULL;
   }
 
@@ -115,7 +115,7 @@ BIGNUM *BN_copy(BIGNUM *dest, const BIGNUM *src) {
   return dest;
 }
 
-const BIGNUM *BN_value_one(void) {
+const BIGNUM *GFp_BN_value_one(void) {
   static const BN_ULONG kOneLimbs[1] = { 1 };
   STATIC_BIGNUM_DIAGNOSTIC_PUSH
   static const BIGNUM kOne = STATIC_BIGNUM(kOneLimbs);
@@ -124,9 +124,9 @@ const BIGNUM *BN_value_one(void) {
   return &kOne;
 }
 
-/* BN_num_bits_word returns the minimum number of bits needed to represent the
- * value in |l|. */
-unsigned BN_num_bits_word(BN_ULONG l) {
+/* GFp_BN_num_bits_word returns the minimum number of bits needed to represent
+ * the value in |l|. */
+unsigned GFp_BN_num_bits_word(BN_ULONG l) {
   static const unsigned char bits[256] = {
       0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5,
       5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
@@ -174,35 +174,35 @@ unsigned BN_num_bits_word(BN_ULONG l) {
   }
 }
 
-unsigned BN_num_bits(const BIGNUM *bn) {
+unsigned GFp_BN_num_bits(const BIGNUM *bn) {
   const int max = bn->top - 1;
 
-  if (BN_is_zero(bn)) {
+  if (GFp_BN_is_zero(bn)) {
     return 0;
   }
 
-  return max*BN_BITS2 + BN_num_bits_word(bn->d[max]);
+  return max*BN_BITS2 + GFp_BN_num_bits_word(bn->d[max]);
 }
 
-unsigned BN_num_bytes(const BIGNUM *bn) {
-  return (BN_num_bits(bn) + 7) / 8;
+unsigned GFp_BN_num_bytes(const BIGNUM *bn) {
+  return (GFp_BN_num_bits(bn) + 7) / 8;
 }
 
-void BN_zero(BIGNUM *bn) {
+void GFp_BN_zero(BIGNUM *bn) {
   bn->top = bn->neg = 0;
 }
 
-int BN_one(BIGNUM *bn) {
-  return BN_set_word(bn, 1);
+int GFp_BN_one(BIGNUM *bn) {
+  return GFp_BN_set_word(bn, 1);
 }
 
-int BN_set_word(BIGNUM *bn, BN_ULONG value) {
+int GFp_BN_set_word(BIGNUM *bn, BN_ULONG value) {
   if (value == 0) {
-    BN_zero(bn);
+    GFp_BN_zero(bn);
     return 1;
   }
 
-  if (bn_wexpand(bn, 1) == NULL) {
+  if (GFp_bn_wexpand(bn, 1) == NULL) {
     return 0;
   }
 
@@ -212,11 +212,11 @@ int BN_set_word(BIGNUM *bn, BN_ULONG value) {
   return 1;
 }
 
-int BN_is_negative(const BIGNUM *bn) {
+int GFp_BN_is_negative(const BIGNUM *bn) {
   return bn->neg != 0;
 }
 
-BIGNUM *bn_wexpand(BIGNUM *bn, size_t words) {
+BIGNUM *GFp_bn_wexpand(BIGNUM *bn, size_t words) {
   BN_ULONG *a;
 
   if (words <= (size_t)bn->dmax) {
@@ -248,7 +248,7 @@ BIGNUM *bn_wexpand(BIGNUM *bn, size_t words) {
   return bn;
 }
 
-void bn_correct_top(BIGNUM *bn) {
+void GFp_bn_correct_top(BIGNUM *bn) {
   BN_ULONG *ftl;
   int tmp_top = bn->top;
 
@@ -266,10 +266,10 @@ void bn_correct_top(BIGNUM *bn) {
   }
 }
 
-int BN_get_flags(const BIGNUM *bn, int flags) {
+int GFp_BN_get_flags(const BIGNUM *bn, int flags) {
   return bn->flags & flags;
 }
 
-void BN_set_flags(BIGNUM *bn, int flags) {
+void GFp_BN_set_flags(BIGNUM *bn, int flags) {
   bn->flags |= flags;
 }

--- a/crypto/bn/bn_test.cc
+++ b/crypto/bn/bn_test.cc
@@ -145,7 +145,7 @@ static bool GetInt(FileTest *t, int *out, const char *attribute) {
 
 static bool ExpectBIGNUMsEqual(FileTest *t, const char *operation,
                                const BIGNUM *expected, const BIGNUM *actual) {
-  if (BN_cmp(expected, actual) == 0) {
+  if (GFp_BN_cmp(expected, actual) == 0) {
     return true;
   }
   t->PrintLine("Got wrong value for %s", operation);
@@ -160,13 +160,13 @@ static bool TestSum(FileTest *t) {
     return false;
   }
 
-  ScopedBIGNUM ret(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new());
   if (!ret ||
-      !BN_add(ret.get(), a.get(), b.get()) ||
+      !GFp_BN_add(ret.get(), a.get(), b.get()) ||
       !ExpectBIGNUMsEqual(t, "A + B", sum.get(), ret.get()) ||
-      !BN_sub(ret.get(), sum.get(), a.get()) ||
+      !GFp_BN_sub(ret.get(), sum.get(), a.get()) ||
       !ExpectBIGNUMsEqual(t, "Sum - A", b.get(), ret.get()) ||
-      !BN_sub(ret.get(), sum.get(), b.get()) ||
+      !GFp_BN_sub(ret.get(), sum.get(), b.get()) ||
       !ExpectBIGNUMsEqual(t, "Sum - B", a.get(), ret.get())) {
     return false;
   }
@@ -174,38 +174,38 @@ static bool TestSum(FileTest *t) {
   // Test that the functions work when |r| and |a| point to the same |BIGNUM|,
   // or when |r| and |b| point to the same |BIGNUM|. TODO: Test the case where
   // all of |r|, |a|, and |b| point to the same |BIGNUM|.
-  if (!BN_copy(ret.get(), a.get()) ||
-      !BN_add(ret.get(), ret.get(), b.get()) ||
+  if (!GFp_BN_copy(ret.get(), a.get()) ||
+      !GFp_BN_add(ret.get(), ret.get(), b.get()) ||
       !ExpectBIGNUMsEqual(t, "A + B (r is a)", sum.get(), ret.get()) ||
-      !BN_copy(ret.get(), b.get()) ||
-      !BN_add(ret.get(), a.get(), ret.get()) ||
+      !GFp_BN_copy(ret.get(), b.get()) ||
+      !GFp_BN_add(ret.get(), a.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "A + B (r is b)", sum.get(), ret.get()) ||
-      !BN_copy(ret.get(), sum.get()) ||
-      !BN_sub(ret.get(), ret.get(), a.get()) ||
+      !GFp_BN_copy(ret.get(), sum.get()) ||
+      !GFp_BN_sub(ret.get(), ret.get(), a.get()) ||
       !ExpectBIGNUMsEqual(t, "Sum - A (r is a)", b.get(), ret.get()) ||
-      !BN_copy(ret.get(), a.get()) ||
-      !BN_sub(ret.get(), sum.get(), ret.get()) ||
+      !GFp_BN_copy(ret.get(), a.get()) ||
+      !GFp_BN_sub(ret.get(), sum.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "Sum - A (r is b)", b.get(), ret.get()) ||
-      !BN_copy(ret.get(), sum.get()) ||
-      !BN_sub(ret.get(), ret.get(), b.get()) ||
+      !GFp_BN_copy(ret.get(), sum.get()) ||
+      !GFp_BN_sub(ret.get(), ret.get(), b.get()) ||
       !ExpectBIGNUMsEqual(t, "Sum - B (r is a)", a.get(), ret.get()) ||
-      !BN_copy(ret.get(), b.get()) ||
-      !BN_sub(ret.get(), sum.get(), ret.get()) ||
+      !GFp_BN_copy(ret.get(), b.get()) ||
+      !GFp_BN_sub(ret.get(), sum.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "Sum - B (r is b)", a.get(), ret.get())) {
     return false;
   }
 
-  // Test |BN_uadd| and |BN_usub| with the prerequisites they are documented as
-  // having. Note that these functions are frequently used when the
-  // prerequisites don't hold. In those cases, they are supposed to work as if
-  // the prerequisite hold, but we don't test that yet. TODO: test that.
-  if (!BN_is_negative(a.get()) &&
-      !BN_is_negative(b.get()) && BN_cmp(a.get(), b.get()) >= 0) {
-    if (!BN_uadd(ret.get(), a.get(), b.get()) ||
+  // Test |GFp_BN_uadd| and |GFp_BN_usub| with the prerequisites they are
+  // documented as having. Note that these functions are frequently used when
+  // the prerequisites don't hold. In those cases, they are supposed to work as
+  // if the prerequisite hold, but we don't test that yet. TODO: test that.
+  if (!GFp_BN_is_negative(a.get()) &&
+      !GFp_BN_is_negative(b.get()) && GFp_BN_cmp(a.get(), b.get()) >= 0) {
+    if (!GFp_BN_uadd(ret.get(), a.get(), b.get()) ||
         !ExpectBIGNUMsEqual(t, "A +u B", sum.get(), ret.get()) ||
-        !BN_usub(ret.get(), sum.get(), a.get()) ||
+        !GFp_BN_usub(ret.get(), sum.get(), a.get()) ||
         !ExpectBIGNUMsEqual(t, "Sum -u A", b.get(), ret.get()) ||
-        !BN_usub(ret.get(), sum.get(), b.get()) ||
+        !GFp_BN_usub(ret.get(), sum.get(), b.get()) ||
         !ExpectBIGNUMsEqual(t, "Sum -u B", a.get(), ret.get())) {
       return false;
     }
@@ -213,23 +213,23 @@ static bool TestSum(FileTest *t) {
     // Test that the functions work when |r| and |a| point to the same |BIGNUM|,
     // or when |r| and |b| point to the same |BIGNUM|. TODO: Test the case where
     // all of |r|, |a|, and |b| point to the same |BIGNUM|.
-    if (!BN_copy(ret.get(), a.get()) ||
-        !BN_uadd(ret.get(), ret.get(), b.get()) ||
+    if (!GFp_BN_copy(ret.get(), a.get()) ||
+        !GFp_BN_uadd(ret.get(), ret.get(), b.get()) ||
         !ExpectBIGNUMsEqual(t, "A +u B (r is a)", sum.get(), ret.get()) ||
-        !BN_copy(ret.get(), b.get()) ||
-        !BN_uadd(ret.get(), a.get(), ret.get()) ||
+        !GFp_BN_copy(ret.get(), b.get()) ||
+        !GFp_BN_uadd(ret.get(), a.get(), ret.get()) ||
         !ExpectBIGNUMsEqual(t, "A +u B (r is b)", sum.get(), ret.get()) ||
-        !BN_copy(ret.get(), sum.get()) ||
-        !BN_usub(ret.get(), ret.get(), a.get()) ||
+        !GFp_BN_copy(ret.get(), sum.get()) ||
+        !GFp_BN_usub(ret.get(), ret.get(), a.get()) ||
         !ExpectBIGNUMsEqual(t, "Sum -u A (r is a)", b.get(), ret.get()) ||
-        !BN_copy(ret.get(), a.get()) ||
-        !BN_usub(ret.get(), sum.get(), ret.get()) ||
+        !GFp_BN_copy(ret.get(), a.get()) ||
+        !GFp_BN_usub(ret.get(), sum.get(), ret.get()) ||
         !ExpectBIGNUMsEqual(t, "Sum -u A (r is b)", b.get(), ret.get()) ||
-        !BN_copy(ret.get(), sum.get()) ||
-        !BN_usub(ret.get(), ret.get(), b.get()) ||
+        !GFp_BN_copy(ret.get(), sum.get()) ||
+        !GFp_BN_usub(ret.get(), ret.get(), b.get()) ||
         !ExpectBIGNUMsEqual(t, "Sum -u B (r is a)", a.get(), ret.get()) ||
-        !BN_copy(ret.get(), b.get()) ||
-        !BN_usub(ret.get(), sum.get(), ret.get()) ||
+        !GFp_BN_copy(ret.get(), b.get()) ||
+        !GFp_BN_usub(ret.get(), sum.get(), ret.get()) ||
         !ExpectBIGNUMsEqual(t, "Sum -u B (r is b)", a.get(), ret.get())) {
       return false;
     }
@@ -241,37 +241,37 @@ static bool TestSum(FileTest *t) {
 static bool TestLShift1(FileTest *t) {
   ScopedBIGNUM a = GetBIGNUM(t, "A");
   ScopedBIGNUM lshift1 = GetBIGNUM(t, "LShift1");
-  ScopedBIGNUM zero(BN_new());
+  ScopedBIGNUM zero(GFp_BN_new());
   if (!a || !lshift1 || !zero) {
     return false;
   }
 
-  BN_zero(zero.get());
+  GFp_BN_zero(zero.get());
 
-  ScopedBIGNUM ret(BN_new()), two(BN_new()), remainder(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new()), two(GFp_BN_new()), remainder(GFp_BN_new());
   if (!ret || !two || !remainder ||
-      !BN_set_word(two.get(), 2) ||
-      !BN_add(ret.get(), a.get(), a.get()) ||
+      !GFp_BN_set_word(two.get(), 2) ||
+      !GFp_BN_add(ret.get(), a.get(), a.get()) ||
       !ExpectBIGNUMsEqual(t, "A + A", lshift1.get(), ret.get()) ||
-      !BN_mul_no_alias(ret.get(), a.get(), two.get()) ||
+      !GFp_BN_mul_no_alias(ret.get(), a.get(), two.get()) ||
       !ExpectBIGNUMsEqual(t, "A * 2", lshift1.get(), ret.get()) ||
-      !BN_div(ret.get(), remainder.get(), lshift1.get(), two.get()) ||
+      !GFp_BN_div(ret.get(), remainder.get(), lshift1.get(), two.get()) ||
       !ExpectBIGNUMsEqual(t, "LShift1 / 2", a.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "LShift1 % 2", zero.get(), remainder.get()) ||
-      !BN_lshift1(ret.get(), a.get()) ||
+      !GFp_BN_lshift1(ret.get(), a.get()) ||
       !ExpectBIGNUMsEqual(t, "A << 1", lshift1.get(), ret.get()) ||
-      !BN_rshift1(ret.get(), lshift1.get()) ||
+      !GFp_BN_rshift1(ret.get(), lshift1.get()) ||
       !ExpectBIGNUMsEqual(t, "LShift >> 1", a.get(), ret.get()) ||
-      !BN_rshift1(ret.get(), lshift1.get()) ||
+      !GFp_BN_rshift1(ret.get(), lshift1.get()) ||
       !ExpectBIGNUMsEqual(t, "LShift >> 1", a.get(), ret.get())) {
     return false;
   }
 
   // Set the LSB to 1 and test rshift1 again.
-  if (!BN_set_bit(lshift1.get(), 0) ||
-      !BN_div(ret.get(), nullptr /* rem */, lshift1.get(), two.get()) ||
+  if (!GFp_BN_set_bit(lshift1.get(), 0) ||
+      !GFp_BN_div(ret.get(), nullptr /* rem */, lshift1.get(), two.get()) ||
       !ExpectBIGNUMsEqual(t, "(LShift1 | 1) / 2", a.get(), ret.get()) ||
-      !BN_rshift1(ret.get(), lshift1.get()) ||
+      !GFp_BN_rshift1(ret.get(), lshift1.get()) ||
       !ExpectBIGNUMsEqual(t, "(LShift | 1) >> 1", a.get(), ret.get())) {
     return false;
   }
@@ -287,11 +287,11 @@ static bool TestLShift(FileTest *t) {
     return false;
   }
 
-  ScopedBIGNUM ret(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new());
   if (!ret ||
-      !BN_lshift(ret.get(), a.get(), n) ||
+      !GFp_BN_lshift(ret.get(), a.get(), n) ||
       !ExpectBIGNUMsEqual(t, "A << N", lshift.get(), ret.get()) ||
-      !BN_rshift(ret.get(), lshift.get(), n) ||
+      !GFp_BN_rshift(ret.get(), lshift.get(), n) ||
       !ExpectBIGNUMsEqual(t, "A >> N", a.get(), ret.get())) {
     return false;
   }
@@ -307,9 +307,9 @@ static bool TestRShift(FileTest *t) {
     return false;
   }
 
-  ScopedBIGNUM ret(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new());
   if (!ret ||
-      !BN_rshift(ret.get(), a.get(), n) ||
+      !GFp_BN_rshift(ret.get(), a.get(), n) ||
       !ExpectBIGNUMsEqual(t, "A >> N", rshift.get(), ret.get())) {
     return false;
   }
@@ -320,18 +320,18 @@ static bool TestRShift(FileTest *t) {
 static bool TestSquare(FileTest *t) {
   ScopedBIGNUM a = GetBIGNUM(t, "A");
   ScopedBIGNUM square = GetBIGNUM(t, "Square");
-  ScopedBIGNUM zero(BN_new());
+  ScopedBIGNUM zero(GFp_BN_new());
   if (!a || !square || !zero) {
     return false;
   }
 
-  BN_zero(zero.get());
+  GFp_BN_zero(zero.get());
 
-  ScopedBIGNUM ret(BN_new()), remainder(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new()), remainder(GFp_BN_new());
   if (!ret ||
-      !BN_mul_no_alias(ret.get(), a.get(), a.get()) ||
+      !GFp_BN_mul_no_alias(ret.get(), a.get(), a.get()) ||
       !ExpectBIGNUMsEqual(t, "A * A", square.get(), ret.get()) ||
-      !BN_div(ret.get(), remainder.get(), square.get(), a.get()) ||
+      !GFp_BN_div(ret.get(), remainder.get(), square.get(), a.get()) ||
       !ExpectBIGNUMsEqual(t, "Square / A", a.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "Square % A", zero.get(), remainder.get())) {
     return false;
@@ -344,21 +344,21 @@ static bool TestProduct(FileTest *t) {
   ScopedBIGNUM a = GetBIGNUM(t, "A");
   ScopedBIGNUM b = GetBIGNUM(t, "B");
   ScopedBIGNUM product = GetBIGNUM(t, "Product");
-  ScopedBIGNUM zero(BN_new());
+  ScopedBIGNUM zero(GFp_BN_new());
   if (!a || !b || !product || !zero) {
     return false;
   }
 
-  BN_zero(zero.get());
+  GFp_BN_zero(zero.get());
 
-  ScopedBIGNUM ret(BN_new()), remainder(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new()), remainder(GFp_BN_new());
   if (!ret || !remainder ||
-      !BN_mul_no_alias(ret.get(), a.get(), b.get()) ||
+      !GFp_BN_mul_no_alias(ret.get(), a.get(), b.get()) ||
       !ExpectBIGNUMsEqual(t, "A * B", product.get(), ret.get()) ||
-      !BN_div(ret.get(), remainder.get(), product.get(), a.get()) ||
+      !GFp_BN_div(ret.get(), remainder.get(), product.get(), a.get()) ||
       !ExpectBIGNUMsEqual(t, "Product / A", b.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "Product % A", zero.get(), remainder.get()) ||
-      !BN_div(ret.get(), remainder.get(), product.get(), b.get()) ||
+      !GFp_BN_div(ret.get(), remainder.get(), product.get(), b.get()) ||
       !ExpectBIGNUMsEqual(t, "Product / B", a.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "Product % B", zero.get(), remainder.get())) {
     return false;
@@ -376,25 +376,25 @@ static bool TestQuotient(FileTest *t) {
     return false;
   }
 
-  ScopedBIGNUM ret(BN_new()), ret2(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new()), ret2(GFp_BN_new());
   if (!ret || !ret2 ||
-      !BN_div(ret.get(), ret2.get(), a.get(), b.get()) ||
+      !GFp_BN_div(ret.get(), ret2.get(), a.get(), b.get()) ||
       !ExpectBIGNUMsEqual(t, "A / B", quotient.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "A % B", remainder.get(), ret2.get()) ||
-      !BN_mul_no_alias(ret.get(), quotient.get(), b.get()) ||
-      !BN_add(ret.get(), ret.get(), remainder.get()) ||
+      !GFp_BN_mul_no_alias(ret.get(), quotient.get(), b.get()) ||
+      !GFp_BN_add(ret.get(), ret.get(), remainder.get()) ||
       !ExpectBIGNUMsEqual(t, "Quotient * B + Remainder", a.get(), ret.get())) {
     return false;
   }
 
-  // Test BN_nnmod.
-  if (!BN_is_negative(b.get())) {
-    ScopedBIGNUM nnmod(BN_new());
+  // Test GFp_BN_nnmod.
+  if (!GFp_BN_is_negative(b.get())) {
+    ScopedBIGNUM nnmod(GFp_BN_new());
     if (!nnmod ||
-        !BN_copy(nnmod.get(), remainder.get()) ||
-        (BN_is_negative(nnmod.get()) &&
-         !BN_add(nnmod.get(), nnmod.get(), b.get())) ||
-        !BN_nnmod(ret.get(), a.get(), b.get()) ||
+        !GFp_BN_copy(nnmod.get(), remainder.get()) ||
+        (GFp_BN_is_negative(nnmod.get()) &&
+         !GFp_BN_add(nnmod.get(), nnmod.get(), b.get())) ||
+        !GFp_BN_nnmod(ret.get(), a.get(), b.get()) ||
         !ExpectBIGNUMsEqual(t, "A % B (non-negative)", nnmod.get(),
                             ret.get())) {
       return false;
@@ -413,19 +413,19 @@ static bool TestModMul(FileTest *t) {
     return false;
   }
 
-  ScopedBIGNUM ret(BN_new());
-  if (BN_is_odd(m.get())) {
+  ScopedBIGNUM ret(GFp_BN_new());
+  if (GFp_BN_is_odd(m.get())) {
     // Reduce |a| and |b| and test the Montgomery version.
-    ScopedBN_MONT_CTX mont(BN_MONT_CTX_new());
-    ScopedBIGNUM a_tmp(BN_new()), b_tmp(BN_new());
+    ScopedBN_MONT_CTX mont(GFp_BN_MONT_CTX_new());
+    ScopedBIGNUM a_tmp(GFp_BN_new()), b_tmp(GFp_BN_new());
     if (!mont || !a_tmp || !b_tmp ||
-        !BN_MONT_CTX_set(mont.get(), m.get()) ||
-        !BN_nnmod(a_tmp.get(), a.get(), m.get()) ||
-        !BN_nnmod(b_tmp.get(), b.get(), m.get()) ||
-        !BN_to_mont(a_tmp.get(), a_tmp.get(), mont.get()) ||
-        !BN_to_mont(b_tmp.get(), b_tmp.get(), mont.get()) ||
-        !BN_mod_mul_mont(ret.get(), a_tmp.get(), b_tmp.get(), mont.get()) ||
-        !BN_from_mont(ret.get(), ret.get(), mont.get()) ||
+        !GFp_BN_MONT_CTX_set(mont.get(), m.get()) ||
+        !GFp_BN_nnmod(a_tmp.get(), a.get(), m.get()) ||
+        !GFp_BN_nnmod(b_tmp.get(), b.get(), m.get()) ||
+        !GFp_BN_to_mont(a_tmp.get(), a_tmp.get(), mont.get()) ||
+        !GFp_BN_to_mont(b_tmp.get(), b_tmp.get(), mont.get()) ||
+        !GFp_BN_mod_mul_mont(ret.get(), a_tmp.get(), b_tmp.get(), mont.get()) ||
+        !GFp_BN_from_mont(ret.get(), ret.get(), mont.get()) ||
         !ExpectBIGNUMsEqual(t, "A * B (mod M) (Montgomery)",
                             mod_mul.get(), ret.get())) {
       return false;
@@ -444,20 +444,21 @@ static bool TestModExp(FileTest *t) {
     return false;
   }
 
-  ScopedBIGNUM ret(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new());
   if (!ret) {
     return false;
   }
 
-  if (BN_is_odd(m.get())) {
-    // |BN_mod_exp_mont_vartime| requires the input to already be reduced mod
-    // |m| unless |e| is zero (purely due to the ordering of how these special
-    // cases are handled). // |BN_mod_exp_mont_consttime| doesn't have the same
-    // requirement simply because we haven't gotten around to it yet.
-    int expected_ok = BN_cmp(a.get(), m.get()) < 0 || BN_is_zero(e.get());
+  if (GFp_BN_is_odd(m.get())) {
+    // |GFp_BN_mod_exp_mont_vartime| requires the input to already be reduced
+    // mod |m| unless |e| is zero (purely due to the ordering of how these
+    // special cases are handled). |GFp_BN_mod_exp_mont_consttime| doesn't have
+    // the same requirement simply because we haven't gotten around to it yet.
+    int expected_ok =
+        GFp_BN_cmp(a.get(), m.get()) < 0 || GFp_BN_is_zero(e.get());
 
-    int ok = BN_mod_exp_mont_vartime(ret.get(), a.get(), e.get(), m.get(),
-                                     nullptr);
+    int ok = GFp_BN_mod_exp_mont_vartime(ret.get(), a.get(), e.get(), m.get(),
+                                         nullptr);
     if (ok != expected_ok) {
       return false;
     }
@@ -468,14 +469,14 @@ static bool TestModExp(FileTest *t) {
     }
 
     // Test with a non-NULL |BN_MONT_CTX|.
-    ScopedBN_MONT_CTX mont(BN_MONT_CTX_new());
+    ScopedBN_MONT_CTX mont(GFp_BN_MONT_CTX_new());
     if (!mont ||
-        !BN_MONT_CTX_set(mont.get(), m.get())) {
+        !GFp_BN_MONT_CTX_set(mont.get(), m.get())) {
       return false;
     }
 
-    ok = BN_mod_exp_mont_vartime(ret.get(), a.get(), e.get(), m.get(),
-                                 mont.get());
+    ok = GFp_BN_mod_exp_mont_vartime(ret.get(), a.get(), e.get(), m.get(),
+                                     mont.get());
     if (ok != expected_ok) {
       return false;
     }
@@ -485,7 +486,8 @@ static bool TestModExp(FileTest *t) {
       return false;
     }
 
-    if (!BN_mod_exp_mont_consttime(ret.get(), a.get(), e.get(), mont.get()) ||
+    if (!GFp_BN_mod_exp_mont_consttime(ret.get(), a.get(), e.get(),
+                                       mont.get()) ||
         !ExpectBIGNUMsEqual(t, "A ^ E (mod M) (constant-time)", mod_exp.get(),
                             ret.get())) {
       return false;
@@ -503,10 +505,10 @@ static bool TestModInv(FileTest *t) {
     return false;
   }
 
-  ScopedBIGNUM ret(BN_new());
+  ScopedBIGNUM ret(GFp_BN_new());
   int no_inverse;
   if (!ret ||
-      !BN_mod_inverse_odd(ret.get(), &no_inverse, a.get(), m.get()) ||
+      !GFp_BN_mod_inverse_odd(ret.get(), &no_inverse, a.get(), m.get()) ||
       no_inverse ||
       !ExpectBIGNUMsEqual(t, "inv(A) (mod M)", mod_inv.get(), ret.get())) {
     return false;
@@ -550,20 +552,20 @@ static bool TestBN2BinPadded(RAND *rng) {
   memset(zeros, 0, sizeof(zeros));
 
   // Test edge case at 0.
-  ScopedBIGNUM n(BN_new());
-  if (!n || !BN_bn2bin_padded(NULL, 0, n.get())) {
+  ScopedBIGNUM n(GFp_BN_new());
+  if (!n || !GFp_BN_bn2bin_padded(NULL, 0, n.get())) {
     fprintf(stderr,
-            "BN_bn2bin_padded failed to encode 0 in an empty buffer.\n");
+            "GFp_BN_bn2bin_padded failed to encode 0 in an empty buffer.\n");
     return false;
   }
   memset(out, -1, sizeof(out));
-  if (!BN_bn2bin_padded(out, sizeof(out), n.get())) {
+  if (!GFp_BN_bn2bin_padded(out, sizeof(out), n.get())) {
     fprintf(stderr,
-            "BN_bn2bin_padded failed to encode 0 in a non-empty buffer.\n");
+            "GFp_BN_bn2bin_padded failed to encode 0 in a non-empty buffer.\n");
     return false;
   }
   if (memcmp(zeros, out, sizeof(out))) {
-    fprintf(stderr, "BN_bn2bin_padded did not zero buffer.\n");
+    fprintf(stderr, "GFp_BN_bn2bin_padded did not zero buffer.\n");
     return false;
   }
 
@@ -572,39 +574,39 @@ static bool TestBN2BinPadded(RAND *rng) {
     if (!BN_rand(n.get(), bytes * 8, rng)) {
       return false;
     }
-    if (BN_num_bytes(n.get()) != bytes ||
+    if (GFp_BN_num_bytes(n.get()) != bytes ||
         BN_bn2bin(n.get(), reference) != bytes) {
-      fprintf(stderr, "Bad result from BN_rand; bytes.\n");
+      fprintf(stderr, "Bad result from GFp_BN_rand; bytes.\n");
       return false;
     }
     // Empty buffer should fail.
-    if (BN_bn2bin_padded(NULL, 0, n.get())) {
+    if (GFp_BN_bn2bin_padded(NULL, 0, n.get())) {
       fprintf(stderr,
-              "BN_bn2bin_padded incorrectly succeeded on empty buffer.\n");
+              "GFp_BN_bn2bin_padded incorrectly succeeded on empty buffer.\n");
       return false;
     }
     // One byte short should fail.
-    if (BN_bn2bin_padded(out, bytes - 1, n.get())) {
-      fprintf(stderr, "BN_bn2bin_padded incorrectly succeeded on short.\n");
+    if (GFp_BN_bn2bin_padded(out, bytes - 1, n.get())) {
+      fprintf(stderr, "GFp_BN_bn2bin_padded incorrectly succeeded on short.\n");
       return false;
     }
     // Exactly right size should encode.
-    if (!BN_bn2bin_padded(out, bytes, n.get()) ||
+    if (!GFp_BN_bn2bin_padded(out, bytes, n.get()) ||
         memcmp(out, reference, bytes) != 0) {
-      fprintf(stderr, "BN_bn2bin_padded gave a bad result.\n");
+      fprintf(stderr, "GFp_BN_bn2bin_padded gave a bad result.\n");
       return false;
     }
     // Pad up one byte extra.
-    if (!BN_bn2bin_padded(out, bytes + 1, n.get()) ||
+    if (!GFp_BN_bn2bin_padded(out, bytes + 1, n.get()) ||
         memcmp(out + 1, reference, bytes) || memcmp(out, zeros, 1)) {
-      fprintf(stderr, "BN_bn2bin_padded gave a bad result.\n");
+      fprintf(stderr, "GFp_BN_bn2bin_padded gave a bad result.\n");
       return false;
     }
     // Pad up to 256.
-    if (!BN_bn2bin_padded(out, sizeof(out), n.get()) ||
+    if (!GFp_BN_bn2bin_padded(out, sizeof(out), n.get()) ||
         memcmp(out + sizeof(out) - bytes, reference, bytes) ||
         memcmp(out, zeros, sizeof(out) - bytes)) {
-      fprintf(stderr, "BN_bn2bin_padded gave a bad result.\n");
+      fprintf(stderr, "GFp_BN_bn2bin_padded gave a bad result.\n");
       return false;
     }
   }
@@ -613,37 +615,40 @@ static bool TestBN2BinPadded(RAND *rng) {
 }
 
 static int BN_is_word(const BIGNUM *bn, BN_ULONG w) {
-  return BN_abs_is_word(bn, w) && (w == 0 || bn->neg == 0);
+  return GFp_BN_abs_is_word(bn, w) && (w == 0 || bn->neg == 0);
 }
 
 static bool TestHex2BN() {
   ScopedBIGNUM bn;
   int ret = HexToBIGNUM(&bn, "0");
-  if (ret != 1 || !BN_is_zero(bn.get()) || BN_is_negative(bn.get())) {
-    fprintf(stderr, "BN_hex2bn gave a bad result.\n");
+  if (ret != 1 || !GFp_BN_is_zero(bn.get()) || GFp_BN_is_negative(bn.get())) {
+    fprintf(stderr, "GFp_BN_hex2bn gave a bad result.\n");
     return false;
   }
 
   ret = HexToBIGNUM(&bn, "256");
-  if (ret != 3 || !BN_is_word(bn.get(), 0x256) || BN_is_negative(bn.get())) {
+  if (ret != 3 || !BN_is_word(bn.get(), 0x256) ||
+      GFp_BN_is_negative(bn.get())) {
     fprintf(stderr, "BN_hex2bn gave a bad result.\n");
     return false;
   }
 
   ret = HexToBIGNUM(&bn, "-42");
-  if (ret != 3 || !BN_abs_is_word(bn.get(), 0x42) || !BN_is_negative(bn.get())) {
+  if (ret != 3 || !GFp_BN_abs_is_word(bn.get(), 0x42) ||
+      !GFp_BN_is_negative(bn.get())) {
     fprintf(stderr, "BN_hex2bn gave a bad result.\n");
     return false;
   }
 
   ret = HexToBIGNUM(&bn, "-0");
-  if (ret != 2 || !BN_is_zero(bn.get()) || BN_is_negative(bn.get())) {
+  if (ret != 2 || !GFp_BN_is_zero(bn.get()) || GFp_BN_is_negative(bn.get())) {
     fprintf(stderr, "BN_hex2bn gave a bad result.\n");
     return false;
   }
 
   ret = HexToBIGNUM(&bn, "abctrailing garbage is ignored");
-  if (ret != 3 || !BN_is_word(bn.get(), 0xabc) || BN_is_negative(bn.get())) {
+  if (ret != 3 || !BN_is_word(bn.get(), 0xabc) ||
+      GFp_BN_is_negative(bn.get())) {
     fprintf(stderr, "BN_hex2bn gave a bad result.\n");
     return false;
   }
@@ -652,14 +657,14 @@ static bool TestHex2BN() {
 }
 
 static bool TestRand(RAND *rng) {
-  ScopedBIGNUM bn(BN_new());
+  ScopedBIGNUM bn(GFp_BN_new());
   if (!bn) {
     return false;
   }
 
-  // Test BN_rand accounts for degenerate cases
+  // Test GFp_BN_rand accounts for degenerate cases
   if (!BN_rand(bn.get(), 0, rng) ||
-      !BN_is_zero(bn.get())) {
+      !GFp_BN_is_zero(bn.get())) {
     fprintf(stderr, "BN_rand gave a bad result.\n");
     return false;
   }
@@ -674,62 +679,62 @@ static bool TestRand(RAND *rng) {
 }
 
 static bool TestNegativeZero() {
-  ScopedBIGNUM a(BN_new());
-  ScopedBIGNUM b(BN_new());
-  ScopedBIGNUM c(BN_new());
+  ScopedBIGNUM a(GFp_BN_new());
+  ScopedBIGNUM b(GFp_BN_new());
+  ScopedBIGNUM c(GFp_BN_new());
   if (!a || !b || !c) {
     return false;
   }
 
-  // Test that BN_mul_no_alias never gives negative zero.
-  if (!BN_set_word(a.get(), 1)) {
+  // Test that GFp_BN_mul_no_alias never gives negative zero.
+  if (!GFp_BN_set_word(a.get(), 1)) {
     return false;
   }
   BN_set_negative(a.get(), 1);
-  BN_zero(b.get());
-  if (!BN_mul_no_alias(c.get(), a.get(), b.get())) {
+  GFp_BN_zero(b.get());
+  if (!GFp_BN_mul_no_alias(c.get(), a.get(), b.get())) {
     return false;
   }
-  if (!BN_is_zero(c.get()) || BN_is_negative(c.get())) {
+  if (!GFp_BN_is_zero(c.get()) || GFp_BN_is_negative(c.get())) {
     fprintf(stderr, "Multiplication test failed.\n");
     return false;
   }
 
-  ScopedBIGNUM numerator(BN_new()), denominator(BN_new());
+  ScopedBIGNUM numerator(GFp_BN_new()), denominator(GFp_BN_new());
   if (!numerator || !denominator) {
     return false;
   }
 
-  // Test that BN_div never gives negative zero in the quotient.
-  if (!BN_set_word(numerator.get(), 1) ||
-      !BN_set_word(denominator.get(), 2)) {
+  // Test that GFp_BN_div never gives negative zero in the quotient.
+  if (!GFp_BN_set_word(numerator.get(), 1) ||
+      !GFp_BN_set_word(denominator.get(), 2)) {
     return false;
   }
   BN_set_negative(numerator.get(), 1);
-  if (!BN_div(a.get(), b.get(), numerator.get(), denominator.get())) {
+  if (!GFp_BN_div(a.get(), b.get(), numerator.get(), denominator.get())) {
     return false;
   }
-  if (!BN_is_zero(a.get()) || BN_is_negative(a.get())) {
+  if (!GFp_BN_is_zero(a.get()) || GFp_BN_is_negative(a.get())) {
     fprintf(stderr, "Incorrect quotient.\n");
     return false;
   }
 
-  // Test that BN_div never gives negative zero in the remainder.
-  if (!BN_set_word(denominator.get(), 1)) {
+  // Test that GFp_BN_div never gives negative zero in the remainder.
+  if (!GFp_BN_set_word(denominator.get(), 1)) {
     return false;
   }
-  if (!BN_div(a.get(), b.get(), numerator.get(), denominator.get())) {
+  if (!GFp_BN_div(a.get(), b.get(), numerator.get(), denominator.get())) {
     return false;
   }
-  if (!BN_is_zero(b.get()) || BN_is_negative(b.get())) {
+  if (!GFp_BN_is_zero(b.get()) || GFp_BN_is_negative(b.get())) {
     fprintf(stderr, "Incorrect remainder.\n");
     return false;
   }
 
   // Test that BN_set_negative will not produce a negative zero.
-  BN_zero(a.get());
+  GFp_BN_zero(a.get());
   BN_set_negative(a.get(), 1);
-  if (BN_is_negative(a.get())) {
+  if (GFp_BN_is_negative(a.get())) {
     fprintf(stderr, "BN_set_negative produced a negative zero.\n");
     return false;
   }
@@ -738,53 +743,53 @@ static bool TestNegativeZero() {
 }
 
 static bool TestBadModulus() {
-  ScopedBIGNUM a(BN_new());
-  ScopedBIGNUM b(BN_new());
-  ScopedBIGNUM zero(BN_new());
-  ScopedBN_MONT_CTX mont(BN_MONT_CTX_new());
+  ScopedBIGNUM a(GFp_BN_new());
+  ScopedBIGNUM b(GFp_BN_new());
+  ScopedBIGNUM zero(GFp_BN_new());
+  ScopedBN_MONT_CTX mont(GFp_BN_MONT_CTX_new());
   if (!a || !b || !zero || !mont) {
     return false;
   }
 
-  BN_zero(zero.get());
+  GFp_BN_zero(zero.get());
 
-  if (BN_div(a.get(), b.get(), BN_value_one(), zero.get())) {
+  if (GFp_BN_div(a.get(), b.get(), GFp_BN_value_one(), zero.get())) {
     fprintf(stderr, "Division by zero unexpectedly succeeded.\n");
     return false;
   }
   ERR_clear_error();
 
-  if (BN_mod_exp_mont_vartime(a.get(), BN_value_one(), BN_value_one(),
-                              zero.get(), nullptr)) {
-    fprintf(stderr, "BN_mod_exp_mont_vartime with zero modulus unexpectedly "
+  if (GFp_BN_mod_exp_mont_vartime(a.get(), GFp_BN_value_one(),
+                                  GFp_BN_value_one(), zero.get(), nullptr)) {
+    fprintf(stderr, "GFp_BN_mod_exp_mont_vartime with zero modulus unexpectedly "
             "succeeded.\n");
     return 0;
   }
   ERR_clear_error();
 
-  if (BN_MONT_CTX_set(mont.get(), zero.get())) {
+  if (GFp_BN_MONT_CTX_set(mont.get(), zero.get())) {
     fprintf(stderr,
-            "BN_MONT_CTX_set unexpectedly succeeded for zero modulus.\n");
+            "GFp_BN_MONT_CTX_set unexpectedly succeeded for zero modulus.\n");
     return false;
   }
   ERR_clear_error();
 
   // Some operations also may not be used with an even modulus.
 
-  if (!BN_set_word(b.get(), 16)) {
+  if (!GFp_BN_set_word(b.get(), 16)) {
     return false;
   }
 
-  if (BN_MONT_CTX_set(mont.get(), b.get())) {
+  if (GFp_BN_MONT_CTX_set(mont.get(), b.get())) {
     fprintf(stderr,
-            "BN_MONT_CTX_set unexpectedly succeeded for even modulus.\n");
+            "GFp_BN_MONT_CTX_set unexpectedly succeeded for even modulus.\n");
     return false;
   }
   ERR_clear_error();
 
-  if (BN_mod_exp_mont_vartime(a.get(), BN_value_one(), BN_value_one(), b.get(),
-                              nullptr)) {
-    fprintf(stderr, "BN_mod_exp_mont_vartime with even modulus unexpectedly "
+  if (GFp_BN_mod_exp_mont_vartime(a.get(), GFp_BN_value_one(),
+                                  GFp_BN_value_one(), b.get(), nullptr)) {
+    fprintf(stderr, "GFp_BN_mod_exp_mont_vartime with even modulus unexpectedly "
             "succeeded!\n");
     return 0;
   }
@@ -795,21 +800,21 @@ static bool TestBadModulus() {
 
 // TestExpModZero tests that 1**0 mod 1 == 0.
 static bool TestExpModZero(RAND *rng) {
-  ScopedBIGNUM zero(BN_new()), a(BN_new()), r(BN_new());
+  ScopedBIGNUM zero(GFp_BN_new()), a(GFp_BN_new()), r(GFp_BN_new());
   if (!zero || !a || !r || !BN_rand(a.get(), 1024, rng)) {
     return false;
   }
-  BN_zero(zero.get());
+  GFp_BN_zero(zero.get());
 
-  ScopedBN_MONT_CTX one_mont(BN_MONT_CTX_new());
-  if (!BN_mod_exp_mont_vartime(r.get(), a.get(), zero.get(), BN_value_one(),
-                               nullptr) ||
-      !BN_is_zero(r.get()) ||
+  ScopedBN_MONT_CTX one_mont(GFp_BN_MONT_CTX_new());
+  if (!GFp_BN_mod_exp_mont_vartime(r.get(), a.get(), zero.get(),
+                                   GFp_BN_value_one(), nullptr) ||
+      !GFp_BN_is_zero(r.get()) ||
       !one_mont ||
-      !BN_MONT_CTX_set(one_mont.get(), BN_value_one()) ||
-      !BN_mod_exp_mont_consttime(r.get(), a.get(), zero.get(),
-                                 one_mont.get()) ||
-      !BN_is_zero(r.get())) {
+      !GFp_BN_MONT_CTX_set(one_mont.get(), GFp_BN_value_one()) ||
+      !GFp_BN_mod_exp_mont_consttime(r.get(), a.get(), zero.get(),
+                                     one_mont.get()) ||
+      !GFp_BN_is_zero(r.get())) {
     return false;
   }
 
@@ -817,7 +822,7 @@ static bool TestExpModZero(RAND *rng) {
 }
 
 static bool TestExpModRejectUnreduced() {
-  ScopedBIGNUM r(BN_new());
+  ScopedBIGNUM r(GFp_BN_new());
   if (!r) {
     return false;
   }
@@ -827,54 +832,54 @@ static bool TestExpModRejectUnreduced() {
   static const BN_ULONG kModuli[] = { 1, 3 };
 
   for (BN_ULONG mod_value : kModuli) {
-    ScopedBIGNUM mod(BN_new());
-    ScopedBN_MONT_CTX mont(BN_MONT_CTX_new());
+    ScopedBIGNUM mod(GFp_BN_new());
+    ScopedBN_MONT_CTX mont(GFp_BN_MONT_CTX_new());
     if (!mod ||
-        !BN_set_word(mod.get(), mod_value) ||
+        !GFp_BN_set_word(mod.get(), mod_value) ||
         !mont ||
-        !BN_MONT_CTX_set(mont.get(), mod.get())) {
+        !GFp_BN_MONT_CTX_set(mont.get(), mod.get())) {
       return false;
     }
     for (BN_ULONG exp_value : kExponents) {
-      ScopedBIGNUM exp(BN_new());
+      ScopedBIGNUM exp(GFp_BN_new());
       if (!exp ||
-          !BN_set_word(exp.get(), exp_value)) {
+          !GFp_BN_set_word(exp.get(), exp_value)) {
         return false;
       }
       for (BN_ULONG base_value : kBases) {
-        ScopedBIGNUM base(BN_new());
+        ScopedBIGNUM base(GFp_BN_new());
         if (!base ||
-            !BN_set_word(base.get(), base_value)) {
+            !GFp_BN_set_word(base.get(), base_value)) {
           return false;
         }
 
         if (base_value >= mod_value &&
-            BN_mod_exp_mont_vartime(r.get(), base.get(), exp.get(), mod.get(),
-                                    nullptr)) {
-          fprintf(stderr, "BN_mod_exp_mont_vartime(%d, %d, %d) succeeded!\n",
+            GFp_BN_mod_exp_mont_vartime(r.get(), base.get(), exp.get(),
+                                        mod.get(), nullptr)) {
+          fprintf(stderr, "GFp_BN_mod_exp_mont_vartime(%d, %d, %d) succeeded!\n",
                   (int)base_value, (int)exp_value, (int)mod_value);
           return false;
         }
 
         if (base_value >= mod_value &&
-            BN_mod_exp_mont_consttime(r.get(), base.get(), exp.get(),
-                                      mont.get())) {
-          fprintf(stderr, "BN_mod_exp_mont_consttime(%d, %d, %d) succeeded!\n",
+            GFp_BN_mod_exp_mont_consttime(r.get(), base.get(), exp.get(),
+                                          mont.get())) {
+          fprintf(stderr, "GFp_BN_mod_exp_mont_consttime(%d, %d, %d) succeeded!\n",
                   (int)base_value, (int)exp_value, (int)mod_value);
           return false;
         }
 
         BN_set_negative(base.get(), 1);
 
-        if (BN_mod_exp_mont_vartime(r.get(), base.get(), exp.get(), mod.get(),
-                                    nullptr)) {
-          fprintf(stderr, "BN_mod_exp_mont_vartime(%d, %d, %d) succeeded!\n",
+        if (GFp_BN_mod_exp_mont_vartime(r.get(), base.get(), exp.get(),
+                                        mod.get(), nullptr)) {
+          fprintf(stderr, "GFp_BN_mod_exp_mont_vartime(%d, %d, %d) succeeded!\n",
                   -(int)base_value, (int)exp_value, (int)mod_value);
           return false;
         }
-        if (BN_mod_exp_mont_consttime(r.get(), base.get(), exp.get(),
-                                      mont.get())) {
-          fprintf(stderr, "BN_mod_exp_mont_consttime(%d, %d, %d) succeeded!\n",
+        if (GFp_BN_mod_exp_mont_consttime(r.get(), base.get(), exp.get(),
+                                          mont.get())) {
+          fprintf(stderr, "GFp_BN_mod_exp_mont_consttime(%d, %d, %d) succeeded!\n",
                   -(int)base_value, (int)exp_value, (int)mod_value);
           return false;
         }
@@ -886,7 +891,7 @@ static bool TestExpModRejectUnreduced() {
 }
 
 static bool TestModInvRejectUnreduced(RAND *rng) {
-  ScopedBIGNUM r(BN_new());
+  ScopedBIGNUM r(GFp_BN_new());
   if (!r) {
     return false;
   }
@@ -895,47 +900,47 @@ static bool TestModInvRejectUnreduced(RAND *rng) {
   static const BN_ULONG kModuli[] = { 1, 3 };
 
   for (BN_ULONG mod_value : kModuli) {
-    ScopedBIGNUM mod(BN_new());
-    ScopedBN_MONT_CTX mont(BN_MONT_CTX_new());
+    ScopedBIGNUM mod(GFp_BN_new());
+    ScopedBN_MONT_CTX mont(GFp_BN_MONT_CTX_new());
     if (!mod ||
-        !BN_set_word(mod.get(), mod_value) ||
+        !GFp_BN_set_word(mod.get(), mod_value) ||
         !mont ||
-        !BN_MONT_CTX_set(mont.get(), mod.get())) {
+        !GFp_BN_MONT_CTX_set(mont.get(), mod.get())) {
       return false;
     }
     for (BN_ULONG base_value : kBases) {
-      ScopedBIGNUM base(BN_new());
+      ScopedBIGNUM base(GFp_BN_new());
       if (!base ||
-          !BN_set_word(base.get(), base_value)) {
+          !GFp_BN_set_word(base.get(), base_value)) {
         return false;
       }
 
       int no_inverse;
 
       if (base_value >= mod_value &&
-          BN_mod_inverse_odd(r.get(), &no_inverse, base.get(), mod.get())) {
-        fprintf(stderr, "BN_mod_inverse_odd(%d, %d) succeeded!\n",
+          GFp_BN_mod_inverse_odd(r.get(), &no_inverse, base.get(), mod.get())) {
+        fprintf(stderr, "GFp_BN_mod_inverse_odd(%d, %d) succeeded!\n",
                 (int)base_value, (int)mod_value);
         return false;
       }
       if (base_value >= mod_value &&
-          BN_mod_inverse_blinded(r.get(), &no_inverse, base.get(), mont.get(),
-                                 rng)) {
-        fprintf(stderr, "BN_mod_inverse_blinded(%d, %d) succeeded!\n",
+          GFp_BN_mod_inverse_blinded(r.get(), &no_inverse, base.get(),
+                                     mont.get(), rng)) {
+        fprintf(stderr, "GFp_BN_mod_inverse_blinded(%d, %d) succeeded!\n",
           (int)base_value, (int)mod_value);
         return false;
       }
 
       BN_set_negative(base.get(), 1);
 
-      if (BN_mod_inverse_odd(r.get(), &no_inverse, base.get(), mod.get())) {
-        fprintf(stderr, "BN_mod_inverse_odd(%d, %d) succeeded!\n",
+      if (GFp_BN_mod_inverse_odd(r.get(), &no_inverse, base.get(), mod.get())) {
+        fprintf(stderr, "GFp_BN_mod_inverse_odd(%d, %d) succeeded!\n",
                 -(int)base_value, (int)mod_value);
         return false;
       }
-      if (BN_mod_inverse_blinded(r.get(), &no_inverse, base.get(), mont.get(),
-                                 rng)) {
-        fprintf(stderr, "BN_mod_inverse_blinded(%d, %d) succeeded!\n",
+      if (GFp_BN_mod_inverse_blinded(r.get(), &no_inverse, base.get(),
+                                     mont.get(), rng)) {
+        fprintf(stderr, "GFp_BN_mod_inverse_blinded(%d, %d) succeeded!\n",
                 -(int)base_value, (int)mod_value);
         return false;
       }
@@ -949,68 +954,68 @@ static bool TestModInvRejectUnreduced(RAND *rng) {
 static bool TestCmpWord() {
   static const BN_ULONG kMaxWord = (BN_ULONG)-1;
 
-  ScopedBIGNUM r(BN_new());
+  ScopedBIGNUM r(GFp_BN_new());
   if (!r ||
-      !BN_set_word(r.get(), 0)) {
+      !GFp_BN_set_word(r.get(), 0)) {
     return false;
   }
 
-  if (BN_cmp_word(r.get(), 0) != 0 ||
-      BN_cmp_word(r.get(), 1) >= 0 ||
-      BN_cmp_word(r.get(), kMaxWord) >= 0) {
-    fprintf(stderr, "BN_cmp_word compared against 0 incorrectly.\n");
+  if (GFp_BN_cmp_word(r.get(), 0) != 0 ||
+      GFp_BN_cmp_word(r.get(), 1) >= 0 ||
+      GFp_BN_cmp_word(r.get(), kMaxWord) >= 0) {
+    fprintf(stderr, "GFp_BN_cmp_word compared against 0 incorrectly.\n");
     return false;
   }
 
-  if (!BN_set_word(r.get(), 100)) {
+  if (!GFp_BN_set_word(r.get(), 100)) {
     return false;
   }
 
-  if (BN_cmp_word(r.get(), 0) <= 0 ||
-      BN_cmp_word(r.get(), 99) <= 0 ||
-      BN_cmp_word(r.get(), 100) != 0 ||
-      BN_cmp_word(r.get(), 101) >= 0 ||
-      BN_cmp_word(r.get(), kMaxWord) >= 0) {
-    fprintf(stderr, "BN_cmp_word compared against 100 incorrectly.\n");
-    return false;
-  }
-
-  BN_set_negative(r.get(), 1);
-
-  if (BN_cmp_word(r.get(), 0) >= 0 ||
-      BN_cmp_word(r.get(), 100) >= 0 ||
-      BN_cmp_word(r.get(), kMaxWord) >= 0) {
-    fprintf(stderr, "BN_cmp_word compared against -100 incorrectly.\n");
-    return false;
-  }
-
-  if (!BN_set_word(r.get(), kMaxWord)) {
-    return false;
-  }
-
-  if (BN_cmp_word(r.get(), 0) <= 0 ||
-      BN_cmp_word(r.get(), kMaxWord - 1) <= 0 ||
-      BN_cmp_word(r.get(), kMaxWord) != 0) {
-    fprintf(stderr, "BN_cmp_word compared against kMaxWord incorrectly.\n");
-    return false;
-  }
-
-  if (!BN_add(r.get(), r.get(), BN_value_one())) {
-    return false;
-  }
-
-  if (BN_cmp_word(r.get(), 0) <= 0 ||
-      BN_cmp_word(r.get(), kMaxWord) <= 0) {
-    fprintf(stderr, "BN_cmp_word compared against kMaxWord + 1 incorrectly.\n");
+  if (GFp_BN_cmp_word(r.get(), 0) <= 0 ||
+      GFp_BN_cmp_word(r.get(), 99) <= 0 ||
+      GFp_BN_cmp_word(r.get(), 100) != 0 ||
+      GFp_BN_cmp_word(r.get(), 101) >= 0 ||
+      GFp_BN_cmp_word(r.get(), kMaxWord) >= 0) {
+    fprintf(stderr, "GFp_BN_cmp_word compared against 100 incorrectly.\n");
     return false;
   }
 
   BN_set_negative(r.get(), 1);
 
-  if (BN_cmp_word(r.get(), 0) >= 0 ||
-      BN_cmp_word(r.get(), kMaxWord) >= 0) {
+  if (GFp_BN_cmp_word(r.get(), 0) >= 0 ||
+      GFp_BN_cmp_word(r.get(), 100) >= 0 ||
+      GFp_BN_cmp_word(r.get(), kMaxWord) >= 0) {
+    fprintf(stderr, "GFp_BN_cmp_word compared against -100 incorrectly.\n");
+    return false;
+  }
+
+  if (!GFp_BN_set_word(r.get(), kMaxWord)) {
+    return false;
+  }
+
+  if (GFp_BN_cmp_word(r.get(), 0) <= 0 ||
+      GFp_BN_cmp_word(r.get(), kMaxWord - 1) <= 0 ||
+      GFp_BN_cmp_word(r.get(), kMaxWord) != 0) {
+    fprintf(stderr, "GFp_BN_cmp_word compared against kMaxWord incorrectly.\n");
+    return false;
+  }
+
+  if (!GFp_BN_add(r.get(), r.get(), GFp_BN_value_one())) {
+    return false;
+  }
+
+  if (GFp_BN_cmp_word(r.get(), 0) <= 0 ||
+      GFp_BN_cmp_word(r.get(), kMaxWord) <= 0) {
+    fprintf(stderr, "GFp_BN_cmp_word compared against kMaxWord + 1 incorrectly.\n");
+    return false;
+  }
+
+  BN_set_negative(r.get(), 1);
+
+  if (GFp_BN_cmp_word(r.get(), 0) >= 0 ||
+      GFp_BN_cmp_word(r.get(), kMaxWord) >= 0) {
     fprintf(stderr,
-            "BN_cmp_word compared against -kMaxWord - 1 incorrectly.\n");
+            "GFp_BN_cmp_word compared against -kMaxWord - 1 incorrectly.\n");
     return false;
   }
 

--- a/crypto/bn/cmp.c
+++ b/crypto/bn/cmp.c
@@ -59,7 +59,7 @@
 #include "internal.h"
 
 
-int BN_ucmp(const BIGNUM *a, const BIGNUM *b) {
+int GFp_BN_ucmp(const BIGNUM *a, const BIGNUM *b) {
   int i;
   BN_ULONG t1, t2, *ap, *bp;
 
@@ -81,7 +81,7 @@ int BN_ucmp(const BIGNUM *a, const BIGNUM *b) {
   return 0;
 }
 
-int BN_cmp(const BIGNUM *a, const BIGNUM *b) {
+int GFp_BN_cmp(const BIGNUM *a, const BIGNUM *b) {
   int i;
   int gt, lt;
   BN_ULONG t1, t2;
@@ -130,7 +130,7 @@ int BN_cmp(const BIGNUM *a, const BIGNUM *b) {
   return 0;
 }
 
-int BN_abs_is_word(const BIGNUM *bn, BN_ULONG w) {
+int GFp_BN_abs_is_word(const BIGNUM *bn, BN_ULONG w) {
   switch (bn->top) {
     case 1:
       return bn->d[0] == w;
@@ -141,25 +141,25 @@ int BN_abs_is_word(const BIGNUM *bn, BN_ULONG w) {
   }
 }
 
-int BN_cmp_word(const BIGNUM *a, BN_ULONG b) {
+int GFp_BN_cmp_word(const BIGNUM *a, BN_ULONG b) {
   BIGNUM b_bn;
-  BN_init(&b_bn);
+  GFp_BN_init(&b_bn);
 
   b_bn.d = &b;
   b_bn.top = b > 0;
   b_bn.dmax = 1;
   b_bn.flags = BN_FLG_STATIC_DATA;
-  return BN_cmp(a, &b_bn);
+  return GFp_BN_cmp(a, &b_bn);
 }
 
-int BN_is_zero(const BIGNUM *bn) {
+int GFp_BN_is_zero(const BIGNUM *bn) {
   return bn->top == 0;
 }
 
-int BN_is_one(const BIGNUM *bn) {
-  return bn->neg == 0 && BN_abs_is_word(bn, 1);
+int GFp_BN_is_one(const BIGNUM *bn) {
+  return bn->neg == 0 && GFp_BN_abs_is_word(bn, 1);
 }
 
-int BN_is_odd(const BIGNUM *bn) {
+int GFp_BN_is_odd(const BIGNUM *bn) {
   return bn->top > 0 && (bn->d[0] & 1) == 1;
 }

--- a/crypto/bn/convert.c
+++ b/crypto/bn/convert.c
@@ -62,14 +62,14 @@
 #include "internal.h"
 
 
-BIGNUM *BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
+BIGNUM *GFp_BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
   size_t num_words;
   unsigned m;
   BN_ULONG word = 0;
   BIGNUM *bn = NULL;
 
   if (ret == NULL) {
-    ret = bn = BN_new();
+    ret = bn = GFp_BN_new();
   }
 
   if (ret == NULL) {
@@ -83,14 +83,14 @@ BIGNUM *BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
 
   num_words = ((len - 1) / BN_BYTES) + 1;
   m = (len - 1) % BN_BYTES;
-  if (bn_wexpand(ret, num_words) == NULL) {
+  if (GFp_bn_wexpand(ret, num_words) == NULL) {
     if (bn) {
-      BN_free(bn);
+      GFp_BN_free(bn);
     }
     return NULL;
   }
 
-  /* |bn_wexpand| must check bounds on |num_words| to write it into
+  /* |GFp_bn_wexpand| must check bounds on |num_words| to write it into
    * |ret->dmax|. */
   assert(num_words <= INT_MAX);
   ret->top = (int)num_words;
@@ -107,7 +107,7 @@ BIGNUM *BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
 
   /* need to call this due to clear byte at top if avoiding having the top bit
    * set (-ve number) */
-  bn_correct_top(ret);
+  GFp_bn_correct_top(ret);
   return ret;
 }
 
@@ -140,12 +140,12 @@ static BN_ULONG read_word_padded(const BIGNUM *in, size_t i) {
   return constant_time_select_ulong(constant_time_le_size_t(in->top, i), 0, l);
 }
 
-int BN_bn2bin_padded(uint8_t *out, size_t len, const BIGNUM *in) {
+int GFp_BN_bn2bin_padded(uint8_t *out, size_t len, const BIGNUM *in) {
   size_t i;
   BN_ULONG l;
 
   /* Special case for |in| = 0. Just branch as the probability is negligible. */
-  if (BN_is_zero(in)) {
+  if (GFp_BN_is_zero(in)) {
     memset(out, 0, len);
     return 1;
   }

--- a/crypto/bn/exponentiation.c
+++ b/crypto/bn/exponentiation.c
@@ -493,11 +493,12 @@ int GFp_BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
    * RSAZ exponentiation. For further information see
    * crypto/bn/rsaz_exp.c and accompanying assembly modules. */
   if ((16 == a->top) && (16 == p->top) && (GFp_BN_num_bits(m) == 1024) &&
-      rsaz_avx2_eligible()) {
+      GFp_rsaz_avx2_eligible()) {
     if (NULL == GFp_bn_wexpand(rr, 16)) {
       goto err;
     }
-    RSAZ_1024_mod_exp_avx2(rr->d, a->d, p->d, m->d, mont->RR.d, mont->n0[0]);
+    GFp_RSAZ_1024_mod_exp_avx2(rr->d, a->d, p->d, m->d, mont->RR.d,
+                               mont->n0[0]);
     rr->top = 16;
     rr->neg = 0;
     GFp_bn_correct_top(rr);

--- a/crypto/bn/gcd.c
+++ b/crypto/bn/gcd.c
@@ -113,39 +113,40 @@
 #include "internal.h"
 
 
-int BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
-                       const BIGNUM *n) {
+int GFp_BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
+                           const BIGNUM *n) {
   *out_no_inverse = 0;
 
-  if (!BN_is_odd(n)) {
+  if (!GFp_BN_is_odd(n)) {
     OPENSSL_PUT_ERROR(BN, BN_R_CALLED_WITH_EVEN_MODULUS);
     return 0;
   }
 
-  if (BN_is_negative(a) || BN_cmp(a, n) >= 0) {
+  if (GFp_BN_is_negative(a) || GFp_BN_cmp(a, n) >= 0) {
     OPENSSL_PUT_ERROR(BN, BN_R_INPUT_NOT_REDUCED);
     return 0;
   }
 
   BIGNUM A;
-  BN_init(&A);
+  GFp_BN_init(&A);
 
   BIGNUM B;
-  BN_init(&B);
+  GFp_BN_init(&B);
 
   BIGNUM X;
-  BN_init(&X);
+  GFp_BN_init(&X);
 
   BIGNUM Y;
-  BN_init(&Y);
+  GFp_BN_init(&Y);
 
   int ret = 0;
   int sign;
 
   BIGNUM *R = out;
 
-  BN_zero(&Y);
-  if (!BN_one(&X) || BN_copy(&B, a) == NULL || BN_copy(&A, n) == NULL) {
+  GFp_BN_zero(&Y);
+  if (!GFp_BN_one(&X) || GFp_BN_copy(&B, a) == NULL ||
+      GFp_BN_copy(&A, n) == NULL) {
     goto err;
   }
   A.neg = 0;
@@ -162,7 +163,7 @@ int BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
    * bits on 32-bit systems, but much more on 64-bit systems) */
   int shift;
 
-  while (!BN_is_zero(&B)) {
+  while (!GFp_BN_is_zero(&B)) {
     /*      0 < B < |n|,
      *      0 < A <= |n|,
      * (1) -sign*X*a  ==  B   (mod |n|),
@@ -172,44 +173,44 @@ int BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
      * and divide  X  by the same value mod |n|.
      * When we're done, (1) still holds. */
     shift = 0;
-    while (!BN_is_bit_set(&B, shift)) {
+    while (!GFp_BN_is_bit_set(&B, shift)) {
       /* note that 0 < B */
       shift++;
 
-      if (BN_is_odd(&X)) {
-        if (!BN_uadd(&X, &X, n)) {
+      if (GFp_BN_is_odd(&X)) {
+        if (!GFp_BN_uadd(&X, &X, n)) {
           goto err;
         }
       }
       /* now X is even, so we can easily divide it by two */
-      if (!BN_rshift1(&X, &X)) {
+      if (!GFp_BN_rshift1(&X, &X)) {
         goto err;
       }
     }
     if (shift > 0) {
-      if (!BN_rshift(&B, &B, shift)) {
+      if (!GFp_BN_rshift(&B, &B, shift)) {
         goto err;
       }
     }
 
     /* Same for A and Y. Afterwards, (2) still holds. */
     shift = 0;
-    while (!BN_is_bit_set(&A, shift)) {
+    while (!GFp_BN_is_bit_set(&A, shift)) {
       /* note that 0 < A */
       shift++;
 
-      if (BN_is_odd(&Y)) {
-        if (!BN_uadd(&Y, &Y, n)) {
+      if (GFp_BN_is_odd(&Y)) {
+        if (!GFp_BN_uadd(&Y, &Y, n)) {
           goto err;
         }
       }
       /* now Y is even */
-      if (!BN_rshift1(&Y, &Y)) {
+      if (!GFp_BN_rshift1(&Y, &Y)) {
         goto err;
       }
     }
     if (shift > 0) {
-      if (!BN_rshift(&A, &A, shift)) {
+      if (!GFp_BN_rshift(&A, &A, shift)) {
         goto err;
       }
     }
@@ -224,29 +225,29 @@ int BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
      * (2)  sign*Y*a  ==  A   (mod |n|),
      *
      * and that either  A  or  B  is even in the next iteration. */
-    if (BN_ucmp(&B, &A) >= 0) {
+    if (GFp_BN_ucmp(&B, &A) >= 0) {
       /* -sign*(X + Y)*a == B - A  (mod |n|) */
-      if (!BN_uadd(&X, &X, &Y)) {
+      if (!GFp_BN_uadd(&X, &X, &Y)) {
         goto err;
       }
-      /* NB: we could use BN_mod_add_quick(X, X, Y, n), but that
+      /* NB: we could use GFp_BN_mod_add_quick(X, X, Y, n), but that
        * actually makes the algorithm slower */
-      if (!BN_usub(&B, &B, &A)) {
+      if (!GFp_BN_usub(&B, &B, &A)) {
         goto err;
       }
     } else {
       /*  sign*(X + Y)*a == A - B  (mod |n|) */
-      if (!BN_uadd(&Y, &Y, &X)) {
+      if (!GFp_BN_uadd(&Y, &Y, &X)) {
         goto err;
       }
-      /* as above, BN_mod_add_quick(Y, Y, X, n) would slow things down */
-      if (!BN_usub(&A, &A, &B)) {
+      /* as above, GFp_BN_mod_add_quick(Y, Y, X, n) would slow things down */
+      if (!GFp_BN_usub(&A, &A, &B)) {
         goto err;
       }
     }
   }
 
-  if (!BN_is_one(&A)) {
+  if (!GFp_BN_is_one(&A)) {
     *out_no_inverse = 1;
     OPENSSL_PUT_ERROR(BN, BN_R_NO_INVERSE);
     goto err;
@@ -259,19 +260,19 @@ int BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
    * where  Y  is non-negative. */
 
   if (sign < 0) {
-    if (!BN_sub(&Y, n, &Y)) {
+    if (!GFp_BN_sub(&Y, n, &Y)) {
       goto err;
     }
   }
   /* Now  Y*a  ==  A  (mod |n|).  */
 
   /* Y*a == 1  (mod |n|) */
-  if (!Y.neg && BN_ucmp(&Y, n) < 0) {
-    if (!BN_copy(R, &Y)) {
+  if (!Y.neg && GFp_BN_ucmp(&Y, n) < 0) {
+    if (!GFp_BN_copy(R, &Y)) {
       goto err;
     }
   } else {
-    if (!BN_nnmod(R, &Y, n)) {
+    if (!GFp_BN_nnmod(R, &Y, n)) {
       goto err;
     }
   }
@@ -279,31 +280,32 @@ int BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
   ret = 1;
 
 err:
-  BN_free(&A);
-  BN_free(&B);
-  BN_free(&X);
-  BN_free(&Y);
+  GFp_BN_free(&A);
+  GFp_BN_free(&B);
+  GFp_BN_free(&X);
+  GFp_BN_free(&Y);
 
   return ret;
 }
 
-int BN_mod_inverse_blinded(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
-                           const BN_MONT_CTX *mont, RAND *rng) {
+int GFp_BN_mod_inverse_blinded(BIGNUM *out, int *out_no_inverse,
+                               const BIGNUM *a, const BN_MONT_CTX *mont,
+                               RAND *rng) {
   *out_no_inverse = 0;
 
-  if (BN_is_negative(a) || BN_cmp(a, &mont->N) >= 0) {
+  if (GFp_BN_is_negative(a) || GFp_BN_cmp(a, &mont->N) >= 0) {
     OPENSSL_PUT_ERROR(BN, BN_R_INPUT_NOT_REDUCED);
     return 0;
   }
 
   int ret = 0;
   BIGNUM blinding_factor;
-  BN_init(&blinding_factor);
+  GFp_BN_init(&blinding_factor);
 
-  if (!BN_rand_range_ex(&blinding_factor, &mont->N, rng) ||
-      !BN_mod_mul_mont(out, &blinding_factor, a, mont) ||
-      !BN_mod_inverse_odd(out, out_no_inverse, out, &mont->N) ||
-      !BN_mod_mul_mont(out, &blinding_factor, out, mont)) {
+  if (!GFp_BN_rand_range_ex(&blinding_factor, &mont->N, rng) ||
+      !GFp_BN_mod_mul_mont(out, &blinding_factor, a, mont) ||
+      !GFp_BN_mod_inverse_odd(out, out_no_inverse, out, &mont->N) ||
+      !GFp_BN_mod_mul_mont(out, &blinding_factor, out, mont)) {
     OPENSSL_PUT_ERROR(BN, ERR_R_BN_LIB);
     goto err;
   }
@@ -311,6 +313,6 @@ int BN_mod_inverse_blinded(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
   ret = 1;
 
 err:
-  BN_free(&blinding_factor);
+  GFp_BN_free(&blinding_factor);
   return ret;
 }

--- a/crypto/bn/generic.c
+++ b/crypto/bn/generic.c
@@ -91,8 +91,8 @@
   }
 
 
-BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
-                          BN_ULONG w) {
+BN_ULONG GFp_bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
+                              BN_ULONG w) {
   BN_ULONG c1 = 0;
 
   assert(num >= 0);
@@ -120,7 +120,8 @@ BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
   return c1;
 }
 
-BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w) {
+BN_ULONG GFp_bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
+                          BN_ULONG w) {
   BN_ULONG c1 = 0;
 
   assert(num >= 0);
@@ -146,8 +147,8 @@ BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w) {
   return c1;
 }
 
-BN_ULONG bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
-                      int n) {
+BN_ULONG GFp_bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
+                          int n) {
   BN_ULONG c, l, t;
 
   assert(n >= 0);
@@ -201,8 +202,8 @@ BN_ULONG bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
   return (BN_ULONG)c;
 }
 
-BN_ULONG bn_sub_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
-                      int n) {
+BN_ULONG GFp_bn_sub_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
+                          int n) {
   BN_ULONG t1, t2;
   int c = 0;
 

--- a/crypto/bn/internal.h
+++ b/crypto/bn/internal.h
@@ -199,10 +199,14 @@ extern "C" {
   }
 
 
-BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w);
-BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w);
-BN_ULONG bn_add_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,int num);
-BN_ULONG bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,int num);
+BN_ULONG GFp_bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
+                              BN_ULONG w);
+BN_ULONG GFp_bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
+                          BN_ULONG w);
+BN_ULONG GFp_bn_add_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                          int num);
+BN_ULONG GFp_bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                          int num);
 
 /* |num| must be at least 4, at least on x86.
  *
@@ -210,10 +214,10 @@ BN_ULONG bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,int n
  * actually did the multiplication. All our implementations always do the
  * multiplication, and forcing callers to deal with the possibility of it
  * failing just leads to further problems. */
-void bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
-                 const BN_ULONG *np, const BN_ULONG *n0, int num);
+void GFp_bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                     const BN_ULONG *np, const BN_ULONG *n0, int num);
 
-uint64_t bn_mont_n0(const BIGNUM *n);
+uint64_t GFp_bn_mont_n0(const BIGNUM *n);
 
 static inline void bn_umult_lohi(BN_ULONG *low_out, BN_ULONG *high_out,
                                  BN_ULONG a, BN_ULONG b) {

--- a/crypto/bn/montgomery_inv.c
+++ b/crypto/bn/montgomery_inv.c
@@ -31,11 +31,11 @@ OPENSSL_COMPILE_ASSERT(sizeof(uint64_t) ==
 /* LG_LITTLE_R is log_2(r). */
 #define LG_LITTLE_R (BN_MONT_CTX_N0_LIMBS * BN_BITS2)
 
-uint64_t bn_mont_n0(const BIGNUM *n) {
+uint64_t GFp_bn_mont_n0(const BIGNUM *n) {
   /* These conditions are checked by the caller, |BN_MONT_CTX_set|. */
-  assert(!BN_is_zero(n));
-  assert(!BN_is_negative(n));
-  assert(BN_is_odd(n));
+  assert(!GFp_BN_is_zero(n));
+  assert(!GFp_BN_is_negative(n));
+  assert(GFp_BN_is_odd(n));
 
   /* r == 2**(BN_MONT_CTX_N0_LIMBS * BN_BITS2) and LG_LITTLE_R == lg(r). This
    * ensures that we can do integer division by |r| by simply ignoring

--- a/crypto/bn/mul.c
+++ b/crypto/bn/mul.c
@@ -62,8 +62,8 @@
 #include "internal.h"
 
 
-static void bn_mul_normal(BN_ULONG *r, BN_ULONG *a, int na, BN_ULONG *b,
-                          int nb) {
+static void GFp_bn_mul_normal(BN_ULONG *r, BN_ULONG *a, int na, BN_ULONG *b,
+                              int nb) {
   assert(r != a);
   assert(r != b);
 
@@ -82,36 +82,36 @@ static void bn_mul_normal(BN_ULONG *r, BN_ULONG *a, int na, BN_ULONG *b,
   }
   rr = &(r[na]);
   if (nb <= 0) {
-    (void)bn_mul_words(r, a, na, 0);
+    (void)GFp_bn_mul_words(r, a, na, 0);
     return;
   } else {
-    rr[0] = bn_mul_words(r, a, na, b[0]);
+    rr[0] = GFp_bn_mul_words(r, a, na, b[0]);
   }
 
   for (;;) {
     if (--nb <= 0) {
       return;
     }
-    rr[1] = bn_mul_add_words(&(r[1]), a, na, b[1]);
+    rr[1] = GFp_bn_mul_add_words(&(r[1]), a, na, b[1]);
     if (--nb <= 0) {
       return;
     }
-    rr[2] = bn_mul_add_words(&(r[2]), a, na, b[2]);
+    rr[2] = GFp_bn_mul_add_words(&(r[2]), a, na, b[2]);
     if (--nb <= 0) {
       return;
     }
-    rr[3] = bn_mul_add_words(&(r[3]), a, na, b[3]);
+    rr[3] = GFp_bn_mul_add_words(&(r[3]), a, na, b[3]);
     if (--nb <= 0) {
       return;
     }
-    rr[4] = bn_mul_add_words(&(r[4]), a, na, b[4]);
+    rr[4] = GFp_bn_mul_add_words(&(r[4]), a, na, b[4]);
     rr += 4;
     r += 4;
     b += 4;
   }
 }
 
-int BN_mul_no_alias(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
+int GFp_BN_mul_no_alias(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   assert(r != a);
   assert(r != b);
 
@@ -122,20 +122,20 @@ int BN_mul_no_alias(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
   bl = b->top;
 
   if ((al == 0) || (bl == 0)) {
-    BN_zero(r);
+    GFp_BN_zero(r);
     return 1;
   }
   top = al + bl;
 
   r->neg = a->neg ^ b->neg;
 
-  if (bn_wexpand(r, top) == NULL) {
+  if (GFp_bn_wexpand(r, top) == NULL) {
     goto err;
   }
   r->top = top;
-  bn_mul_normal(r->d, a->d, al, b->d, bl);
+  GFp_bn_mul_normal(r->d, a->d, al, b->d, bl);
 
-  bn_correct_top(r);
+  GFp_bn_correct_top(r);
   ret = 1;
 
 err:

--- a/crypto/bn/random.c
+++ b/crypto/bn/random.c
@@ -111,13 +111,13 @@
 #include <openssl/err.h>
 
 
-int BN_rand_range_ex(BIGNUM *r, const BIGNUM *max_exclusive, RAND *rng) {
-  if (BN_cmp_word(max_exclusive, 1) <= 0) {
+int GFp_BN_rand_range_ex(BIGNUM *r, const BIGNUM *max_exclusive, RAND *rng) {
+  if (GFp_BN_cmp_word(max_exclusive, 1) <= 0) {
     OPENSSL_PUT_ERROR(BN, BN_R_INVALID_RANGE);
     return 0;
   }
 
-  if (bn_wexpand(r, max_exclusive->top) == NULL) {
+  if (GFp_bn_wexpand(r, max_exclusive->top) == NULL) {
     return 0;
   }
 
@@ -126,7 +126,7 @@ int BN_rand_range_ex(BIGNUM *r, const BIGNUM *max_exclusive, RAND *rng) {
   }
 
   r->top = max_exclusive->top;
-  bn_correct_top(r);
+  GFp_bn_correct_top(r);
 
   return 1;
 }

--- a/crypto/bn/rsaz_exp.c
+++ b/crypto/bn/rsaz_exp.c
@@ -54,19 +54,21 @@
 /*
  * See crypto/bn/asm/rsaz-avx2.pl for further details.
  */
-void rsaz_1024_norm2red_avx2(void *red,const void *norm);
-void rsaz_1024_mul_avx2(void *ret,const void *a,const void *b,const void *n,BN_ULONG k);
-void rsaz_1024_sqr_avx2(void *ret,const void *a,const void *n,BN_ULONG k,int cnt);
-void rsaz_1024_scatter5_avx2(void *tbl,const void *val,int i);
-void rsaz_1024_gather5_avx2(void *val,const void *tbl,int i);
-void rsaz_1024_red2norm_avx2(void *norm,const void *red);
+void GFp_rsaz_1024_norm2red_avx2(void *red, const void *norm);
+void GFp_rsaz_1024_mul_avx2(void *ret, const void *a, const void *b,
+                            const void *n, BN_ULONG k);
+void GFp_rsaz_1024_sqr_avx2(void *ret, const void *a, const void *n, BN_ULONG k,
+                            int cnt);
+void GFp_rsaz_1024_scatter5_avx2(void *tbl, const void *val, int i);
+void GFp_rsaz_1024_gather5_avx2(void *val, const void *tbl, int i);
+void GFp_rsaz_1024_red2norm_avx2(void *norm, const void *red);
 
 alignas(64) static const BN_ULONG one[40] =
 	{1,0,0,    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 alignas(64) static const BN_ULONG two80[40] =
 	{0,0,1<<22,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
-void RSAZ_1024_mod_exp_avx2(BN_ULONG result_norm[16],
+void GFp_RSAZ_1024_mod_exp_avx2(BN_ULONG result_norm[16],
 	const BN_ULONG base_norm[16], const BN_ULONG exponent[16],
 	const BN_ULONG m_norm[16], const BN_ULONG RR[16], BN_ULONG k0)
 {
@@ -87,166 +89,166 @@ void RSAZ_1024_mod_exp_avx2(BN_ULONG result_norm[16],
 		a_inv = storage + (320 * 2);
 	}
 
-	rsaz_1024_norm2red_avx2(m, m_norm);
-	rsaz_1024_norm2red_avx2(a_inv, base_norm);
-	rsaz_1024_norm2red_avx2(R2, RR);
+	GFp_rsaz_1024_norm2red_avx2(m, m_norm);
+	GFp_rsaz_1024_norm2red_avx2(a_inv, base_norm);
+	GFp_rsaz_1024_norm2red_avx2(R2, RR);
 
-	rsaz_1024_mul_avx2(R2, R2, R2, m, k0);
-	rsaz_1024_mul_avx2(R2, R2, two80, m, k0);
+	GFp_rsaz_1024_mul_avx2(R2, R2, R2, m, k0);
+	GFp_rsaz_1024_mul_avx2(R2, R2, two80, m, k0);
 
 	/* table[0] = 1 */
-	rsaz_1024_mul_avx2(result, R2, one, m, k0);
+	GFp_rsaz_1024_mul_avx2(result, R2, one, m, k0);
 	/* table[1] = a_inv^1 */
-	rsaz_1024_mul_avx2(a_inv, a_inv, R2, m, k0);
+	GFp_rsaz_1024_mul_avx2(a_inv, a_inv, R2, m, k0);
 
-	rsaz_1024_scatter5_avx2(table_s,result,0);
-	rsaz_1024_scatter5_avx2(table_s,a_inv,1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,a_inv,1);
 
 	/* table[2] = a_inv^2 */
-	rsaz_1024_sqr_avx2(result, a_inv, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,2);
+	GFp_rsaz_1024_sqr_avx2(result, a_inv, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,2);
 #if 0
 	/* this is almost 2x smaller and less than 1% slower */
 	for (index=3; index<32; index++) {
-		rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-		rsaz_1024_scatter5_avx2(table_s,result,index);
+		GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+		GFp_rsaz_1024_scatter5_avx2(table_s,result,index);
 	}
 #else
 	/* table[4] = a_inv^4 */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,4);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,4);
 	/* table[8] = a_inv^8 */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,8);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,8);
 	/* table[16] = a_inv^16 */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,16);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,16);
 	/* table[17] = a_inv^17 */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-	rsaz_1024_scatter5_avx2(table_s,result,17);
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,17);
 
 	/* table[3] */
-	rsaz_1024_gather5_avx2(result,table_s,2);
-	rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
-	rsaz_1024_scatter5_avx2(table_s,result,3);
+	GFp_rsaz_1024_gather5_avx2(result,table_s,2);
+	GFp_rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,3);
 	/* table[6] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,6);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,6);
 	/* table[12] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,12);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,12);
  	/* table[24] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,24);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,24);
 	/* table[25] */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-	rsaz_1024_scatter5_avx2(table_s,result,25);
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,25);
 
 	/* table[5] */
-	rsaz_1024_gather5_avx2(result,table_s,4);
-	rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
-	rsaz_1024_scatter5_avx2(table_s,result,5);
+	GFp_rsaz_1024_gather5_avx2(result,table_s,4);
+	GFp_rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,5);
 	/* table[10] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,10);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,10);
 	/* table[20] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,20);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,20);
 	/* table[21] */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-	rsaz_1024_scatter5_avx2(table_s,result,21);
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,21);
 
 	/* table[7] */
-	rsaz_1024_gather5_avx2(result,table_s,6);
-	rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
-	rsaz_1024_scatter5_avx2(table_s,result,7);
+	GFp_rsaz_1024_gather5_avx2(result,table_s,6);
+	GFp_rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,7);
 	/* table[14] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,14);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,14);
 	/* table[28] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,28);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,28);
 	/* table[29] */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-	rsaz_1024_scatter5_avx2(table_s,result,29);
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,29);
 
 	/* table[9] */
-	rsaz_1024_gather5_avx2(result,table_s,8);
-	rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
-	rsaz_1024_scatter5_avx2(table_s,result,9);
+	GFp_rsaz_1024_gather5_avx2(result,table_s,8);
+	GFp_rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,9);
 	/* table[18] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,18);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,18);
 	/* table[19] */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-	rsaz_1024_scatter5_avx2(table_s,result,19);
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,19);
 
 	/* table[11] */
-	rsaz_1024_gather5_avx2(result,table_s,10);
-	rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
-	rsaz_1024_scatter5_avx2(table_s,result,11);
+	GFp_rsaz_1024_gather5_avx2(result,table_s,10);
+	GFp_rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,11);
 	/* table[22] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,22);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,22);
 	/* table[23] */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-	rsaz_1024_scatter5_avx2(table_s,result,23);
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,23);
 
 	/* table[13] */
-	rsaz_1024_gather5_avx2(result,table_s,12);
-	rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
-	rsaz_1024_scatter5_avx2(table_s,result,13);
+	GFp_rsaz_1024_gather5_avx2(result,table_s,12);
+	GFp_rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,13);
 	/* table[26] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,26);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,26);
 	/* table[27] */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-	rsaz_1024_scatter5_avx2(table_s,result,27);
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,27);
 
 	/* table[15] */
-	rsaz_1024_gather5_avx2(result,table_s,14);
-	rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
-	rsaz_1024_scatter5_avx2(table_s,result,15);
+	GFp_rsaz_1024_gather5_avx2(result,table_s,14);
+	GFp_rsaz_1024_mul_avx2(result,result,a_inv,m,k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,15);
 	/* table[30] */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 1);
-	rsaz_1024_scatter5_avx2(table_s,result,30);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 1);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,30);
 	/* table[31] */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
-	rsaz_1024_scatter5_avx2(table_s,result,31);
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_scatter5_avx2(table_s,result,31);
 #endif
 
 	const uint8_t *p_str = (const uint8_t *)exponent;
 
 	/* load first window */
 	wvalue = p_str[127] >> 3;
-	rsaz_1024_gather5_avx2(result,table_s,wvalue);
+	GFp_rsaz_1024_gather5_avx2(result,table_s,wvalue);
 
 	index = 1014;
 
 	while(index > -1) {	/* loop for the remaining 127 windows */
 
-		rsaz_1024_sqr_avx2(result, result, m, k0, 5);
+		GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 5);
 
 		wvalue = *((const unsigned short*)&p_str[index / 8]);
 		wvalue = (wvalue>> (index%8)) & 31;
 		index-=5;
 
-		rsaz_1024_gather5_avx2(a_inv,table_s,wvalue);	/* borrow a_inv */
-		rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+		GFp_rsaz_1024_gather5_avx2(a_inv,table_s,wvalue);	/* borrow a_inv */
+		GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
 	}
 
 	/* square four times */
-	rsaz_1024_sqr_avx2(result, result, m, k0, 4);
+	GFp_rsaz_1024_sqr_avx2(result, result, m, k0, 4);
 
 	wvalue = p_str[0] & 15;
 
-	rsaz_1024_gather5_avx2(a_inv,table_s,wvalue);	/* borrow a_inv */
-	rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
+	GFp_rsaz_1024_gather5_avx2(a_inv,table_s,wvalue);	/* borrow a_inv */
+	GFp_rsaz_1024_mul_avx2(result, result, a_inv, m, k0);
 
 	/* from Montgomery */
-	rsaz_1024_mul_avx2(result, result, one, m, k0);
+	GFp_rsaz_1024_mul_avx2(result, result, one, m, k0);
 
-	rsaz_1024_red2norm_avx2(result_norm, result);
+	GFp_rsaz_1024_red2norm_avx2(result_norm, result);
 }
 
 #endif  /* OPENSSL_X86_64 */

--- a/crypto/bn/rsaz_exp.h
+++ b/crypto/bn/rsaz_exp.h
@@ -45,9 +45,9 @@
 
 #include <openssl/bn.h>
 
-void RSAZ_1024_mod_exp_avx2(BN_ULONG result[16],
+void GFp_RSAZ_1024_mod_exp_avx2(BN_ULONG result[16],
 	const BN_ULONG base_norm[16], const BN_ULONG exponent[16],
 	const BN_ULONG m_norm[16], const BN_ULONG RR[16], BN_ULONG k0);
-int rsaz_avx2_eligible(void);
+int GFp_rsaz_avx2_eligible(void);
 
 #endif

--- a/crypto/bn/shift.c
+++ b/crypto/bn/shift.c
@@ -63,7 +63,7 @@
 #include "internal.h"
 
 
-int BN_lshift(BIGNUM *r, const BIGNUM *a, int n) {
+int GFp_BN_lshift(BIGNUM *r, const BIGNUM *a, int n) {
   int i, nw, lb, rb;
   BN_ULONG *t, *f;
   BN_ULONG l;
@@ -75,7 +75,7 @@ int BN_lshift(BIGNUM *r, const BIGNUM *a, int n) {
 
   r->neg = a->neg;
   nw = n / BN_BITS2;
-  if (bn_wexpand(r, a->top + nw + 1) == NULL) {
+  if (GFp_bn_wexpand(r, a->top + nw + 1) == NULL) {
     return 0;
   }
   lb = n % BN_BITS2;
@@ -96,23 +96,23 @@ int BN_lshift(BIGNUM *r, const BIGNUM *a, int n) {
   }
   memset(t, 0, nw * sizeof(t[0]));
   r->top = a->top + nw + 1;
-  bn_correct_top(r);
+  GFp_bn_correct_top(r);
 
   return 1;
 }
 
-int BN_lshift1(BIGNUM *r, const BIGNUM *a) {
+int GFp_BN_lshift1(BIGNUM *r, const BIGNUM *a) {
   BN_ULONG *ap, *rp, t, c;
   int i;
 
   if (r != a) {
     r->neg = a->neg;
-    if (bn_wexpand(r, a->top + 1) == NULL) {
+    if (GFp_bn_wexpand(r, a->top + 1) == NULL) {
       return 0;
     }
     r->top = a->top;
   } else {
-    if (bn_wexpand(r, a->top + 1) == NULL) {
+    if (GFp_bn_wexpand(r, a->top + 1) == NULL) {
       return 0;
     }
   }
@@ -132,7 +132,7 @@ int BN_lshift1(BIGNUM *r, const BIGNUM *a) {
   return 1;
 }
 
-int BN_rshift(BIGNUM *r, const BIGNUM *a, int n) {
+int GFp_BN_rshift(BIGNUM *r, const BIGNUM *a, int n) {
   int i, j, nw, lb, rb;
   BN_ULONG *t, *f;
   BN_ULONG l, tmp;
@@ -146,13 +146,13 @@ int BN_rshift(BIGNUM *r, const BIGNUM *a, int n) {
   rb = n % BN_BITS2;
   lb = BN_BITS2 - rb;
   if (nw >= a->top || a->top == 0) {
-    BN_zero(r);
+    GFp_BN_zero(r);
     return 1;
   }
-  i = (BN_num_bits(a) - n + (BN_BITS2 - 1)) / BN_BITS2;
+  i = (GFp_BN_num_bits(a) - n + (BN_BITS2 - 1)) / BN_BITS2;
   if (r != a) {
     r->neg = a->neg;
-    if (bn_wexpand(r, i) == NULL) {
+    if (GFp_bn_wexpand(r, i) == NULL) {
       return 0;
     }
   } else {
@@ -185,19 +185,19 @@ int BN_rshift(BIGNUM *r, const BIGNUM *a, int n) {
   return 1;
 }
 
-int BN_rshift1(BIGNUM *r, const BIGNUM *a) {
+int GFp_BN_rshift1(BIGNUM *r, const BIGNUM *a) {
   BN_ULONG *ap, *rp, t, c;
   int i, j;
 
-  if (BN_is_zero(a)) {
-    BN_zero(r);
+  if (GFp_BN_is_zero(a)) {
+    GFp_BN_zero(r);
     return 1;
   }
   i = a->top;
   ap = a->d;
   j = i - (ap[i - 1] == 1);
   if (a != r) {
-    if (bn_wexpand(r, j) == NULL) {
+    if (GFp_bn_wexpand(r, j) == NULL) {
       return 0;
     }
     r->neg = a->neg;
@@ -218,7 +218,7 @@ int BN_rshift1(BIGNUM *r, const BIGNUM *a) {
   return 1;
 }
 
-int BN_set_bit(BIGNUM *a, int n) {
+int GFp_BN_set_bit(BIGNUM *a, int n) {
   int i, j, k;
 
   if (n < 0) {
@@ -228,7 +228,7 @@ int BN_set_bit(BIGNUM *a, int n) {
   i = n / BN_BITS2;
   j = n % BN_BITS2;
   if (a->top <= i) {
-    if (bn_wexpand(a, i + 1) == NULL) {
+    if (GFp_bn_wexpand(a, i + 1) == NULL) {
       return 0;
     }
     for (k = a->top; k < i + 1; k++) {
@@ -242,7 +242,7 @@ int BN_set_bit(BIGNUM *a, int n) {
   return 1;
 }
 
-int BN_is_bit_set(const BIGNUM *a, int n) {
+int GFp_BN_is_bit_set(const BIGNUM *a, int n) {
   int i, j;
 
   if (n < 0) {

--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -188,10 +188,10 @@ $code.=<<___;
 .word	-1
 #endif
 
-.globl	ChaCha20_ctr32
-.type	ChaCha20_ctr32,%function
+.globl	GFp_ChaCha20_ctr32
+.type	GFp_ChaCha20_ctr32,%function
 .align	5
-ChaCha20_ctr32:
+GFp_ChaCha20_ctr32:
 .LChaCha20_ctr32:
 	ldr	r12,[sp,#0]		@ pull pointer to counter and nonce
 	stmdb	sp!,{r0-r2,r4-r11,lr}
@@ -613,7 +613,7 @@ $code.=<<___;
 	add	sp,sp,#4*(32+3)
 .Lno_data:
 	ldmia	sp!,{r4-r11,pc}
-.size	ChaCha20_ctr32,.-ChaCha20_ctr32
+.size	GFp_ChaCha20_ctr32,.-GFp_ChaCha20_ctr32
 ___
 
 {{{

--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -183,7 +183,7 @@ $code.=<<___;
 .long	1,0,0,0
 #if __ARM_MAX_ARCH__>=7
 .LOPENSSL_armcap:
-.word   OPENSSL_armcap_P-.LChaCha20_ctr32
+.word   GFp_armcap_P-.LChaCha20_ctr32
 #else
 .word	-1
 #endif
@@ -1136,7 +1136,7 @@ $code.=<<___;
 	add		sp,sp,#4*(16+3)
 	ldmia		sp!,{r4-r11,pc}
 .size	ChaCha20_neon,.-ChaCha20_neon
-.comm	OPENSSL_armcap_P,4,4
+.comm	GFp_armcap_P,4,4
 #endif
 ___
 }}}

--- a/crypto/chacha/asm/chacha-armv8.pl
+++ b/crypto/chacha/asm/chacha-armv8.pl
@@ -115,18 +115,18 @@ $code.=<<___;
 
 .text
 
-.extern	OPENSSL_armcap_P
+.extern	GFp_armcap_P
 
 .align	5
 .Lsigma:
 .quad	0x3320646e61707865,0x6b20657479622d32		// endian-neutral
 .Lone:
 .long	1,0,0,0
-.LOPENSSL_armcap_P:
+.LGFp_armcap_P:
 #ifdef	__ILP32__
-.long	OPENSSL_armcap_P-.
+.long	GFp_armcap_P-.
 #else
-.quad	OPENSSL_armcap_P-.
+.quad	GFp_armcap_P-.
 #endif
 .asciz	"ChaCha20 for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
 
@@ -135,7 +135,7 @@ $code.=<<___;
 .align	5
 ChaCha20_ctr32:
 	cbz	$len,.Labort
-	adr	@x[0],.LOPENSSL_armcap_P
+	adr	@x[0],.LGFp_armcap_P
 	cmp	$len,#192
 	b.lo	.Lshort
 #ifdef	__ILP32__

--- a/crypto/chacha/asm/chacha-armv8.pl
+++ b/crypto/chacha/asm/chacha-armv8.pl
@@ -130,10 +130,10 @@ $code.=<<___;
 #endif
 .asciz	"ChaCha20 for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
 
-.globl	ChaCha20_ctr32
-.type	ChaCha20_ctr32,%function
+.globl	GFp_ChaCha20_ctr32
+.type	GFp_ChaCha20_ctr32,%function
 .align	5
-ChaCha20_ctr32:
+GFp_ChaCha20_ctr32:
 	cbz	$len,.Labort
 	adr	@x[0],.LGFp_armcap_P
 	cmp	$len,#192
@@ -324,7 +324,7 @@ $code.=<<___;
 	ldp	x27,x28,[x29,#80]
 	ldp	x29,x30,[sp],#96
 	ret
-.size	ChaCha20_ctr32,.-ChaCha20_ctr32
+.size	GFp_ChaCha20_ctr32,.-GFp_ChaCha20_ctr32
 ___
 
 {{{

--- a/crypto/chacha/asm/chacha-x86.pl
+++ b/crypto/chacha/asm/chacha-x86.pl
@@ -119,7 +119,7 @@ if ($xmm) {
 	&call	(&label("pic_point"));
 &set_label("pic_point");
 	&blindpop("eax");
-	&picmeup("ebp","OPENSSL_ia32cap_P","eax",&label("pic_point"));
+	&picmeup("ebp","GFp_ia32cap_P","eax",&label("pic_point"));
 	&test	(&DWP(0,"ebp"),1<<24);		# test FXSR bit
 	&jz	(&label("x86"));
 	&test	(&DWP(4,"ebp"),1<<9);		# test SSSE3 bit

--- a/crypto/chacha/asm/chacha-x86.pl
+++ b/crypto/chacha/asm/chacha-x86.pl
@@ -111,7 +111,7 @@ my ($ap,$bp,$cp,$dp)=map(($_&~3)+(($_-1)&3),($ai,$bi,$ci,$di));	# previous
 &static_label("ssse3_data");
 &static_label("pic_point");
 
-&function_begin("ChaCha20_ctr32");
+&function_begin("GFp_ChaCha20_ctr32");
 	&xor	("eax","eax");
 	&cmp	("eax",&wparam(2));		# len==0?
 	&je	(&label("no_data"));
@@ -349,7 +349,7 @@ if ($xmm) {
 &set_label("done");
 	&stack_pop(33);
 &set_label("no_data");
-&function_end("ChaCha20_ctr32");
+&function_end("GFp_ChaCha20_ctr32");
 
 if ($xmm) {
 my ($xa,$xa_,$xb,$xb_,$xc,$xc_,$xd,$xd_)=map("xmm$_",(0..7));

--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -61,7 +61,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 $code.=<<___;
 .text
 
-.extern OPENSSL_ia32cap_P
+.extern GFp_ia32cap_P
 
 .align	64
 .Lzero:
@@ -206,7 +206,7 @@ $code.=<<___;
 ChaCha20_ctr32:
 	cmp	\$0,$len
 	je	.Lno_data
-	mov	OPENSSL_ia32cap_P+4(%rip),%r10
+	mov	GFp_ia32cap_P+4(%rip),%r10
 	test	\$`1<<(41-32)`,%r10d
 	jnz	.LChaCha20_ssse3
 
@@ -672,7 +672,7 @@ ChaCha20_4x:
 	mov		%r10,%r11
 ___
 $code.=<<___	if ($avx>1);
-	shr		\$32,%r10		# OPENSSL_ia32cap_P+8
+	shr		\$32,%r10		# GFp_ia32cap_P+8
 	test		\$`1<<5`,%r10		# test AVX2
 	jnz		.LChaCha20_8x
 ___

--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -200,10 +200,10 @@ my @x=map("\"$_\"",@x);
 ########################################################################
 # Generic code path that handles all lengths on pre-SSSE3 processors.
 $code.=<<___;
-.globl	ChaCha20_ctr32
-.type	ChaCha20_ctr32,\@function,5
+.globl	GFp_ChaCha20_ctr32
+.type	GFp_ChaCha20_ctr32,\@function,5
 .align	64
-ChaCha20_ctr32:
+GFp_ChaCha20_ctr32:
 	cmp	\$0,$len
 	je	.Lno_data
 	mov	GFp_ia32cap_P+4(%rip),%r10
@@ -364,7 +364,7 @@ $code.=<<___;
 	pop	%rbx
 .Lno_data:
 	ret
-.size	ChaCha20_ctr32,.-ChaCha20_ctr32
+.size	GFp_ChaCha20_ctr32,.-GFp_ChaCha20_ctr32
 ___
 
 ########################################################################

--- a/crypto/cipher/e_aes.c
+++ b/crypto/cipher/e_aes.c
@@ -85,7 +85,7 @@ int GFp_has_aes_hardware(void);
 
 #define VPAES
 static char vpaes_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << (41 - 32))) != 0;
+  return (GFp_ia32cap_P[1] & (1 << (41 - 32))) != 0;
 }
 
 #if defined(OPENSSL_X86_64)
@@ -228,7 +228,7 @@ static aes_ctr_f aes_ctr(void) {
 
 #if defined(AESNI)
 static char aesni_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << (57 - 32))) != 0;
+  return (GFp_ia32cap_P[1] & (1 << (57 - 32))) != 0;
 }
 #endif
 

--- a/crypto/cipher/internal.h
+++ b/crypto/cipher/internal.h
@@ -95,7 +95,7 @@ static inline int aead_check_alias(const uint8_t *in, size_t in_len,
   return 0;
 }
 
-/* |CRYPTO_chacha_20| uses a 32-bit block counter. Therefore we disallow
+/* |GFp_chacha_20| uses a 32-bit block counter. Therefore we disallow
  * individual operations that work on more than 256GB at a time, for all AEADs.
  * |in_len_64| is needed because, on 32-bit platforms, size_t is only
  * 32-bits and this produces a warning because it's always false.

--- a/crypto/cpu-aarch64-linux.c
+++ b/crypto/cpu-aarch64-linux.c
@@ -23,9 +23,9 @@
 #include "internal.h"
 
 
-extern uint32_t OPENSSL_armcap_P;
+extern uint32_t GFp_armcap_P;
 
-void OPENSSL_cpuid_setup(void) {
+void GFp_cpuid_setup(void) {
   unsigned long hwcap = getauxval(AT_HWCAP);
 
   /* See /usr/include/asm/hwcap.h on an aarch64 installation for the source of
@@ -42,19 +42,19 @@ void OPENSSL_cpuid_setup(void) {
     return;
   }
 
-  OPENSSL_armcap_P |= ARMV7_NEON;
+  GFp_armcap_P |= ARMV7_NEON;
 
   if (hwcap & kAES) {
-    OPENSSL_armcap_P |= ARMV8_AES;
+    GFp_armcap_P |= ARMV8_AES;
   }
   if (hwcap & kPMULL) {
-    OPENSSL_armcap_P |= ARMV8_PMULL;
+    GFp_armcap_P |= ARMV8_PMULL;
   }
   if (hwcap & kSHA1) {
-    OPENSSL_armcap_P |= ARMV8_SHA1;
+    GFp_armcap_P |= ARMV8_SHA1;
   }
   if (hwcap & kSHA256) {
-    OPENSSL_armcap_P |= ARMV8_SHA256;
+    GFp_armcap_P |= ARMV8_SHA256;
   }
 }
 

--- a/crypto/cpu-arm-linux.c
+++ b/crypto/cpu-arm-linux.c
@@ -353,6 +353,6 @@ void OPENSSL_cpuid_setup(void) {
   OPENSSL_free(cpuinfo_data);
 }
 
-int CRYPTO_has_broken_NEON(void) { return g_has_broken_neon; }
+int GFp_has_broken_NEON(void) { return g_has_broken_neon; }
 
 #endif /* OPENSSL_ARM && !OPENSSL_STATIC_ARMCAP */

--- a/crypto/cpu-arm-linux.c
+++ b/crypto/cpu-arm-linux.c
@@ -284,11 +284,11 @@ static int has_broken_neon(const STRING_PIECE *cpuinfo) {
          cpuinfo_field_equals(cpuinfo, "CPU revision", "0");
 }
 
-extern uint32_t OPENSSL_armcap_P;
+extern uint32_t GFp_armcap_P;
 
 static int g_has_broken_neon;
 
-void OPENSSL_cpuid_setup(void) {
+void GFp_cpuid_setup(void) {
   char *cpuinfo_data;
   size_t cpuinfo_len;
   if (!read_file(&cpuinfo_data, &cpuinfo_len, "/proc/cpuinfo")) {
@@ -324,7 +324,7 @@ void OPENSSL_cpuid_setup(void) {
 
   /* Matching OpenSSL, only report other features if NEON is present. */
   if (hwcap & HWCAP_NEON) {
-    OPENSSL_armcap_P |= ARMV7_NEON;
+    GFp_armcap_P |= ARMV7_NEON;
 
     /* Some ARMv8 Android devices don't expose AT_HWCAP2. Fall back to
      * /proc/cpuinfo. See https://crbug.com/596156. */
@@ -337,16 +337,16 @@ void OPENSSL_cpuid_setup(void) {
     }
 
     if (hwcap2 & HWCAP2_AES) {
-      OPENSSL_armcap_P |= ARMV8_AES;
+      GFp_armcap_P |= ARMV8_AES;
     }
     if (hwcap2 & HWCAP2_PMULL) {
-      OPENSSL_armcap_P |= ARMV8_PMULL;
+      GFp_armcap_P |= ARMV8_PMULL;
     }
     if (hwcap2 & HWCAP2_SHA1) {
-      OPENSSL_armcap_P |= ARMV8_SHA1;
+      GFp_armcap_P |= ARMV8_SHA1;
     }
     if (hwcap2 & HWCAP2_SHA2) {
-      OPENSSL_armcap_P |= ARMV8_SHA256;
+      GFp_armcap_P |= ARMV8_SHA256;
     }
   }
 

--- a/crypto/cpu-arm.c
+++ b/crypto/cpu-arm.c
@@ -22,15 +22,15 @@
 
 extern uint32_t OPENSSL_armcap_P;
 
-char CRYPTO_is_NEON_capable_at_runtime(void) {
+char GFp_is_NEON_capable_at_runtime(void) {
   return (OPENSSL_armcap_P & ARMV7_NEON) != 0;
 }
 
-int CRYPTO_is_ARMv8_AES_capable(void) {
+int GFp_is_ARMv8_AES_capable(void) {
   return (OPENSSL_armcap_P & ARMV8_AES) != 0;
 }
 
-int CRYPTO_is_ARMv8_PMULL_capable(void) {
+int GFp_is_ARMv8_PMULL_capable(void) {
   return (OPENSSL_armcap_P & ARMV8_PMULL) != 0;
 }
 

--- a/crypto/cpu-arm.c
+++ b/crypto/cpu-arm.c
@@ -20,18 +20,18 @@
 #include <openssl/arm_arch.h>
 
 
-extern uint32_t OPENSSL_armcap_P;
+extern uint32_t GFp_armcap_P;
 
 char GFp_is_NEON_capable_at_runtime(void) {
-  return (OPENSSL_armcap_P & ARMV7_NEON) != 0;
+  return (GFp_armcap_P & ARMV7_NEON) != 0;
 }
 
 int GFp_is_ARMv8_AES_capable(void) {
-  return (OPENSSL_armcap_P & ARMV8_AES) != 0;
+  return (GFp_armcap_P & ARMV8_AES) != 0;
 }
 
 int GFp_is_ARMv8_PMULL_capable(void) {
-  return (OPENSSL_armcap_P & ARMV8_PMULL) != 0;
+  return (GFp_armcap_P & ARMV8_PMULL) != 0;
 }
 
 #endif  /* (defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)) &&

--- a/crypto/cpu-intel.c
+++ b/crypto/cpu-intel.c
@@ -116,7 +116,7 @@ static uint64_t OPENSSL_xgetbv(uint32_t xcr) {
 #endif
 }
 
-void OPENSSL_cpuid_setup(void) {
+void GFp_cpuid_setup(void) {
   /* Determine the vendor and maximum input value. */
   uint32_t eax, ebx, ecx, edx;
   OPENSSL_cpuid(&eax, &ebx, &ecx, &edx, 0);
@@ -206,10 +206,10 @@ void OPENSSL_cpuid_setup(void) {
     extended_features &= ~(1 << 5); /* AVX2 */
   }
 
-  OPENSSL_ia32cap_P[0] = edx;
-  OPENSSL_ia32cap_P[1] = ecx;
-  OPENSSL_ia32cap_P[2] = extended_features;
-  OPENSSL_ia32cap_P[3] = 0;
+  GFp_ia32cap_P[0] = edx;
+  GFp_ia32cap_P[1] = ecx;
+  GFp_ia32cap_P[2] = extended_features;
+  GFp_ia32cap_P[3] = 0;
 }
 
 #endif  /* !OPENSSL_NO_ASM && (OPENSSL_X86 || OPENSSL_X86_64) */

--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -46,14 +46,14 @@
  * archive, linking on OS X will fail to resolve common symbols. By
  * initialising it to zero, it becomes a "data symbol", which isn't so
  * affected. */
-uint32_t OPENSSL_ia32cap_P[4] = {0};
+uint32_t GFp_ia32cap_P[4] = {0};
 #elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
 
 #include <openssl/arm_arch.h>
 
 #if defined(OPENSSL_STATIC_ARMCAP)
 
-uint32_t OPENSSL_armcap_P =
+uint32_t GFp_armcap_P =
 #if defined(OPENSSL_STATIC_ARMCAP_NEON) || defined(__ARM_NEON__)
     ARMV7_NEON |
 #endif
@@ -72,7 +72,7 @@ uint32_t OPENSSL_armcap_P =
     0;
 
 #else
-uint32_t OPENSSL_armcap_P = 0;
+uint32_t GFp_armcap_P = 0;
 #endif
 
 #endif

--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -77,29 +77,25 @@ uint32_t GFp_armcap_P = 0;
 
 #endif
 
-/* These functions allow tests in other languages to verify that their
- * understanding of the C types matches the C compiler's understanding. */
+/* These allow tests in other languages to verify that their understanding of
+ * the C types matches the C compiler's understanding. */
 
-#define DEFINE_METRICS_FUNCTIONS(ty) \
-  /* Declarations to avoid -Wmissing-prototypes warnings. */ \
-  OPENSSL_EXPORT uint16_t ring_##ty##_align(void); \
-  OPENSSL_EXPORT uint16_t ring_##ty##_size(void); \
-  \
-  OPENSSL_EXPORT uint16_t ring_##ty##_align(void) { return alignof(ty); } \
-  OPENSSL_EXPORT uint16_t ring_##ty##_size(void) { return sizeof(ty); }
+#define DEFINE_METRICS(ty) \
+  OPENSSL_EXPORT uint16_t GFp_##ty##_align = alignof(ty); \
+  OPENSSL_EXPORT uint16_t GFp_##ty##_size = sizeof(ty);
 
-DEFINE_METRICS_FUNCTIONS(int8_t)
-DEFINE_METRICS_FUNCTIONS(uint8_t)
+DEFINE_METRICS(int8_t)
+DEFINE_METRICS(uint8_t)
 
-DEFINE_METRICS_FUNCTIONS(int16_t)
-DEFINE_METRICS_FUNCTIONS(uint16_t)
+DEFINE_METRICS(int16_t)
+DEFINE_METRICS(uint16_t)
 
-DEFINE_METRICS_FUNCTIONS(int32_t)
-DEFINE_METRICS_FUNCTIONS(uint32_t)
+DEFINE_METRICS(int32_t)
+DEFINE_METRICS(uint32_t)
 
-DEFINE_METRICS_FUNCTIONS(int64_t)
-DEFINE_METRICS_FUNCTIONS(uint64_t)
+DEFINE_METRICS(int64_t)
+DEFINE_METRICS(uint64_t)
 
-DEFINE_METRICS_FUNCTIONS(int)
+DEFINE_METRICS(int)
 
-DEFINE_METRICS_FUNCTIONS(size_t)
+DEFINE_METRICS(size_t)

--- a/crypto/curve25519/asm/x25519-asm-arm.S
+++ b/crypto/curve25519/asm/x25519-asm-arm.S
@@ -24,10 +24,10 @@
 .text
 .align 4
 
-.global x25519_NEON
-.hidden x25519_NEON
-.type x25519_NEON, %function
-x25519_NEON:
+.global GFp_x25519_NEON
+.hidden GFp_x25519_NEON
+.type GFp_x25519_NEON, %function
+GFp_x25519_NEON:
 vpush {q4,q5,q6,q7}
 mov r12,sp
 sub sp,sp,#736

--- a/crypto/curve25519/asm/x25519-asm-x86_64.S
+++ b/crypto/curve25519/asm/x25519-asm-x86_64.S
@@ -57,9 +57,9 @@ x25519_x86_64__38:         .quad 38
 .text
 .p2align 5
 
-.globl C_ABI(x25519_x86_64_freeze)
-HIDDEN C_ABI(x25519_x86_64_freeze)
-C_ABI(x25519_x86_64_freeze):
+.globl C_ABI(GFp_x25519_x86_64_freeze)
+HIDDEN C_ABI(GFp_x25519_x86_64_freeze)
+C_ABI(GFp_x25519_x86_64_freeze):
 mov %rsp,%r11
 and $31,%r11
 add $64,%r11
@@ -141,9 +141,9 @@ mov %rsi,%rdx
 ret
 
 .p2align 5
-.globl C_ABI(x25519_x86_64_mul)
-HIDDEN C_ABI(x25519_x86_64_mul)
-C_ABI(x25519_x86_64_mul):
+.globl C_ABI(GFp_x25519_x86_64_mul)
+HIDDEN C_ABI(GFp_x25519_x86_64_mul)
+C_ABI(GFp_x25519_x86_64_mul):
 mov %rsp,%r11
 and $31,%r11
 add $96,%r11
@@ -320,9 +320,9 @@ mov %rsi,%rdx
 ret
 
 .p2align 5
-.globl C_ABI(x25519_x86_64_square)
-HIDDEN C_ABI(x25519_x86_64_square)
-C_ABI(x25519_x86_64_square):
+.globl C_ABI(GFp_x25519_x86_64_square)
+HIDDEN C_ABI(GFp_x25519_x86_64_square)
+C_ABI(GFp_x25519_x86_64_square):
 mov %rsp,%r11
 and $31,%r11
 add $64,%r11
@@ -462,9 +462,9 @@ mov %rsi,%rdx
 ret
 
 .p2align 5
-.globl C_ABI(x25519_x86_64_ladderstep)
-HIDDEN C_ABI(x25519_x86_64_ladderstep)
-C_ABI(x25519_x86_64_ladderstep):
+.globl C_ABI(GFp_x25519_x86_64_ladderstep)
+HIDDEN C_ABI(GFp_x25519_x86_64_ladderstep)
+C_ABI(GFp_x25519_x86_64_ladderstep):
 mov %rsp,%r11
 and $31,%r11
 add $352,%r11
@@ -1850,9 +1850,9 @@ mov %rsi,%rdx
 ret
 
 .p2align 5
-.globl C_ABI(x25519_x86_64_work_cswap)
-HIDDEN C_ABI(x25519_x86_64_work_cswap)
-C_ABI(x25519_x86_64_work_cswap):
+.globl C_ABI(GFp_x25519_x86_64_work_cswap)
+HIDDEN C_ABI(GFp_x25519_x86_64_work_cswap)
+C_ABI(GFp_x25519_x86_64_work_cswap):
 mov %rsp,%r11
 and $31,%r11
 add $0,%r11

--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -961,7 +961,7 @@ static void fe_pow22523(fe out, const fe z) {
   fe_mul(out, t0, z);
 }
 
-void x25519_ge_tobytes(uint8_t *s, const ge_p2 *h) {
+static void x25519_ge_tobytes(uint8_t *s, const ge_p2 *h) {
   fe recip;
   fe x;
   fe y;
@@ -991,7 +991,7 @@ static const fe d = {-10913610, 13857413, -15372611, 6949391,   114729,
 static const fe sqrtm1 = {-32595792, -7943725,  9377950,  3500415, 12389472,
                           -272473,   -25146209, -2005654, 326686,  11406482};
 
-int x25519_ge_frombytes_vartime(ge_p3 *h, const uint8_t *s) {
+static int x25519_ge_frombytes_vartime(ge_p3 *h, const uint8_t *s) {
   fe u;
   fe v;
   fe v3;
@@ -1047,13 +1047,6 @@ static void ge_p3_0(ge_p3 *h) {
   fe_0(h->T);
 }
 
-static void ge_cached_0(ge_cached *h) {
-  fe_1(h->YplusX);
-  fe_1(h->YminusX);
-  fe_1(h->Z);
-  fe_0(h->T2d);
-}
-
 static void ge_precomp_0(ge_precomp *h) {
   fe_1(h->yplusx);
   fe_1(h->yminusx);
@@ -1071,7 +1064,7 @@ static const fe d2 = {-21827239, -5839606,  -30745221, 13898782, 229458,
                       15978800,  -12551817, -6495438,  29715968, 9444199};
 
 /* r = p */
-void x25519_ge_p3_to_cached(ge_cached *r, const ge_p3 *p) {
+static void x25519_ge_p3_to_cached(ge_cached *r, const ge_p3 *p) {
   fe_add(r->YplusX, p->Y, p->X);
   fe_sub(r->YminusX, p->Y, p->X);
   fe_copy(r->Z, p->Z);
@@ -1079,25 +1072,18 @@ void x25519_ge_p3_to_cached(ge_cached *r, const ge_p3 *p) {
 }
 
 /* r = p */
-void x25519_ge_p1p1_to_p2(ge_p2 *r, const ge_p1p1 *p) {
+static void x25519_ge_p1p1_to_p2(ge_p2 *r, const ge_p1p1 *p) {
   fe_mul(r->X, p->X, p->T);
   fe_mul(r->Y, p->Y, p->Z);
   fe_mul(r->Z, p->Z, p->T);
 }
 
 /* r = p */
-void x25519_ge_p1p1_to_p3(ge_p3 *r, const ge_p1p1 *p) {
+static void x25519_ge_p1p1_to_p3(ge_p3 *r, const ge_p1p1 *p) {
   fe_mul(r->X, p->X, p->T);
   fe_mul(r->Y, p->Y, p->Z);
   fe_mul(r->Z, p->Z, p->T);
   fe_mul(r->T, p->X, p->Y);
-}
-
-/* r = p */
-static void ge_p1p1_to_cached(ge_cached *r, const ge_p1p1 *p) {
-  ge_p3 t;
-  x25519_ge_p1p1_to_p3(&t, p);
-  x25519_ge_p3_to_cached(r, &t);
 }
 
 /* r = 2 * p */
@@ -1155,7 +1141,7 @@ static void ge_msub(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q) {
 }
 
 /* r = p + q */
-void x25519_ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q) {
+static void x25519_ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q) {
   fe t0;
 
   fe_add(r->X, p->Y, p->X);
@@ -1172,7 +1158,7 @@ void x25519_ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q) {
 }
 
 /* r = p - q */
-void x25519_ge_sub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q) {
+static void x25519_ge_sub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q) {
   fe t0;
 
   fe_add(r->X, p->Y, p->X);
@@ -1204,7 +1190,9 @@ static void cmov(ge_precomp *t, const ge_precomp *u, uint8_t b) {
   fe_cmov(t->xy2d, u->xy2d, b);
 }
 
-void x25519_ge_scalarmult_small_precomp(
+#if defined(OPENSSL_SMALL)
+
+static void x25519_ge_scalarmult_small_precomp(
     ge_p3 *h, const uint8_t a[32], const uint8_t precomp_table[15 * 2 * 32]) {
   /* precomp_table is first expanded into matching |ge_precomp|
    * elements. */
@@ -1255,8 +1243,6 @@ void x25519_ge_scalarmult_small_precomp(
     x25519_ge_p1p1_to_p3(h, &r);
   }
 }
-
-#if defined(OPENSSL_SMALL)
 
 /* This block of code replaces the standard base-point table with a much smaller
  * one. The standard table is 30,720 bytes while this one is just 960.
@@ -1349,7 +1335,7 @@ static const uint8_t k25519SmallPrecomp[15 * 2 * 32] = {
     0x45, 0xc9, 0x8b, 0x17, 0x79, 0xe7, 0xc7, 0x90, 0x99, 0x3a, 0x18, 0x25,
 };
 
-void x25519_ge_scalarmult_base(ge_p3 *h, const uint8_t a[32]) {
+static void x25519_ge_scalarmult_base(ge_p3 *h, const uint8_t a[32]) {
   x25519_ge_scalarmult_small_precomp(h, a, k25519SmallPrecomp);
 }
 
@@ -3503,7 +3489,7 @@ static void table_select(ge_precomp *t, int pos, signed char b) {
  *
  * Preconditions:
  *   a[31] <= 127 */
-void x25519_ge_scalarmult_base(ge_p3 *h, const uint8_t *a) {
+static void x25519_ge_scalarmult_base(ge_p3 *h, const uint8_t *a) {
   signed char e[64];
   signed char carry;
   ge_p1p1 r;
@@ -3552,67 +3538,6 @@ void x25519_ge_scalarmult_base(ge_p3 *h, const uint8_t *a) {
 }
 
 #endif
-
-static void cmov_cached(ge_cached *t, ge_cached *u, uint8_t b) {
-  fe_cmov(t->YplusX, u->YplusX, b);
-  fe_cmov(t->YminusX, u->YminusX, b);
-  fe_cmov(t->Z, u->Z, b);
-  fe_cmov(t->T2d, u->T2d, b);
-}
-
-/* r = scalar * A.
- * where a = a[0]+256*a[1]+...+256^31 a[31]. */
-void x25519_ge_scalarmult(ge_p2 *r, const uint8_t *scalar, const ge_p3 *A) {
-  ge_p2 Ai_p2[8];
-  ge_cached Ai[16];
-  ge_p1p1 t;
-
-  ge_cached_0(&Ai[0]);
-  x25519_ge_p3_to_cached(&Ai[1], A);
-  ge_p3_to_p2(&Ai_p2[1], A);
-
-  unsigned i;
-  for (i = 2; i < 16; i += 2) {
-    ge_p2_dbl(&t, &Ai_p2[i / 2]);
-    ge_p1p1_to_cached(&Ai[i], &t);
-    if (i < 8) {
-      x25519_ge_p1p1_to_p2(&Ai_p2[i], &t);
-    }
-    x25519_ge_add(&t, A, &Ai[i]);
-    ge_p1p1_to_cached(&Ai[i + 1], &t);
-    if (i < 7) {
-      x25519_ge_p1p1_to_p2(&Ai_p2[i + 1], &t);
-    }
-  }
-
-  ge_p2_0(r);
-  ge_p3 u;
-
-  for (i = 0; i < 256; i += 4) {
-    ge_p2_dbl(&t, r);
-    x25519_ge_p1p1_to_p2(r, &t);
-    ge_p2_dbl(&t, r);
-    x25519_ge_p1p1_to_p2(r, &t);
-    ge_p2_dbl(&t, r);
-    x25519_ge_p1p1_to_p2(r, &t);
-    ge_p2_dbl(&t, r);
-    x25519_ge_p1p1_to_p3(&u, &t);
-
-    uint8_t index = scalar[31 - i/8];
-    index >>= 4 - (i & 4);
-    index &= 0xf;
-
-    unsigned j;
-    ge_cached selected;
-    ge_cached_0(&selected);
-    for (j = 0; j < 16; j++) {
-      cmov_cached(&selected, &Ai[j], equal(j, index));
-    }
-
-    x25519_ge_add(&t, &u, &selected);
-    x25519_ge_p1p1_to_p2(r, &t);
-  }
-}
 
 static void slide(signed char *r, const uint8_t *a) {
   int i;
@@ -3798,7 +3723,7 @@ static void ge_double_scalarmult_vartime(ge_p2 *r, const uint8_t *a,
  *   s[0]+256*s[1]+...+256^31*s[31] = s mod l
  *   where l = 2^252 + 27742317777372353535851937790883648493.
  *   Overwrites s in place. */
-void x25519_sc_reduce(uint8_t *s) {
+static void x25519_sc_reduce(uint8_t *s) {
   int64_t s0 = 2097151 & load_3(s);
   int64_t s1 = 2097151 & (load_4(s + 2) >> 5);
   int64_t s2 = 2097151 & (load_3(s + 5) >> 2);
@@ -4632,7 +4557,7 @@ int GFp_ed25519_verify(const uint8_t *message, size_t message_len,
 
 void GFp_ed25519_public_from_private(uint8_t out[32], const uint8_t in[32]) {
   uint8_t az[SHA512_DIGEST_LENGTH];
-  SHA512_4(az, sizeof(az), in, 32, NULL, 0, NULL, 0, NULL, 0);
+  GFp_SHA512_4(az, sizeof(az), in, 32, NULL, 0, NULL, 0, NULL, 0);
 
   az[0] &= 248;
   az[31] &= 63;
@@ -4646,15 +4571,15 @@ void GFp_ed25519_public_from_private(uint8_t out[32], const uint8_t in[32]) {
 void GFp_ed25519_sign(uint8_t *out_sig, const uint8_t *message,
                       size_t message_len, const uint8_t private_key[64]) {
   uint8_t az[SHA512_DIGEST_LENGTH];
-  SHA512_4(az, sizeof(az), private_key, 32, NULL, 0, NULL, 0, NULL, 0);
+  GFp_SHA512_4(az, sizeof(az), private_key, 32, NULL, 0, NULL, 0, NULL, 0);
 
   az[0] &= 248;
   az[31] &= 63;
   az[31] |= 64;
 
   uint8_t nonce[SHA512_DIGEST_LENGTH];
-  SHA512_4(nonce, sizeof(nonce), az + 32, 32, message, message_len, NULL, 0,
-           NULL, 0);
+  GFp_SHA512_4(nonce, sizeof(nonce), az + 32, 32, message, message_len, NULL, 0,
+               NULL, 0);
 
   x25519_sc_reduce(nonce);
   ge_p3 R;
@@ -4662,8 +4587,8 @@ void GFp_ed25519_sign(uint8_t *out_sig, const uint8_t *message,
   ge_p3_tobytes(out_sig, &R);
 
   uint8_t hram[SHA512_DIGEST_LENGTH];
-  SHA512_4(hram, sizeof(hram), out_sig, 32, private_key + 32, 32, message,
-           message_len, NULL, 0);
+  GFp_SHA512_4(hram, sizeof(hram), out_sig, 32, private_key + 32, 32, message,
+               message_len, NULL, 0);
 
   x25519_sc_reduce(hram);
   sc_muladd(out_sig + 32, hram, az, nonce);
@@ -4689,8 +4614,8 @@ int GFp_ed25519_verify(const uint8_t *message, size_t message_len,
   memcpy(scopy, signature + 32, 32);
 
   uint8_t h[SHA512_DIGEST_LENGTH];
-  SHA512_4(h, sizeof(h), signature, 32, public_key, 32, message, message_len,
-           NULL, 0);
+  GFp_SHA512_4(h, sizeof(h), signature, 32, public_key, 32, message,
+               message_len, NULL, 0);
 
   x25519_sc_reduce(h);
 
@@ -4708,7 +4633,7 @@ int GFp_ed25519_verify(const uint8_t *message, size_t message_len,
 
 static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
                                const uint8_t point[32]) {
-  x25519_x86_64(out, scalar, point);
+  GFp_x25519_x86_64(out, scalar, point);
 }
 
 #else
@@ -4847,7 +4772,7 @@ static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
                                const uint8_t point[32]) {
 #if defined(BORINGSSL_X25519_NEON)
   if (GFp_is_NEON_capable()) {
-    x25519_NEON(out, scalar, point);
+    GFp_x25519_NEON(out, scalar, point);
     return;
   }
 #endif
@@ -4893,7 +4818,7 @@ void GFp_x25519_public_from_private(uint8_t out_public_value[32],
 #if defined(BORINGSSL_X25519_NEON)
   if (GFp_is_NEON_capable()) {
     static const uint8_t kMongomeryBasePoint[32] = {9};
-    x25519_NEON(out_public_value, private_key, kMongomeryBasePoint);
+    GFp_x25519_NEON(out_public_value, private_key, kMongomeryBasePoint);
     return;
   }
 #endif

--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -732,7 +732,7 @@ static int fe_isnonzero(const fe f) {
   fe_tobytes(s, f);
 
   static const uint8_t zero[32] = {0};
-  return CRYPTO_memcmp(s, zero, sizeof(zero)) != 0;
+  return GFp_memcmp(s, zero, sizeof(zero)) != 0;
 }
 
 /* return 1 if f is in {1,3,5,...,q-2}
@@ -4700,7 +4700,7 @@ int GFp_ed25519_verify(const uint8_t *message, size_t message_len,
   uint8_t rcheck[32];
   x25519_ge_tobytes(rcheck, &R);
 
-  return CRYPTO_memcmp(rcheck, rcopy, sizeof(rcheck)) == 0;
+  return GFp_memcmp(rcheck, rcopy, sizeof(rcheck)) == 0;
 }
 
 
@@ -4846,7 +4846,7 @@ static void x25519_scalar_mult_generic(uint8_t out[32],
 static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
                                const uint8_t point[32]) {
 #if defined(BORINGSSL_X25519_NEON)
-  if (CRYPTO_is_NEON_capable()) {
+  if (GFp_is_NEON_capable()) {
     x25519_NEON(out, scalar, point);
     return;
   }
@@ -4871,7 +4871,7 @@ int GFp_x25519_ecdh(uint8_t out_shared_key[32], const uint8_t private_key[32],
   static const uint8_t kZeros[32] = {0};
   x25519_scalar_mult(out_shared_key, private_key, peer_public_value);
   /* The all-zero output results when the input is a point of small order. */
-  return CRYPTO_memcmp(kZeros, out_shared_key, 32) != 0;
+  return GFp_memcmp(kZeros, out_shared_key, 32) != 0;
 }
 
 #if defined(BORINGSSL_X25519_X86_64)
@@ -4891,7 +4891,7 @@ void GFp_x25519_public_from_private(uint8_t out_public_value[32],
 void GFp_x25519_public_from_private(uint8_t out_public_value[32],
                                     const uint8_t private_key[32]) {
 #if defined(BORINGSSL_X25519_NEON)
-  if (CRYPTO_is_NEON_capable()) {
+  if (GFp_is_NEON_capable()) {
     static const uint8_t kMongomeryBasePoint[32] = {9};
     x25519_NEON(out_public_value, private_key, kMongomeryBasePoint);
     return;

--- a/crypto/curve25519/internal.h
+++ b/crypto/curve25519/internal.h
@@ -29,8 +29,8 @@ extern "C" {
     !defined(OPENSSL_WINDOWS) && !defined(OPENSSL_NO_ASM)
 #define BORINGSSL_X25519_X86_64
 
-void x25519_x86_64(uint8_t out[32], const uint8_t scalar[32],
-                   const uint8_t point[32]);
+void GFp_x25519_x86_64(uint8_t out[32], const uint8_t scalar[32],
+                       const uint8_t point[32]);
 #endif
 
 
@@ -38,8 +38,8 @@ void x25519_x86_64(uint8_t out[32], const uint8_t scalar[32],
 #define BORINGSSL_X25519_NEON
 
 /* x25519_NEON is defined in asm/x25519-arm.S. */
-void x25519_NEON(uint8_t out[32], const uint8_t scalar[32],
-                 const uint8_t point[32]);
+void GFp_x25519_NEON(uint8_t out[32], const uint8_t scalar[32],
+                     const uint8_t point[32]);
 #endif
 
 /* fe means field element. Here the field is \Z/(2^255-19). An element t,
@@ -92,19 +92,6 @@ typedef struct {
   fe Z;
   fe T2d;
 } ge_cached;
-
-void x25519_ge_tobytes(uint8_t *s, const ge_p2 *h);
-int x25519_ge_frombytes_vartime(ge_p3 *h, const uint8_t *s);
-void x25519_ge_p3_to_cached(ge_cached *r, const ge_p3 *p);
-void x25519_ge_p1p1_to_p2(ge_p2 *r, const ge_p1p1 *p);
-void x25519_ge_p1p1_to_p3(ge_p3 *r, const ge_p1p1 *p);
-void x25519_ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
-void x25519_ge_sub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
-void x25519_ge_scalarmult_small_precomp(
-    ge_p3 *h, const uint8_t a[32], const uint8_t precomp_table[15 * 2 * 32]);
-void x25519_ge_scalarmult_base(ge_p3 *h, const uint8_t a[32]);
-void x25519_ge_scalarmult(ge_p2 *r, const uint8_t *scalar, const ge_p3 *A);
-void x25519_sc_reduce(uint8_t *s);
 
 
 #if defined(__cplusplus)

--- a/crypto/curve25519/x25519-x86_64.c
+++ b/crypto/curve25519/x25519-x86_64.c
@@ -29,11 +29,11 @@
 typedef struct { uint64_t v[5]; } fe25519;
 
 /* These functions are defined in asm/x25519-x86_64.S */
-void x25519_x86_64_work_cswap(fe25519 *, uint64_t);
-void x25519_x86_64_mul(fe25519 *out, const fe25519 *a, const fe25519 *b);
-void x25519_x86_64_square(fe25519 *out, const fe25519 *a);
-void x25519_x86_64_freeze(fe25519 *);
-void x25519_x86_64_ladderstep(fe25519 *work);
+void GFp_x25519_x86_64_work_cswap(fe25519 *, uint64_t);
+void GFp_x25519_x86_64_mul(fe25519 *out, const fe25519 *a, const fe25519 *b);
+void GFp_x25519_x86_64_square(fe25519 *out, const fe25519 *a);
+void GFp_x25519_x86_64_freeze(fe25519 *);
+void GFp_x25519_x86_64_ladderstep(fe25519 *work);
 
 static void fe25519_setint(fe25519 *r, unsigned v) {
   r->v[0] = v;
@@ -47,7 +47,7 @@ static void fe25519_setint(fe25519 *r, unsigned v) {
 static void fe25519_pack(unsigned char r[32], const fe25519 *x) {
   fe25519 t;
   t = *x;
-  x25519_x86_64_freeze(&t);
+  GFp_x25519_x86_64_freeze(&t);
 
   r[0] = (uint8_t)(t.v[0] & 0xff);
   r[1] = (uint8_t)((t.v[0] >> 8) & 0xff);
@@ -146,52 +146,52 @@ static void fe25519_invert(fe25519 *r, const fe25519 *x) {
   fe25519 t;
   int i;
 
-  /* 2 */ x25519_x86_64_square(&z2, x);
-  /* 4 */ x25519_x86_64_square(&t, &z2);
-  /* 8 */ x25519_x86_64_square(&t, &t);
-  /* 9 */ x25519_x86_64_mul(&z9, &t, x);
-  /* 11 */ x25519_x86_64_mul(&z11, &z9, &z2);
-  /* 22 */ x25519_x86_64_square(&t, &z11);
-  /* 2^5 - 2^0 = 31 */ x25519_x86_64_mul(&z2_5_0, &t, &z9);
+  /* 2 */ GFp_x25519_x86_64_square(&z2, x);
+  /* 4 */ GFp_x25519_x86_64_square(&t, &z2);
+  /* 8 */ GFp_x25519_x86_64_square(&t, &t);
+  /* 9 */ GFp_x25519_x86_64_mul(&z9, &t, x);
+  /* 11 */ GFp_x25519_x86_64_mul(&z11, &z9, &z2);
+  /* 22 */ GFp_x25519_x86_64_square(&t, &z11);
+  /* 2^5 - 2^0 = 31 */ GFp_x25519_x86_64_mul(&z2_5_0, &t, &z9);
 
-  /* 2^6 - 2^1 */ x25519_x86_64_square(&t, &z2_5_0);
-  /* 2^20 - 2^10 */ for (i = 1; i < 5; i++) { x25519_x86_64_square(&t, &t); }
-  /* 2^10 - 2^0 */ x25519_x86_64_mul(&z2_10_0, &t, &z2_5_0);
+  /* 2^6 - 2^1 */ GFp_x25519_x86_64_square(&t, &z2_5_0);
+  /* 2^20 - 2^10 */ for (i = 1; i < 5; i++) { GFp_x25519_x86_64_square(&t, &t); }
+  /* 2^10 - 2^0 */ GFp_x25519_x86_64_mul(&z2_10_0, &t, &z2_5_0);
 
-  /* 2^11 - 2^1 */ x25519_x86_64_square(&t, &z2_10_0);
-  /* 2^20 - 2^10 */ for (i = 1; i < 10; i++) { x25519_x86_64_square(&t, &t); }
-  /* 2^20 - 2^0 */ x25519_x86_64_mul(&z2_20_0, &t, &z2_10_0);
+  /* 2^11 - 2^1 */ GFp_x25519_x86_64_square(&t, &z2_10_0);
+  /* 2^20 - 2^10 */ for (i = 1; i < 10; i++) { GFp_x25519_x86_64_square(&t, &t); }
+  /* 2^20 - 2^0 */ GFp_x25519_x86_64_mul(&z2_20_0, &t, &z2_10_0);
 
-  /* 2^21 - 2^1 */ x25519_x86_64_square(&t, &z2_20_0);
-  /* 2^40 - 2^20 */ for (i = 1; i < 20; i++) { x25519_x86_64_square(&t, &t); }
-  /* 2^40 - 2^0 */ x25519_x86_64_mul(&t, &t, &z2_20_0);
+  /* 2^21 - 2^1 */ GFp_x25519_x86_64_square(&t, &z2_20_0);
+  /* 2^40 - 2^20 */ for (i = 1; i < 20; i++) { GFp_x25519_x86_64_square(&t, &t); }
+  /* 2^40 - 2^0 */ GFp_x25519_x86_64_mul(&t, &t, &z2_20_0);
 
-  /* 2^41 - 2^1 */ x25519_x86_64_square(&t, &t);
-  /* 2^50 - 2^10 */ for (i = 1; i < 10; i++) { x25519_x86_64_square(&t, &t); }
-  /* 2^50 - 2^0 */ x25519_x86_64_mul(&z2_50_0, &t, &z2_10_0);
+  /* 2^41 - 2^1 */ GFp_x25519_x86_64_square(&t, &t);
+  /* 2^50 - 2^10 */ for (i = 1; i < 10; i++) { GFp_x25519_x86_64_square(&t, &t); }
+  /* 2^50 - 2^0 */ GFp_x25519_x86_64_mul(&z2_50_0, &t, &z2_10_0);
 
-  /* 2^51 - 2^1 */ x25519_x86_64_square(&t, &z2_50_0);
-  /* 2^100 - 2^50 */ for (i = 1; i < 50; i++) { x25519_x86_64_square(&t, &t); }
-  /* 2^100 - 2^0 */ x25519_x86_64_mul(&z2_100_0, &t, &z2_50_0);
+  /* 2^51 - 2^1 */ GFp_x25519_x86_64_square(&t, &z2_50_0);
+  /* 2^100 - 2^50 */ for (i = 1; i < 50; i++) { GFp_x25519_x86_64_square(&t, &t); }
+  /* 2^100 - 2^0 */ GFp_x25519_x86_64_mul(&z2_100_0, &t, &z2_50_0);
 
-  /* 2^101 - 2^1 */ x25519_x86_64_square(&t, &z2_100_0);
+  /* 2^101 - 2^1 */ GFp_x25519_x86_64_square(&t, &z2_100_0);
   /* 2^200 - 2^100 */ for (i = 1; i < 100; i++) {
-    x25519_x86_64_square(&t, &t);
+    GFp_x25519_x86_64_square(&t, &t);
   }
-  /* 2^200 - 2^0 */ x25519_x86_64_mul(&t, &t, &z2_100_0);
+  /* 2^200 - 2^0 */ GFp_x25519_x86_64_mul(&t, &t, &z2_100_0);
 
-  /* 2^201 - 2^1 */ x25519_x86_64_square(&t, &t);
-  /* 2^250 - 2^50 */ for (i = 1; i < 50; i++) { x25519_x86_64_square(&t, &t); }
-  /* 2^250 - 2^0 */ x25519_x86_64_mul(&t, &t, &z2_50_0);
+  /* 2^201 - 2^1 */ GFp_x25519_x86_64_square(&t, &t);
+  /* 2^250 - 2^50 */ for (i = 1; i < 50; i++) { GFp_x25519_x86_64_square(&t, &t); }
+  /* 2^250 - 2^0 */ GFp_x25519_x86_64_mul(&t, &t, &z2_50_0);
 
-  /* 2^251 - 2^1 */ x25519_x86_64_square(&t, &t);
-  /* 2^252 - 2^2 */ x25519_x86_64_square(&t, &t);
-  /* 2^253 - 2^3 */ x25519_x86_64_square(&t, &t);
+  /* 2^251 - 2^1 */ GFp_x25519_x86_64_square(&t, &t);
+  /* 2^252 - 2^2 */ GFp_x25519_x86_64_square(&t, &t);
+  /* 2^253 - 2^3 */ GFp_x25519_x86_64_square(&t, &t);
 
-  /* 2^254 - 2^4 */ x25519_x86_64_square(&t, &t);
+  /* 2^254 - 2^4 */ GFp_x25519_x86_64_square(&t, &t);
 
-  /* 2^255 - 2^5 */ x25519_x86_64_square(&t, &t);
-  /* 2^255 - 21 */ x25519_x86_64_mul(r, &t, &z11);
+  /* 2^255 - 2^5 */ GFp_x25519_x86_64_square(&t, &t);
+  /* 2^255 - 21 */ GFp_x25519_x86_64_mul(r, &t, &z11);
 }
 
 static void mladder(fe25519 *xr, fe25519 *zr, const uint8_t s[32]) {
@@ -212,8 +212,8 @@ static void mladder(fe25519 *xr, fe25519 *zr, const uint8_t s[32]) {
       const uint8_t bit = 1 & (s[i] >> j);
       const uint64_t swap = bit ^ prevbit;
       prevbit = bit;
-      x25519_x86_64_work_cswap(work + 1, swap);
-      x25519_x86_64_ladderstep(work);
+      GFp_x25519_x86_64_work_cswap(work + 1, swap);
+      GFp_x25519_x86_64_ladderstep(work);
       j -= 1;
     }
     j = 7;
@@ -223,8 +223,8 @@ static void mladder(fe25519 *xr, fe25519 *zr, const uint8_t s[32]) {
   *zr = work[2];
 }
 
-void x25519_x86_64(uint8_t out[32], const uint8_t scalar[32],
-                  const uint8_t point[32]) {
+void GFp_x25519_x86_64(uint8_t out[32], const uint8_t scalar[32],
+                       const uint8_t point[32]) {
   uint8_t e[32];
   memcpy(e, scalar, sizeof(e));
 
@@ -237,7 +237,7 @@ void x25519_x86_64(uint8_t out[32], const uint8_t scalar[32],
   fe25519_unpack(&t, point);
   mladder(&t, &z, e);
   fe25519_invert(&z, &z);
-  x25519_x86_64_mul(&t, &t, &z);
+  GFp_x25519_x86_64_mul(&t, &t, &z);
   fe25519_pack(out, &t);
 }
 

--- a/crypto/ec/asm/ecp_nistz256-armv4.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv4.pl
@@ -92,12 +92,12 @@ __ecp_nistz256_mul_by_2:
 	b	.Lreduce_by_sub
 .size	__ecp_nistz256_mul_by_2,.-__ecp_nistz256_mul_by_2
 
-@ void	ecp_nistz256_add(BN_ULONG r0[8],const BN_ULONG r1[8],
+@ void	GFp_nistz256_add(BN_ULONG r0[8],const BN_ULONG r1[8],
 @					const BN_ULONG r2[8]);
-.globl	ecp_nistz256_add
-.type	ecp_nistz256_add,%function
+.globl	GFp_nistz256_add
+.type	GFp_nistz256_add,%function
 .align	4
-ecp_nistz256_add:
+GFp_nistz256_add:
 	stmdb	sp!,{r4-r12,lr}
 	bl	__ecp_nistz256_add
 #if __ARM_ARCH__>=5 || !defined(__thumb__)
@@ -106,7 +106,7 @@ ecp_nistz256_add:
 	ldmia	sp!,{r4-r12,lr}
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	ecp_nistz256_add,.-ecp_nistz256_add
+.size	GFp_nistz256_add,.-GFp_nistz256_add
 
 .type	__ecp_nistz256_add,%function
 .align	4
@@ -363,11 +363,11 @@ __ecp_nistz256_sub:
 	mov	pc,lr
 .size	__ecp_nistz256_sub,.-__ecp_nistz256_sub
 
-@ void	ecp_nistz256_neg(BN_ULONG r0[8],const BN_ULONG r1[8]);
-.globl	ecp_nistz256_neg
-.type	ecp_nistz256_neg,%function
+@ void	GFp_nistz256_neg(BN_ULONG r0[8],const BN_ULONG r1[8]);
+.globl	GFp_nistz256_neg
+.type	GFp_nistz256_neg,%function
 .align	4
-ecp_nistz256_neg:
+GFp_nistz256_neg:
 	stmdb	sp!,{r4-r12,lr}
 	bl	__ecp_nistz256_neg
 #if __ARM_ARCH__>=5 || !defined(__thumb__)
@@ -376,7 +376,7 @@ ecp_nistz256_neg:
 	ldmia	sp!,{r4-r12,lr}
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	ecp_nistz256_neg,.-ecp_nistz256_neg
+.size	GFp_nistz256_neg,.-GFp_nistz256_neg
 
 .type	__ecp_nistz256_neg,%function
 .align	4
@@ -408,13 +408,12 @@ my @acc=map("r$_",(3..11));
 my ($t0,$t1,$bj,$t2,$t3)=map("r$_",(0,1,2,12,14));
 
 $code.=<<___;
-@ void	ecp_nistz256_mul_mont(BN_ULONG r0[8],const BN_ULONG r1[8],
+@ void	GFp_nistz256_mul_mont(BN_ULONG r0[8],const BN_ULONG r1[8],
 @					     const BN_ULONG r2[8]);
-.globl	ecp_nistz256_mul_mont
-.type	ecp_nistz256_mul_mont,%function
+.globl	GFp_nistz256_mul_mont
+.type	GFp_nistz256_mul_mont,%function
 .align	4
-ecp_nistz256_mul_mont:
-.Lecp_nistz256_mul_mont:
+GFp_nistz256_mul_mont:
 	stmdb	sp!,{r4-r12,lr}
 	bl	__ecp_nistz256_mul_mont
 #if __ARM_ARCH__>=5 || !defined(__thumb__)
@@ -423,7 +422,7 @@ ecp_nistz256_mul_mont:
 	ldmia	sp!,{r4-r12,lr}
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	ecp_nistz256_mul_mont,.-ecp_nistz256_mul_mont
+.size	GFp_nistz256_mul_mont,.-GFp_nistz256_mul_mont
 
 .type	__ecp_nistz256_mul_mont,%function
 .align	4
@@ -618,7 +617,6 @@ $code.=<<___;
 #if __ARM_ARCH__>=7
 .fpu	neon
 
-.globl	ecp_nistz256_mul_mont_neon
 .type	ecp_nistz256_mul_mont_neon,%function
 .align	5
 ecp_nistz256_mul_mont_neon:
@@ -904,10 +902,10 @@ my ($S,$M,$Zsqr,$in_x,$tmp0)=map(32*$_,(0..4));
 # input arguments just below these temporary vectors.
 
 $code.=<<___;
-.globl	ecp_nistz256_point_double
-.type	ecp_nistz256_point_double,%function
+.globl	GFp_nistz256_point_double
+.type	GFp_nistz256_point_double,%function
 .align	5
-ecp_nistz256_point_double:
+GFp_nistz256_point_double:
 	stmdb	sp!,{r0-r12,lr}		@ push from r0, unusual, but intentional
 	sub	sp,sp,#32*5
 
@@ -1004,12 +1002,12 @@ ecp_nistz256_point_double:
 	ldmia	sp!,{r4-r12,lr}
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	ecp_nistz256_point_double,.-ecp_nistz256_point_double
+.size	GFp_nistz256_point_double,.-GFp_nistz256_point_double
 ___
 }
 
 ########################################################################
-# void ecp_nistz256_point_add(P256_POINT *out,const P256_POINT *in1,
+# void GFp_nistz256_point_add(P256_POINT *out,const P256_POINT *in1,
 #			      const P256_POINT *in2);
 {
 my ($res_x,$res_y,$res_z,
@@ -1026,10 +1024,10 @@ my ($Z1sqr, $Z2sqr) = ($Hsqr, $Rsqr);
 # result of check for zero.
 
 $code.=<<___;
-.globl	ecp_nistz256_point_add
-.type	ecp_nistz256_point_add,%function
+.globl	GFp_nistz256_point_add
+.type	GFp_nistz256_point_add,%function
 .align	5
-ecp_nistz256_point_add:
+GFp_nistz256_point_add:
 	stmdb	sp!,{r0-r12,lr}		@ push from r0, unusual, but intentional
 	sub	sp,sp,#32*18+16
 
@@ -1283,12 +1281,12 @@ $code.=<<___;
 	ldmia	sp!,{r4-r12,lr}
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	ecp_nistz256_point_add,.-ecp_nistz256_point_add
+.size	GFp_nistz256_point_add,.-GFp_nistz256_point_add
 ___
 }
 
 ########################################################################
-# void ecp_nistz256_point_add_affine(P256_POINT *out,const P256_POINT *in1,
+# void GFp_nistz256_point_add_affine(P256_POINT *out,const P256_POINT *in1,
 #				     const P256_POINT_AFFINE *in2);
 {
 my ($res_x,$res_y,$res_z,
@@ -1305,10 +1303,10 @@ my $Z1sqr = $S2;
 my @ONE_mont=(1,0,0,-1,-1,-1,-2,0);
 
 $code.=<<___;
-.globl	ecp_nistz256_point_add_affine
-.type	ecp_nistz256_point_add_affine,%function
+.globl	GFp_nistz256_point_add_affine
+.type	GFp_nistz256_point_add_affine,%function
 .align	5
-ecp_nistz256_point_add_affine:
+GFp_nistz256_point_add_affine:
 	stmdb	sp!,{r0-r12,lr}		@ push from r0, unusual, but intentional
 	sub	sp,sp,#32*15
 
@@ -1503,7 +1501,7 @@ $code.=<<___;
 	ldmia	sp!,{r4-r12,lr}
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	ecp_nistz256_point_add_affine,.-ecp_nistz256_point_add_affine
+.size	GFp_nistz256_point_add_affine,.-GFp_nistz256_point_add_affine
 ___
 }					}}}
 

--- a/crypto/ec/asm/ecp_nistz256-armv8.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv8.pl
@@ -56,12 +56,12 @@ $code.=<<___;
 .quad	1,0,0,0
 .asciz	"ECP_NISTZ256 for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
 
-// void	ecp_nistz256_mul_mont(BN_ULONG x0[4],const BN_ULONG x1[4],
+// void	GFp_nistz256_mul_mont(BN_ULONG x0[4],const BN_ULONG x1[4],
 //					     const BN_ULONG x2[4]);
-.globl	ecp_nistz256_mul_mont
-.type	ecp_nistz256_mul_mont,%function
+.globl	GFp_nistz256_mul_mont
+.type	GFp_nistz256_mul_mont,%function
 .align	4
-ecp_nistz256_mul_mont:
+GFp_nistz256_mul_mont:
 	stp	x29,x30,[sp,#-32]!
 	add	x29,sp,#0
 	stp	x19,x20,[sp,#16]
@@ -77,13 +77,13 @@ ecp_nistz256_mul_mont:
 	ldp	x19,x20,[sp,#16]
 	ldp	x29,x30,[sp],#32
 	ret
-.size	ecp_nistz256_mul_mont,.-ecp_nistz256_mul_mont
+.size	GFp_nistz256_mul_mont,.-GFp_nistz256_mul_mont
 
-// void	ecp_nistz256_sqr_mont(BN_ULONG x0[4],const BN_ULONG x1[4]);
-.globl	ecp_nistz256_sqr_mont
-.type	ecp_nistz256_sqr_mont,%function
+// void	GFp_nistz256_sqr_mont(BN_ULONG x0[4],const BN_ULONG x1[4]);
+.globl	GFp_nistz256_sqr_mont
+.type	GFp_nistz256_sqr_mont,%function
 .align	4
-ecp_nistz256_sqr_mont:
+GFp_nistz256_sqr_mont:
 	stp	x29,x30,[sp,#-32]!
 	add	x29,sp,#0
 	stp	x19,x20,[sp,#16]
@@ -98,14 +98,14 @@ ecp_nistz256_sqr_mont:
 	ldp	x19,x20,[sp,#16]
 	ldp	x29,x30,[sp],#32
 	ret
-.size	ecp_nistz256_sqr_mont,.-ecp_nistz256_sqr_mont
+.size	GFp_nistz256_sqr_mont,.-GFp_nistz256_sqr_mont
 
-// void	ecp_nistz256_add(BN_ULONG x0[4],const BN_ULONG x1[4],
+// void	GFp_nistz256_add(BN_ULONG x0[4],const BN_ULONG x1[4],
 //					const BN_ULONG x2[4]);
-.globl	ecp_nistz256_add
-.type	ecp_nistz256_add,%function
+.globl	GFp_nistz256_add
+.type	GFp_nistz256_add,%function
 .align	4
-ecp_nistz256_add:
+GFp_nistz256_add:
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
 
@@ -120,13 +120,13 @@ ecp_nistz256_add:
 
 	ldp	x29,x30,[sp],#16
 	ret
-.size	ecp_nistz256_add,.-ecp_nistz256_add
+.size	GFp_nistz256_add,.-GFp_nistz256_add
 
-// void	ecp_nistz256_neg(BN_ULONG x0[4],const BN_ULONG x1[4]);
-.globl	ecp_nistz256_neg
-.type	ecp_nistz256_neg,%function
+// void	GFp_nistz256_neg(BN_ULONG x0[4],const BN_ULONG x1[4]);
+.globl	GFp_nistz256_neg
+.type	GFp_nistz256_neg,%function
 .align	4
-ecp_nistz256_neg:
+GFp_nistz256_neg:
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
 
@@ -142,7 +142,7 @@ ecp_nistz256_neg:
 
 	ldp	x29,x30,[sp],#16
 	ret
-.size	ecp_nistz256_neg,.-ecp_nistz256_neg
+.size	GFp_nistz256_neg,.-GFp_nistz256_neg
 
 // note that __ecp_nistz256_mul_mont expects a[0-3] input pre-loaded
 // to $a0-$a3 and b[0] - to $bi
@@ -488,7 +488,7 @@ ___
 # ecp_nistz256.c
 #
 ########################################################################
-# void ecp_nistz256_point_double(P256_POINT *out,const P256_POINT *inp);
+# void GFp_nistz256_point_double(P256_POINT *out,const P256_POINT *inp);
 #
 {
 my ($S,$M,$Zsqr,$tmp0)=map(32*$_,(0..3));
@@ -497,10 +497,10 @@ my ($S,$M,$Zsqr,$tmp0)=map(32*$_,(0..3));
 my ($rp_real,$ap_real) = map("x$_",(21,22));
 
 $code.=<<___;
-.globl	ecp_nistz256_point_double
-.type	ecp_nistz256_point_double,%function
+.globl	GFp_nistz256_point_double
+.type	GFp_nistz256_point_double,%function
 .align	5
-ecp_nistz256_point_double:
+GFp_nistz256_point_double:
 	stp	x29,x30,[sp,#-80]!
 	add	x29,sp,#0
 	stp	x19,x20,[sp,#16]
@@ -636,12 +636,12 @@ ecp_nistz256_point_double:
 	ldp	x21,x22,[x29,#32]
 	ldp	x29,x30,[sp],#80
 	ret
-.size	ecp_nistz256_point_double,.-ecp_nistz256_point_double
+.size	GFp_nistz256_point_double,.-GFp_nistz256_point_double
 ___
 }
 
 ########################################################################
-# void ecp_nistz256_point_add(P256_POINT *out,const P256_POINT *in1,
+# void GFp_nistz256_point_add(P256_POINT *out,const P256_POINT *in1,
 #			      const P256_POINT *in2);
 {
 my ($res_x,$res_y,$res_z,
@@ -653,10 +653,10 @@ my ($Z1sqr, $Z2sqr) = ($Hsqr, $Rsqr);
 my ($rp_real,$ap_real,$bp_real,$in1infty,$in2infty,$temp)=map("x$_",(21..26));
 
 $code.=<<___;
-.globl	ecp_nistz256_point_add
-.type	ecp_nistz256_point_add,%function
+.globl	GFp_nistz256_point_add
+.type	GFp_nistz256_point_add,%function
 .align	5
-ecp_nistz256_point_add:
+GFp_nistz256_point_add:
 	stp	x29,x30,[sp,#-80]!
 	add	x29,sp,#0
 	stp	x19,x20,[sp,#16]
@@ -919,12 +919,12 @@ $code.=<<___;
 	ldp	x25,x26,[x29,#64]
 	ldp	x29,x30,[sp],#80
 	ret
-.size	ecp_nistz256_point_add,.-ecp_nistz256_point_add
+.size	GFp_nistz256_point_add,.-GFp_nistz256_point_add
 ___
 }
 
 ########################################################################
-# void ecp_nistz256_point_add_affine(P256_POINT *out,const P256_POINT *in1,
+# void GFp_nistz256_point_add_affine(P256_POINT *out,const P256_POINT *in1,
 #				     const P256_POINT_AFFINE *in2);
 {
 my ($res_x,$res_y,$res_z,
@@ -935,10 +935,10 @@ my $Z1sqr = $S2;
 my ($rp_real,$ap_real,$bp_real,$in1infty,$in2infty,$temp)=map("x$_",(21..26));
 
 $code.=<<___;
-.globl	ecp_nistz256_point_add_affine
-.type	ecp_nistz256_point_add_affine,%function
+.globl	GFp_nistz256_point_add_affine
+.type	GFp_nistz256_point_add_affine,%function
 .align	5
-ecp_nistz256_point_add_affine:
+GFp_nistz256_point_add_affine:
 	stp	x29,x30,[sp,#-80]!
 	add	x29,sp,#0
 	stp	x19,x20,[sp,#16]
@@ -1136,7 +1136,7 @@ $code.=<<___;
 	ldp	x25,x26,[x29,#64]
 	ldp	x29,x30,[sp],#80
 	ret
-.size	ecp_nistz256_point_add_affine,.-ecp_nistz256_point_add_affine
+.size	GFp_nistz256_point_add_affine,.-GFp_nistz256_point_add_affine
 ___
 }	}
 

--- a/crypto/ec/asm/ecp_nistz256-x86.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86.pl
@@ -43,7 +43,7 @@ open STDOUT,">$output";
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 
-&external_label("OPENSSL_ia32cap_P") if ($sse2);
+&external_label("GFp_ia32cap_P") if ($sse2);
 
 
 ########################################################################
@@ -334,7 +334,7 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 						if ($sse2) {
 	&call	("_picup_eax");
     &set_label("pic");
-	&picmeup("eax","OPENSSL_ia32cap_P","eax",&label("pic"));
+	&picmeup("eax","GFp_ia32cap_P","eax",&label("pic"));
 	&mov	("eax",&DWP(0,"eax"));		}
 	&mov	("edi",&wparam(0));
 	&call	("_ecp_nistz256_mul_mont");
@@ -961,12 +961,12 @@ for ($i=0;$i<7;$i++) {
 
 	# above map() describes stack layout with 5 temporary
 	# 256-bit vectors on top, then we take extra word for
-	# OPENSSL_ia32cap_P copy.
+	# GFp_ia32cap_P copy.
 	&stack_push(8*5+1);
 						if ($sse2) {
 	&call	("_picup_eax");
     &set_label("pic");
-	&picmeup("edx","OPENSSL_ia32cap_P","eax",&label("pic"));
+	&picmeup("edx","GFp_ia32cap_P","eax",&label("pic"));
 	&mov	("ebp",&DWP(0,"edx"));		}
 
 &set_label("point_double_shortcut");
@@ -986,27 +986,27 @@ for ($i=0;$i<7;$i++) {
 	&mov	(&DWP($in_x+20,"esp"),"ebx");
 	&mov	(&DWP($in_x+24,"esp"),"ecx");
 	&mov	(&DWP($in_x+28,"esp"),"edx");
-	&mov	(&DWP(32*5,"esp"),"ebp");	# OPENSSL_ia32cap_P copy
+	&mov	(&DWP(32*5,"esp"),"ebp");	# GFp_ia32cap_P copy
 
 	&lea	("ebp",&DWP(32,"esi"));
 	&lea	("esi",&DWP(32,"esi"));
 	&lea	("edi",&DWP($S,"esp"));
 	&call	("_ecp_nistz256_add");		# p256_mul_by_2(S, in_y);
 
-	&mov	("eax",&DWP(32*5,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*5,"esp"));	# GFp_ia32cap_P copy
 	&mov	("esi",64);
 	&add	("esi",&wparam(1));
 	&lea	("edi",&DWP($Zsqr,"esp"));
 	&mov	("ebp","esi");
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(Zsqr, in_z);
 
-	&mov	("eax",&DWP(32*5,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*5,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($S,"esp"));
 	&lea	("ebp",&DWP($S,"esp"));
 	&lea	("edi",&DWP($S,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(S, S);
 
-	&mov	("eax",&DWP(32*5,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*5,"esp"));	# GFp_ia32cap_P copy
 	&mov	("ebp",&wparam(1));
 	&lea	("esi",&DWP(32,"ebp"));
 	&lea	("ebp",&DWP(64,"ebp"));
@@ -1029,13 +1029,13 @@ for ($i=0;$i<7;$i++) {
 	&lea	("edi",&DWP($Zsqr,"esp"));
 	&call	("_ecp_nistz256_sub");		# p256_sub(Zsqr, in_x, Zsqr);
 
-	&mov	("eax",&DWP(32*5,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*5,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($S,"esp"));
 	&lea	("ebp",&DWP($S,"esp"));
 	&lea	("edi",&DWP($tmp0,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(tmp0, S);
 
-	&mov	("eax",&DWP(32*5,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*5,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($M,"esp"));
 	&lea	("ebp",&DWP($Zsqr,"esp"));
 	&lea	("edi",&DWP($M,"esp"));
@@ -1051,7 +1051,7 @@ for ($i=0;$i<7;$i++) {
 	&lea	("edi",&DWP($tmp0,"esp"));
 	&call	("_ecp_nistz256_add");		# 1/2 p256_mul_by_3(M, M);
 
-	&mov	("eax",&DWP(32*5,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*5,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in_x,"esp"));
 	&lea	("ebp",&DWP($S,"esp"));
 	&lea	("edi",&DWP($S,"esp"));
@@ -1067,7 +1067,7 @@ for ($i=0;$i<7;$i++) {
 	&lea	("edi",&DWP($tmp0,"esp"));
 	&call	("_ecp_nistz256_add");		# p256_mul_by_2(tmp0, S);
 
-	&mov	("eax",&DWP(32*5,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*5,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($M,"esp"));
 	&lea	("ebp",&DWP($M,"esp"));
 	&mov	("edi",&wparam(0));
@@ -1082,7 +1082,7 @@ for ($i=0;$i<7;$i++) {
 	&lea	("edi",&DWP($S,"esp"));
 	&call	("_ecp_nistz256_sub");		# p256_sub(S, S, res_x);
 
-	&mov	("eax",&DWP(32*5,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*5,"esp"));	# GFp_ia32cap_P copy
 	&mov	("esi","edi");			# %edi is still &S
 	&lea	("ebp",&DWP($M,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(S, S, M);
@@ -1112,12 +1112,12 @@ for ($i=0;$i<7;$i++) {
 	# above map() describes stack layout with 18 temporary
 	# 256-bit vectors on top, then we take extra words for
 	# !in1infty, !in2infty, result of check for zero and
-	# OPENSSL_ia32cap_P copy. [one unused word for padding]
+	# GFp_ia32cap_P copy. [one unused word for padding]
 	&stack_push(8*18+5);
 						if ($sse2) {
 	&call	("_picup_eax");
     &set_label("pic");
-	&picmeup("edx","OPENSSL_ia32cap_P","eax",&label("pic"));
+	&picmeup("edx","GFp_ia32cap_P","eax",&label("pic"));
 	&mov	("ebp",&DWP(0,"edx"));		}
 
 	&lea	("edi",&DWP($in2_x,"esp"));
@@ -1166,37 +1166,37 @@ for ($i=0;$i<7;$i++) {
 	&sar	("ebp",31);
 	&mov	(&DWP(32*18+0,"esp"),"ebp");	# !in1infty
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in2_z,"esp"));
 	&lea	("ebp",&DWP($in2_z,"esp"));
 	&lea	("edi",&DWP($Z2sqr,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(Z2sqr, in2_z);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in1_z,"esp"));
 	&lea	("ebp",&DWP($in1_z,"esp"));
 	&lea	("edi",&DWP($Z1sqr,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(Z1sqr, in1_z);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($Z2sqr,"esp"));
 	&lea	("ebp",&DWP($in2_z,"esp"));
 	&lea	("edi",&DWP($S1,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(S1, Z2sqr, in2_z);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($Z1sqr,"esp"));
 	&lea	("ebp",&DWP($in1_z,"esp"));
 	&lea	("edi",&DWP($S2,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(S2, Z1sqr, in1_z);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in1_y,"esp"));
 	&lea	("ebp",&DWP($S1,"esp"));
 	&lea	("edi",&DWP($S1,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(S1, S1, in1_y);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in2_y,"esp"));
 	&lea	("ebp",&DWP($S2,"esp"));
 	&lea	("edi",&DWP($S2,"esp"));
@@ -1208,7 +1208,7 @@ for ($i=0;$i<7;$i++) {
 	&call	("_ecp_nistz256_sub");		# p256_sub(R, S2, S1);
 
 	&or	("ebx","eax");			# see if result is zero
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&or	("ebx","ecx");
 	&or	("ebx","edx");
 	&or	("ebx",&DWP(0,"edi"));
@@ -1222,7 +1222,7 @@ for ($i=0;$i<7;$i++) {
 
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(U1, in1_x, Z2sqr);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in2_x,"esp"));
 	&lea	("ebp",&DWP($Z1sqr,"esp"));
 	&lea	("edi",&DWP($U2,"esp"));
@@ -1259,42 +1259,42 @@ for ($i=0;$i<7;$i++) {
 
 &set_label("add_double",16);
 	&mov	("esi",&wparam(1));
-	&mov	("ebp",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("ebp",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&add	("esp",4*((8*18+5)-(8*5+1)));	# difference in frame sizes
 	&jmp	(&label("point_double_shortcut"));
 
 &set_label("add_proceed",16);
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($R,"esp"));
 	&lea	("ebp",&DWP($R,"esp"));
 	&lea	("edi",&DWP($Rsqr,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(Rsqr, R);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($H,"esp"));
 	&lea	("ebp",&DWP($in1_z,"esp"));
 	&lea	("edi",&DWP($res_z,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(res_z, H, in1_z);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($H,"esp"));
 	&lea	("ebp",&DWP($H,"esp"));
 	&lea	("edi",&DWP($Hsqr,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(Hsqr, H);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in2_z,"esp"));
 	&lea	("ebp",&DWP($res_z,"esp"));
 	&lea	("edi",&DWP($res_z,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(res_z, res_z, in2_z);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($Hsqr,"esp"));
 	&lea	("ebp",&DWP($U1,"esp"));
 	&lea	("edi",&DWP($U2,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(U2, U1, Hsqr);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($H,"esp"));
 	&lea	("ebp",&DWP($Hsqr,"esp"));
 	&lea	("edi",&DWP($Hcub,"esp"));
@@ -1320,13 +1320,13 @@ for ($i=0;$i<7;$i++) {
 	&lea	("edi",&DWP($res_y,"esp"));
 	&call	("_ecp_nistz256_sub");		# p256_sub(res_y, U2, res_x);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($Hcub,"esp"));
 	&lea	("ebp",&DWP($S1,"esp"));
 	&lea	("edi",&DWP($S2,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(S2, S1, Hcub);
 
-	&mov	("eax",&DWP(32*18+12,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*18+12,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($R,"esp"));
 	&lea	("ebp",&DWP($res_y,"esp"));
 	&lea	("edi",&DWP($res_y,"esp"));
@@ -1391,12 +1391,12 @@ for ($i=0;$i<7;$i++) {
 
 	# above map() describes stack layout with 15 temporary
 	# 256-bit vectors on top, then we take extra words for
-	# !in1infty, !in2infty, and OPENSSL_ia32cap_P copy.
+	# !in1infty, !in2infty, and GFp_ia32cap_P copy.
 	&stack_push(8*15+3);
 						if ($sse2) {
 	&call	("_picup_eax");
     &set_label("pic");
-	&picmeup("edx","OPENSSL_ia32cap_P","eax",&label("pic"));
+	&picmeup("edx","GFp_ia32cap_P","eax",&label("pic"));
 	&mov	("ebp",&DWP(0,"edx"));		}
 
 	&lea	("edi",&DWP($in1_x,"esp"));
@@ -1440,7 +1440,7 @@ for ($i=0;$i<7;$i++) {
 	&or	("ebp","edx");
     }
 	&xor	("ebx","ebx");
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&sub	("ebx","ebp");
 	 &lea	("esi",&DWP($in1_z,"esp"));
 	&or	("ebx","ebp");
@@ -1451,13 +1451,13 @@ for ($i=0;$i<7;$i++) {
 
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(Z1sqr, in1_z);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in2_x,"esp"));
 	&mov	("ebp","edi");			# %esi is stull &Z1sqr
 	&lea	("edi",&DWP($U2,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(U2, Z1sqr, in2_x);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in1_z,"esp"));
 	&lea	("ebp",&DWP($Z1sqr,"esp"));
 	&lea	("edi",&DWP($S2,"esp"));
@@ -1468,13 +1468,13 @@ for ($i=0;$i<7;$i++) {
 	&lea	("edi",&DWP($H,"esp"));
 	&call	("_ecp_nistz256_sub");		# p256_sub(H, U2, in1_x);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in2_y,"esp"));
 	&lea	("ebp",&DWP($S2,"esp"));
 	&lea	("edi",&DWP($S2,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(S2, S2, in2_y);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in1_z,"esp"));
 	&lea	("ebp",&DWP($H,"esp"));
 	&lea	("edi",&DWP($res_z,"esp"));
@@ -1485,25 +1485,25 @@ for ($i=0;$i<7;$i++) {
 	&lea	("edi",&DWP($R,"esp"));
 	&call	("_ecp_nistz256_sub");		# p256_sub(R, S2, in1_y);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($H,"esp"));
 	&lea	("ebp",&DWP($H,"esp"));
 	&lea	("edi",&DWP($Hsqr,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(Hsqr, H);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($R,"esp"));
 	&lea	("ebp",&DWP($R,"esp"));
 	&lea	("edi",&DWP($Rsqr,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_sqr_mont(Rsqr, R);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($in1_x,"esp"));
 	&lea	("ebp",&DWP($Hsqr,"esp"));
 	&lea	("edi",&DWP($U2,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(U2, in1_x, Hsqr);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($H,"esp"));
 	&lea	("ebp",&DWP($Hsqr,"esp"));
 	&lea	("edi",&DWP($Hcub,"esp"));
@@ -1529,13 +1529,13 @@ for ($i=0;$i<7;$i++) {
 	&lea	("edi",&DWP($res_y,"esp"));
 	&call	("_ecp_nistz256_sub");		# p256_sub(res_y, U2, res_x);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($Hcub,"esp"));
 	&lea	("ebp",&DWP($in1_y,"esp"));
 	&lea	("edi",&DWP($S2,"esp"));
 	&call	("_ecp_nistz256_mul_mont");	# p256_mul_mont(S2, Hcub, in1_y);
 
-	&mov	("eax",&DWP(32*15+8,"esp"));	# OPENSSL_ia32cap_P copy
+	&mov	("eax",&DWP(32*15+8,"esp"));	# GFp_ia32cap_P copy
 	&lea	("esi",&DWP($R,"esp"));
 	&lea	("ebp",&DWP($res_y,"esp"));
 	&lea	("edi",&DWP($res_y,"esp"));

--- a/crypto/ec/asm/ecp_nistz256-x86.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86.pl
@@ -156,14 +156,14 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 &function_end_B("_ecp_nistz256_div_by_2");
 
 ########################################################################
-# void ecp_nistz256_add(BN_ULONG edi[8],const BN_ULONG esi[8],
+# void GFp_nistz256_add(BN_ULONG edi[8],const BN_ULONG esi[8],
 #					const BN_ULONG ebp[8]);
-&function_begin("ecp_nistz256_add");
+&function_begin("GFp_nistz256_add");
 	&mov	("esi",&wparam(1));
 	&mov	("ebp",&wparam(2));
 	&mov	("edi",&wparam(0));
 	&call	("_ecp_nistz256_add");
-&function_end("ecp_nistz256_add");
+&function_end("GFp_nistz256_add");
 
 &function_begin_B("_ecp_nistz256_add");
 	&mov	("eax",&DWP(0,"esi"));
@@ -298,8 +298,8 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 &function_end_B("_ecp_nistz256_sub");
 
 ########################################################################
-# void ecp_nistz256_neg(BN_ULONG edi[8],const BN_ULONG esi[8]);
-&function_begin("ecp_nistz256_neg");
+# void GFp_nistz256_neg(BN_ULONG edi[8],const BN_ULONG esi[8]);
+&function_begin("GFp_nistz256_neg");
 	&mov	("ebp",&wparam(1));
 	&mov	("edi",&wparam(0));
 
@@ -318,7 +318,7 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 	&call	("_ecp_nistz256_sub");
 
 	&stack_pop(8);
-&function_end("ecp_nistz256_neg");
+&function_end("GFp_nistz256_neg");
 
 &function_begin_B("_picup_eax");
 	&mov	("eax",&DWP(0,"esp"));
@@ -326,9 +326,9 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 &function_end_B("_picup_eax");
 
 ########################################################################
-# void ecp_nistz256_mul_mont(BN_ULONG edi[8],const BN_ULONG esi[8],
+# void GFp_nistz256_mul_mont(BN_ULONG edi[8],const BN_ULONG esi[8],
 #					     const BN_ULONG ebp[8]);
-&function_begin("ecp_nistz256_mul_mont");
+&function_begin("GFp_nistz256_mul_mont");
 	&mov	("esi",&wparam(1));
 	&mov	("ebp",&wparam(2));
 						if ($sse2) {
@@ -338,7 +338,7 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 	&mov	("eax",&DWP(0,"eax"));		}
 	&mov	("edi",&wparam(0));
 	&call	("_ecp_nistz256_mul_mont");
-&function_end("ecp_nistz256_mul_mont");
+&function_end("GFp_nistz256_mul_mont");
 
 &function_begin_B("_ecp_nistz256_mul_mont");
 						if ($sse2) {
@@ -951,10 +951,10 @@ for ($i=0;$i<7;$i++) {
 # ecp_nistz256.c
 #
 ########################################################################
-# void ecp_nistz256_point_double(P256_POINT *out,const P256_POINT *inp);
+# void GFp_nistz256_point_double(P256_POINT *out,const P256_POINT *inp);
 #
 &static_label("point_double_shortcut");
-&function_begin("ecp_nistz256_point_double");
+&function_begin("GFp_nistz256_point_double");
 {   my ($S,$M,$Zsqr,$in_x,$tmp0)=map(32*$_,(0..4));
 
 	&mov	("esi",&wparam(1));
@@ -1094,12 +1094,12 @@ for ($i=0;$i<7;$i++) {
 	&call	("_ecp_nistz256_sub");		# p256_sub(res_y, S, res_y);
 
 	&stack_pop(8*5+1);
-} &function_end("ecp_nistz256_point_double");
+} &function_end("GFp_nistz256_point_double");
 
 ########################################################################
-# void ecp_nistz256_point_add(P256_POINT *out,const P256_POINT *in1,
+# void GFp_nistz256_point_add(P256_POINT *out,const P256_POINT *in1,
 #					      const P256_POINT *in2);
-&function_begin("ecp_nistz256_point_add");
+&function_begin("GFp_nistz256_point_add");
 {   my ($res_x,$res_y,$res_z,
 	$in1_x,$in1_y,$in1_z,
 	$in2_x,$in2_y,$in2_z,
@@ -1372,13 +1372,13 @@ for ($i=0;$i<7;$i++) {
     }
     &set_label("add_done");
 	&stack_pop(8*18+5);
-} &function_end("ecp_nistz256_point_add");
+} &function_end("GFp_nistz256_point_add");
 
 ########################################################################
-# void ecp_nistz256_point_add_affine(P256_POINT *out,
+# void GFp_nistz256_point_add_affine(P256_POINT *out,
 #				     const P256_POINT *in1,
 #				     const P256_POINT_AFFINE *in2);
-&function_begin("ecp_nistz256_point_add_affine");
+&function_begin("GFp_nistz256_point_add_affine");
 {
     my ($res_x,$res_y,$res_z,
 	$in1_x,$in1_y,$in1_z,
@@ -1582,7 +1582,7 @@ for ($i=0;$i<7;$i++) {
 	&mov	(&DWP($i,"edi"),"eax");
     }
 	&stack_pop(8*15+3);
-} &function_end("ecp_nistz256_point_add_affine");
+} &function_end("GFp_nistz256_point_add_affine");
 
 &asm_finish();
 

--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -87,7 +87,7 @@ $addx=0;
 
 $code.=<<___;
 .text
-.extern	OPENSSL_ia32cap_P
+.extern	GFp_ia32cap_P
 
 # Constants for computations modulo ord(p256)
 .align 64
@@ -117,7 +117,7 @@ GFp_p256_scalar_mul_mont:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
-	and	OPENSSL_ia32cap_P+8(%rip), %ecx
+	and	GFp_ia32cap_P+8(%rip), %ecx
 	cmp	\$0x80100, %ecx
 	je	ecp_nistz256_ord_mul_montx
 ___
@@ -625,7 +625,7 @@ GFp_p256_scalar_sqr_rep_mont:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
-	and	OPENSSL_ia32cap_P+8(%rip), %ecx
+	and	GFp_ia32cap_P+8(%rip), %ecx
 	cmp	\$0x80100, %ecx
 	je	ecp_nistz256_ord_sqr_montx
 ___

--- a/crypto/ec/asm/p256-x86_64-asm.pl
+++ b/crypto/ec/asm/p256-x86_64-asm.pl
@@ -85,11 +85,11 @@ my ($r_ptr,$a_ptr,$b_ptr)=("%rdi","%rsi","%rdx");
 $code.=<<___;
 
 ################################################################################
-# void ecp_nistz256_add(uint64_t res[4], uint64_t a[4], uint64_t b[4]);
-.globl	ecp_nistz256_add
-.type	ecp_nistz256_add,\@function,3
+# void GFp_nistz256_add(uint64_t res[4], uint64_t a[4], uint64_t b[4]);
+.globl	GFp_nistz256_add
+.type	GFp_nistz256_add,\@function,3
 .align	32
-ecp_nistz256_add:
+GFp_nistz256_add:
 	push	%r12
 	push	%r13
 
@@ -128,14 +128,14 @@ ecp_nistz256_add:
 	pop %r13
 	pop %r12
 	ret
-.size	ecp_nistz256_add,.-ecp_nistz256_add
+.size	GFp_nistz256_add,.-GFp_nistz256_add
 
 ################################################################################
-# void ecp_nistz256_neg(uint64_t res[4], uint64_t a[4]);
-.globl	ecp_nistz256_neg
-.type	ecp_nistz256_neg,\@function,2
+# void GFp_nistz256_neg(uint64_t res[4], uint64_t a[4]);
+.globl	GFp_nistz256_neg
+.type	GFp_nistz256_neg,\@function,2
 .align	32
-ecp_nistz256_neg:
+GFp_nistz256_neg:
 	push	%r12
 	push	%r13
 
@@ -174,7 +174,7 @@ ecp_nistz256_neg:
 	pop %r13
 	pop %r12
 	ret
-.size	ecp_nistz256_neg,.-ecp_nistz256_neg
+.size	GFp_nistz256_neg,.-GFp_nistz256_neg
 ___
 }
 {
@@ -185,15 +185,15 @@ my ($poly1,$poly3)=($acc6,$acc7);
 
 $code.=<<___;
 ################################################################################
-# void ecp_nistz256_mul_mont(
+# void GFp_nistz256_mul_mont(
 #   uint64_t res[4],
 #   uint64_t a[4],
 #   uint64_t b[4]);
 
-.globl	ecp_nistz256_mul_mont
-.type	ecp_nistz256_mul_mont,\@function,3
+.globl	GFp_nistz256_mul_mont
+.type	GFp_nistz256_mul_mont,\@function,3
 .align	32
-ecp_nistz256_mul_mont:
+GFp_nistz256_mul_mont:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
@@ -246,7 +246,7 @@ $code.=<<___;
 	pop	%rbx
 	pop	%rbp
 	ret
-.size	ecp_nistz256_mul_mont,.-ecp_nistz256_mul_mont
+.size	GFp_nistz256_mul_mont,.-GFp_nistz256_mul_mont
 
 .type	__ecp_nistz256_mul_montq,\@abi-omnipotent
 .align	32
@@ -465,16 +465,16 @@ __ecp_nistz256_mul_montq:
 .size	__ecp_nistz256_mul_montq,.-__ecp_nistz256_mul_montq
 
 ################################################################################
-# void ecp_nistz256_sqr_mont(
+# void GFp_nistz256_sqr_mont(
 #   uint64_t res[4],
 #   uint64_t a[4]);
 
 # we optimize the square according to S.Gueron and V.Krasnov,
 # "Speeding up Big-Number Squaring"
-.globl	ecp_nistz256_sqr_mont
-.type	ecp_nistz256_sqr_mont,\@function,2
+.globl	GFp_nistz256_sqr_mont
+.type	GFp_nistz256_sqr_mont,\@function,2
 .align	32
-ecp_nistz256_sqr_mont:
+GFp_nistz256_sqr_mont:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
@@ -522,7 +522,7 @@ $code.=<<___;
 	pop	%rbx
 	pop	%rbp
 	ret
-.size	ecp_nistz256_sqr_mont,.-ecp_nistz256_sqr_mont
+.size	GFp_nistz256_sqr_mont,.-GFp_nistz256_sqr_mont
 
 .type	__ecp_nistz256_sqr_montq,\@abi-omnipotent
 .align	32
@@ -998,11 +998,11 @@ my ($M1,$T2a,$T2b,$TMP2,$M2,$T2a,$T2b,$TMP2)=map("%xmm$_",(8..15));
 
 $code.=<<___;
 ################################################################################
-# void ecp_nistz256_select_w5(uint64_t *val, uint64_t *in_t, int index);
-.globl	ecp_nistz256_select_w5
-.type	ecp_nistz256_select_w5,\@abi-omnipotent
+# void GFp_nistz256_select_w5(uint64_t *val, uint64_t *in_t, int index);
+.globl	GFp_nistz256_select_w5
+.type	GFp_nistz256_select_w5,\@abi-omnipotent
 .align	32
-ecp_nistz256_select_w5:
+GFp_nistz256_select_w5:
 ___
 $code.=<<___	if ($avx>1);
 	mov	GFp_ia32cap_P+8(%rip), %eax
@@ -1011,7 +1011,7 @@ $code.=<<___	if ($avx>1);
 ___
 $code.=<<___	if ($win64);
 	lea	-0x88(%rsp), %rax
-.LSEH_begin_ecp_nistz256_select_w5:
+.LSEH_begin_GFp_nistz256_select_w5:
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax), %rsp
 	.byte	0x0f,0x29,0x70,0xe0		#movaps	%xmm6, -0x20(%rax)
 	.byte	0x0f,0x29,0x78,0xf0		#movaps	%xmm7, -0x10(%rax)
@@ -1088,18 +1088,18 @@ $code.=<<___	if ($win64);
 	movaps	0x80(%rsp), %xmm14
 	movaps	0x90(%rsp), %xmm15
 	lea	0xa8(%rsp), %rsp
-.LSEH_end_ecp_nistz256_select_w5:
+.LSEH_end_GFp_nistz256_select_w5:
 ___
 $code.=<<___;
 	ret
-.size	ecp_nistz256_select_w5,.-ecp_nistz256_select_w5
+.size	GFp_nistz256_select_w5,.-GFp_nistz256_select_w5
 
 ################################################################################
-# void ecp_nistz256_select_w7(uint64_t *val, uint64_t *in_t, int index);
-.globl	ecp_nistz256_select_w7
-.type	ecp_nistz256_select_w7,\@abi-omnipotent
+# void GFp_nistz256_select_w7(uint64_t *val, uint64_t *in_t, int index);
+.globl	GFp_nistz256_select_w7
+.type	GFp_nistz256_select_w7,\@abi-omnipotent
 .align	32
-ecp_nistz256_select_w7:
+GFp_nistz256_select_w7:
 ___
 $code.=<<___	if ($avx>1);
 	mov	GFp_ia32cap_P+8(%rip), %eax
@@ -1108,7 +1108,7 @@ $code.=<<___	if ($avx>1);
 ___
 $code.=<<___	if ($win64);
 	lea	-0x88(%rsp), %rax
-.LSEH_begin_ecp_nistz256_select_w7:
+.LSEH_begin_GFp_nistz256_select_w7:
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax), %rsp
 	.byte	0x0f,0x29,0x70,0xe0		#movaps	%xmm6, -0x20(%rax)
 	.byte	0x0f,0x29,0x78,0xf0		#movaps	%xmm7, -0x10(%rax)
@@ -1174,11 +1174,11 @@ $code.=<<___	if ($win64);
 	movaps	0x80(%rsp), %xmm14
 	movaps	0x90(%rsp), %xmm15
 	lea	0xa8(%rsp), %rsp
-.LSEH_end_ecp_nistz256_select_w7:
+.LSEH_end_GFp_nistz256_select_w7:
 ___
 $code.=<<___;
 	ret
-.size	ecp_nistz256_select_w7,.-ecp_nistz256_select_w7
+.size	GFp_nistz256_select_w7,.-GFp_nistz256_select_w7
 ___
 }
 if ($avx>1) {
@@ -1189,16 +1189,16 @@ my ($M1,$T1a,$T1b,$T1c,$TMP1)=map("%ymm$_",(10..14));
 
 $code.=<<___;
 ################################################################################
-# void ecp_nistz256_avx2_select_w5(uint64_t *val, uint64_t *in_t, int index);
-.type	ecp_nistz256_avx2_select_w5,\@abi-omnipotent
+# void GFp_nistz256_avx2_select_w5(uint64_t *val, uint64_t *in_t, int index);
+.type	GFp_nistz256_avx2_select_w5,\@abi-omnipotent
 .align	32
-ecp_nistz256_avx2_select_w5:
+GFp_nistz256_avx2_select_w5:
 .Lavx2_select_w5:
 	vzeroupper
 ___
 $code.=<<___	if ($win64);
 	lea	-0x88(%rsp), %rax
-.LSEH_begin_ecp_nistz256_avx2_select_w5:
+.LSEH_begin_GFp_nistz256_avx2_select_w5:
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax), %rsp
 	.byte	0xc5,0xf8,0x29,0x70,0xe0	#vmovaps %xmm6, -0x20(%rax)
 	.byte	0xc5,0xf8,0x29,0x78,0xf0	#vmovaps %xmm7, -0x10(%rax)
@@ -1276,11 +1276,11 @@ $code.=<<___	if ($win64);
 	movaps	0x80(%rsp), %xmm14
 	movaps	0x90(%rsp), %xmm15
 	lea	0xa8(%rsp), %rsp
-.LSEH_end_ecp_nistz256_avx2_select_w5:
+.LSEH_end_GFp_nistz256_avx2_select_w5:
 ___
 $code.=<<___;
 	ret
-.size	ecp_nistz256_avx2_select_w5,.-ecp_nistz256_avx2_select_w5
+.size	GFp_nistz256_avx2_select_w5,.-GFp_nistz256_avx2_select_w5
 ___
 }
 if ($avx>1) {
@@ -1293,17 +1293,17 @@ my ($M2,$T2a,$T2b,$TMP2)=map("%ymm$_",(12..15));
 $code.=<<___;
 
 ################################################################################
-# void ecp_nistz256_avx2_select_w7(uint64_t *val, uint64_t *in_t, int index);
-.globl	ecp_nistz256_avx2_select_w7
-.type	ecp_nistz256_avx2_select_w7,\@abi-omnipotent
+# void GFp_nistz256_avx2_select_w7(uint64_t *val, uint64_t *in_t, int index);
+.globl	GFp_nistz256_avx2_select_w7
+.type	GFp_nistz256_avx2_select_w7,\@abi-omnipotent
 .align	32
-ecp_nistz256_avx2_select_w7:
+GFp_nistz256_avx2_select_w7:
 .Lavx2_select_w7:
 	vzeroupper
 ___
 $code.=<<___	if ($win64);
 	lea	-0x88(%rsp), %rax
-.LSEH_begin_ecp_nistz256_avx2_select_w7:
+.LSEH_begin_GFp_nistz256_avx2_select_w7:
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax), %rsp
 	.byte	0xc5,0xf8,0x29,0x70,0xe0	#vmovaps %xmm6, -0x20(%rax)
 	.byte	0xc5,0xf8,0x29,0x78,0xf0	#vmovaps %xmm7, -0x10(%rax)
@@ -1396,21 +1396,21 @@ $code.=<<___	if ($win64);
 	movaps	0x80(%rsp), %xmm14
 	movaps	0x90(%rsp), %xmm15
 	lea	0xa8(%rsp), %rsp
-.LSEH_end_ecp_nistz256_avx2_select_w7:
+.LSEH_end_GFp_nistz256_avx2_select_w7:
 ___
 $code.=<<___;
 	ret
-.size	ecp_nistz256_avx2_select_w7,.-ecp_nistz256_avx2_select_w7
+.size	GFp_nistz256_avx2_select_w7,.-GFp_nistz256_avx2_select_w7
 ___
 } else {
 $code.=<<___;
-.globl	ecp_nistz256_avx2_select_w7
-.type	ecp_nistz256_avx2_select_w7,\@function,3
+.globl	GFp_nistz256_avx2_select_w7
+.type	GFp_nistz256_avx2_select_w7,\@function,3
 .align	32
-ecp_nistz256_avx2_select_w7:
+GFp_nistz256_avx2_select_w7:
 	.byte	0x0f,0x0b	# ud2
 	ret
-.size	ecp_nistz256_avx2_select_w7,.-ecp_nistz256_avx2_select_w7
+.size	GFp_nistz256_avx2_select_w7,.-GFp_nistz256_avx2_select_w7
 ___
 }
 {{{
@@ -1597,10 +1597,10 @@ sub gen_double () {
 	$bias = 0;
 
 $code.=<<___;
-.globl	ecp_nistz256_point_double
-.type	ecp_nistz256_point_double,\@function,2
+.globl	GFp_nistz256_point_double
+.type	GFp_nistz256_point_double,\@function,2
 .align	32
-ecp_nistz256_point_double:
+GFp_nistz256_point_double:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
@@ -1614,9 +1614,9 @@ ___
 	$bias = 128;
 
 $code.=<<___;
-.type	ecp_nistz256_point_doublex,\@function,2
+.type	GFp_nistz256_point_doublex,\@function,2
 .align	32
-ecp_nistz256_point_doublex:
+GFp_nistz256_point_doublex:
 .Lpoint_doublex:
 ___
     }
@@ -1694,7 +1694,7 @@ $code.=<<___;
 	call	__ecp_nistz256_sqr_mont$x	# p256_sqr_mont(res_y, S);
 ___
 {
-######## ecp_nistz256_div_by_2(res_y, res_y); ##########################
+######## GFp_nistz256_div_by_2(res_y, res_y); ##########################
 # operate in 4-5-6-7 "name space" that matches squaring output
 #
 my ($poly1,$poly3)=($a_ptr,$t1);
@@ -1806,7 +1806,7 @@ $code.=<<___;
 	pop	%rbx
 	pop	%rbp
 	ret
-.size	ecp_nistz256_point_double$sfx,.-ecp_nistz256_point_double$sfx
+.size	GFp_nistz256_point_double$sfx,.-GFp_nistz256_point_double$sfx
 ___
 }
 &gen_double("q");
@@ -1827,10 +1827,10 @@ sub gen_add () {
 	$bias = 0;
 
 $code.=<<___;
-.globl	ecp_nistz256_point_add
-.type	ecp_nistz256_point_add,\@function,3
+.globl	GFp_nistz256_point_add
+.type	GFp_nistz256_point_add,\@function,3
 .align	32
-ecp_nistz256_point_add:
+GFp_nistz256_point_add:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
@@ -1844,9 +1844,9 @@ ___
 	$bias = 128;
 
 $code.=<<___;
-.type	ecp_nistz256_point_addx,\@function,3
+.type	GFp_nistz256_point_addx,\@function,3
 .align	32
-ecp_nistz256_point_addx:
+GFp_nistz256_point_addx:
 .Lpoint_addx:
 ___
     }
@@ -2175,7 +2175,7 @@ $code.=<<___;
 	pop	%rbx
 	pop	%rbp
 	ret
-.size	ecp_nistz256_point_add$sfx,.-ecp_nistz256_point_add$sfx
+.size	GFp_nistz256_point_add$sfx,.-GFp_nistz256_point_add$sfx
 ___
 }
 &gen_add("q");
@@ -2195,10 +2195,10 @@ sub gen_add_affine () {
 	$bias = 0;
 
 $code.=<<___;
-.globl	ecp_nistz256_point_add_affine
-.type	ecp_nistz256_point_add_affine,\@function,3
+.globl	GFp_nistz256_point_add_affine
+.type	GFp_nistz256_point_add_affine,\@function,3
 .align	32
-ecp_nistz256_point_add_affine:
+GFp_nistz256_point_add_affine:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
@@ -2212,9 +2212,9 @@ ___
 	$bias = 128;
 
 $code.=<<___;
-.type	ecp_nistz256_point_add_affinex,\@function,3
+.type	GFp_nistz256_point_add_affinex,\@function,3
 .align	32
-ecp_nistz256_point_add_affinex:
+GFp_nistz256_point_add_affinex:
 .Lpoint_add_affinex:
 ___
     }
@@ -2479,7 +2479,7 @@ $code.=<<___;
 	pop	%rbx
 	pop	%rbp
 	ret
-.size	ecp_nistz256_point_add_affine$sfx,.-ecp_nistz256_point_add_affine$sfx
+.size	GFp_nistz256_point_add_affine$sfx,.-GFp_nistz256_point_add_affine$sfx
 ___
 }
 &gen_add_affine("q");

--- a/crypto/ec/asm/p256-x86_64-asm.pl
+++ b/crypto/ec/asm/p256-x86_64-asm.pl
@@ -60,7 +60,7 @@ $addx=0;
 
 $code.=<<___;
 .text
-.extern	OPENSSL_ia32cap_P
+.extern	GFp_ia32cap_P
 
 # The polynomial
 .align 64
@@ -197,7 +197,7 @@ ecp_nistz256_mul_mont:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
-	and	OPENSSL_ia32cap_P+8(%rip), %ecx
+	and	GFp_ia32cap_P+8(%rip), %ecx
 ___
 $code.=<<___;
 .Lmul_mont:
@@ -478,7 +478,7 @@ ecp_nistz256_sqr_mont:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
-	and	OPENSSL_ia32cap_P+8(%rip), %ecx
+	and	GFp_ia32cap_P+8(%rip), %ecx
 ___
 $code.=<<___;
 	push	%rbp
@@ -1005,7 +1005,7 @@ $code.=<<___;
 ecp_nistz256_select_w5:
 ___
 $code.=<<___	if ($avx>1);
-	mov	OPENSSL_ia32cap_P+8(%rip), %eax
+	mov	GFp_ia32cap_P+8(%rip), %eax
 	test	\$`1<<5`, %eax
 	jnz	.Lavx2_select_w5
 ___
@@ -1102,7 +1102,7 @@ $code.=<<___;
 ecp_nistz256_select_w7:
 ___
 $code.=<<___	if ($avx>1);
-	mov	OPENSSL_ia32cap_P+8(%rip), %eax
+	mov	GFp_ia32cap_P+8(%rip), %eax
 	test	\$`1<<5`, %eax
 	jnz	.Lavx2_select_w7
 ___
@@ -1604,7 +1604,7 @@ ecp_nistz256_point_double:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
-	and	OPENSSL_ia32cap_P+8(%rip), %ecx
+	and	GFp_ia32cap_P+8(%rip), %ecx
 	cmp	\$0x80100, %ecx
 	je	.Lpoint_doublex
 ___
@@ -1834,7 +1834,7 @@ ecp_nistz256_point_add:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
-	and	OPENSSL_ia32cap_P+8(%rip), %ecx
+	and	GFp_ia32cap_P+8(%rip), %ecx
 	cmp	\$0x80100, %ecx
 	je	.Lpoint_addx
 ___
@@ -2202,7 +2202,7 @@ ecp_nistz256_point_add_affine:
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
-	and	OPENSSL_ia32cap_P+8(%rip), %ecx
+	and	GFp_ia32cap_P+8(%rip), %ecx
 	cmp	\$0x80100, %ecx
 	je	.Lpoint_add_affinex
 ___

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -40,16 +40,16 @@ typedef P256_POINT_AFFINE PRECOMP256_ROW[64];
 
 
 /* Prototypes to avoid -Wmissing-prototypes warnings. */
-void ecp_nistz256_point_mul_base(P256_POINT *r,
+void GFp_nistz256_point_mul_base(P256_POINT *r,
                                  const BN_ULONG g_scalar[P256_LIMBS]);
-void ecp_nistz256_point_mul(P256_POINT *r, const BN_ULONG p_scalar[P256_LIMBS],
+void GFp_nistz256_point_mul(P256_POINT *r, const BN_ULONG p_scalar[P256_LIMBS],
                             const BN_ULONG p_x[P256_LIMBS],
                             const BN_ULONG p_y[P256_LIMBS]);
 
 
 /* Functions implemented in assembly */
 /* Modular neg: res = -a mod P */
-void ecp_nistz256_neg(BN_ULONG res[P256_LIMBS], const BN_ULONG a[P256_LIMBS]);
+void GFp_nistz256_neg(BN_ULONG res[P256_LIMBS], const BN_ULONG a[P256_LIMBS]);
 
 
 /* One converted into the Montgomery domain */
@@ -96,15 +96,15 @@ static void copy_conditional(BN_ULONG dst[P256_LIMBS],
   }
 }
 
-void ecp_nistz256_point_double(P256_POINT *r, const P256_POINT *a);
-void ecp_nistz256_point_add(P256_POINT *r, const P256_POINT *a,
+void GFp_nistz256_point_double(P256_POINT *r, const P256_POINT *a);
+void GFp_nistz256_point_add(P256_POINT *r, const P256_POINT *a,
                             const P256_POINT *b);
-void ecp_nistz256_point_add_affine(P256_POINT *r, const P256_POINT *a,
+void GFp_nistz256_point_add_affine(P256_POINT *r, const P256_POINT *a,
                                    const P256_POINT_AFFINE *b);
 
 
 /* r = p * p_scalar */
-void ecp_nistz256_point_mul(P256_POINT *r, const BN_ULONG p_scalar[P256_LIMBS],
+void GFp_nistz256_point_mul(P256_POINT *r, const BN_ULONG p_scalar[P256_LIMBS],
                             const BN_ULONG p_x[P256_LIMBS],
                             const BN_ULONG p_y[P256_LIMBS]) {
   static const unsigned kWindowSize = 5;
@@ -128,21 +128,21 @@ void ecp_nistz256_point_mul(P256_POINT *r, const BN_ULONG p_scalar[P256_LIMBS],
   memcpy(row[1 - 1].Y, p_y, P256_LIMBS * BN_BYTES);
   memcpy(row[1 - 1].Z, ONE, P256_LIMBS * BN_BYTES);
 
-  ecp_nistz256_point_double(&row[2 - 1], &row[1 - 1]);
-  ecp_nistz256_point_add(&row[3 - 1], &row[2 - 1], &row[1 - 1]);
-  ecp_nistz256_point_double(&row[4 - 1], &row[2 - 1]);
-  ecp_nistz256_point_double(&row[6 - 1], &row[3 - 1]);
-  ecp_nistz256_point_double(&row[8 - 1], &row[4 - 1]);
-  ecp_nistz256_point_double(&row[12 - 1], &row[6 - 1]);
-  ecp_nistz256_point_add(&row[5 - 1], &row[4 - 1], &row[1 - 1]);
-  ecp_nistz256_point_add(&row[7 - 1], &row[6 - 1], &row[1 - 1]);
-  ecp_nistz256_point_add(&row[9 - 1], &row[8 - 1], &row[1 - 1]);
-  ecp_nistz256_point_add(&row[13 - 1], &row[12 - 1], &row[1 - 1]);
-  ecp_nistz256_point_double(&row[14 - 1], &row[7 - 1]);
-  ecp_nistz256_point_double(&row[10 - 1], &row[5 - 1]);
-  ecp_nistz256_point_add(&row[15 - 1], &row[14 - 1], &row[1 - 1]);
-  ecp_nistz256_point_add(&row[11 - 1], &row[10 - 1], &row[1 - 1]);
-  ecp_nistz256_point_double(&row[16 - 1], &row[8 - 1]);
+  GFp_nistz256_point_double(&row[2 - 1], &row[1 - 1]);
+  GFp_nistz256_point_add(&row[3 - 1], &row[2 - 1], &row[1 - 1]);
+  GFp_nistz256_point_double(&row[4 - 1], &row[2 - 1]);
+  GFp_nistz256_point_double(&row[6 - 1], &row[3 - 1]);
+  GFp_nistz256_point_double(&row[8 - 1], &row[4 - 1]);
+  GFp_nistz256_point_double(&row[12 - 1], &row[6 - 1]);
+  GFp_nistz256_point_add(&row[5 - 1], &row[4 - 1], &row[1 - 1]);
+  GFp_nistz256_point_add(&row[7 - 1], &row[6 - 1], &row[1 - 1]);
+  GFp_nistz256_point_add(&row[9 - 1], &row[8 - 1], &row[1 - 1]);
+  GFp_nistz256_point_add(&row[13 - 1], &row[12 - 1], &row[1 - 1]);
+  GFp_nistz256_point_double(&row[14 - 1], &row[7 - 1]);
+  GFp_nistz256_point_double(&row[10 - 1], &row[5 - 1]);
+  GFp_nistz256_point_add(&row[15 - 1], &row[14 - 1], &row[1 - 1]);
+  GFp_nistz256_point_add(&row[11 - 1], &row[10 - 1], &row[1 - 1]);
+  GFp_nistz256_point_double(&row[16 - 1], &row[8 - 1]);
 
   BN_ULONG tmp[P256_LIMBS];
   alignas(32) P256_POINT h;
@@ -158,7 +158,7 @@ void ecp_nistz256_point_mul(P256_POINT *r, const BN_ULONG p_scalar[P256_LIMBS],
 
   booth_recode(&recoded_is_negative, &recoded, raw_wvalue, kWindowSize);
   assert(!recoded_is_negative);
-  ecp_nistz256_select_w5(r, table, recoded);
+  GFp_nistz256_select_w5(r, table, recoded);
 
   while (index >= kWindowSize) {
     if (index != START_INDEX) {
@@ -168,20 +168,20 @@ void ecp_nistz256_point_mul(P256_POINT *r, const BN_ULONG p_scalar[P256_LIMBS],
       raw_wvalue = (raw_wvalue >> ((index - 1) % 8)) & kMask;
       booth_recode(&recoded_is_negative, &recoded, raw_wvalue, kWindowSize);
 
-      ecp_nistz256_select_w5(&h, table, recoded);
-      ecp_nistz256_neg(tmp, h.Y);
+      GFp_nistz256_select_w5(&h, table, recoded);
+      GFp_nistz256_neg(tmp, h.Y);
       copy_conditional(h.Y, tmp, recoded_is_negative);
 
-      ecp_nistz256_point_add(r, r, &h);
+      GFp_nistz256_point_add(r, r, &h);
     }
 
     index -= kWindowSize;
 
-    ecp_nistz256_point_double(r, r);
-    ecp_nistz256_point_double(r, r);
-    ecp_nistz256_point_double(r, r);
-    ecp_nistz256_point_double(r, r);
-    ecp_nistz256_point_double(r, r);
+    GFp_nistz256_point_double(r, r);
+    GFp_nistz256_point_double(r, r);
+    GFp_nistz256_point_double(r, r);
+    GFp_nistz256_point_double(r, r);
+    GFp_nistz256_point_double(r, r);
   }
 
   /* Final window */
@@ -189,13 +189,13 @@ void ecp_nistz256_point_mul(P256_POINT *r, const BN_ULONG p_scalar[P256_LIMBS],
   raw_wvalue = (raw_wvalue << 1) & kMask;
 
   booth_recode(&recoded_is_negative, &recoded, raw_wvalue, kWindowSize);
-  ecp_nistz256_select_w5(&h, table, recoded);
-  ecp_nistz256_neg(tmp, h.Y);
+  GFp_nistz256_select_w5(&h, table, recoded);
+  GFp_nistz256_neg(tmp, h.Y);
   copy_conditional(h.Y, tmp, recoded_is_negative);
-  ecp_nistz256_point_add(r, r, &h);
+  GFp_nistz256_point_add(r, r, &h);
 }
 
-void ecp_nistz256_point_mul_base(P256_POINT *r,
+void GFp_nistz256_point_mul_base(P256_POINT *r,
                                  const BN_ULONG g_scalar[P256_LIMBS]) {
   static const unsigned kWindowSize = 7;
   static const unsigned kMask = (1 << (7 /* kWindowSize */ + 1)) - 1;
@@ -223,9 +223,9 @@ void ecp_nistz256_point_mul_base(P256_POINT *r,
 
   booth_recode(&recoded_is_negative, &recoded, raw_wvalue, kWindowSize);
   const PRECOMP256_ROW *const precomputed_table =
-      (const PRECOMP256_ROW *)ecp_nistz256_precomputed;
-  ecp_nistz256_select_w7(&p.a, precomputed_table[0], recoded);
-  ecp_nistz256_neg(p.p.Z, p.p.Y);
+      (const PRECOMP256_ROW *)GFp_nistz256_precomputed;
+  GFp_nistz256_select_w7(&p.a, precomputed_table[0], recoded);
+  GFp_nistz256_neg(p.p.Z, p.p.Y);
   copy_conditional(p.p.Y, p.p.Z, recoded_is_negative);
 
   memcpy(p.p.Z, ONE, sizeof(ONE));
@@ -239,10 +239,10 @@ void ecp_nistz256_point_mul_base(P256_POINT *r,
     index += kWindowSize;
 
     booth_recode(&recoded_is_negative, &recoded, raw_wvalue, kWindowSize);
-    ecp_nistz256_select_w7(&t.a, precomputed_table[i], recoded);
-    ecp_nistz256_neg(t.p.Z, t.a.Y);
+    GFp_nistz256_select_w7(&t.a, precomputed_table[i], recoded);
+    GFp_nistz256_neg(t.p.Z, t.a.Y);
     copy_conditional(t.a.Y, t.p.Z, recoded_is_negative);
-    ecp_nistz256_point_add_affine(&p.p, &p.p, &t.a);
+    GFp_nistz256_point_add_affine(&p.p, &p.p, &t.a);
   }
 
   GFp_constant_time_limbs_reduce_once(p.p.X, Q, P256_LIMBS);

--- a/crypto/ec/ecp_nistz256.h
+++ b/crypto/ec/ecp_nistz256.h
@@ -36,16 +36,16 @@ typedef struct {
 } P256_POINT_AFFINE;
 
 
-void ecp_nistz256_mul_mont(BN_ULONG res[P256_LIMBS],
+void GFp_nistz256_mul_mont(BN_ULONG res[P256_LIMBS],
                            const BN_ULONG a[P256_LIMBS],
                            const BN_ULONG b[P256_LIMBS]);
-void ecp_nistz256_sqr_mont(BN_ULONG res[P256_LIMBS],
+void GFp_nistz256_sqr_mont(BN_ULONG res[P256_LIMBS],
                            const BN_ULONG a[P256_LIMBS]);
 
 /* Functions that perform constant time access to the precomputed tables */
-void ecp_nistz256_select_w5(P256_POINT *out, const P256_POINT table[16],
+void GFp_nistz256_select_w5(P256_POINT *out, const P256_POINT table[16],
                             int index);
-void ecp_nistz256_select_w7(P256_POINT_AFFINE *out,
+void GFp_nistz256_select_w7(P256_POINT_AFFINE *out,
                             const P256_POINT_AFFINE table[64], int index);
 
 

--- a/crypto/ec/ecp_nistz256_table.inl
+++ b/crypto/ec/ecp_nistz256_table.inl
@@ -13,7 +13,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 
 /* This is the precomputed constant time access table for the code in
- * ecp_nistz256.c, for the default generator. The table consists of 37
+ * GFp_nistz256.c, for the default generator. The table consists of 37
  * subtables, each subtable contains 64 affine points. The affine points are
  * encoded as eight uint64's, four for the x coordinate and four for the y.
  * Both values are in little-endian order. There are 37 tables because a
@@ -25,7 +25,7 @@
  * lead to invalid ELF files being produced. */
 
 static const alignas(4096) BN_ULONG
-    ecp_nistz256_precomputed[37][64 * sizeof(P256_POINT_AFFINE) /
+    GFp_nistz256_precomputed[37][64 * sizeof(P256_POINT_AFFINE) /
                                  sizeof(BN_ULONG)] = {
         {TOBN(0x79e730d4, 0x18a9143c), TOBN(0x75ba95fc, 0x5fedb601),
          TOBN(0x79fb732b, 0x77622510), TOBN(0x18905f76, 0xa53755c6),

--- a/crypto/ec/ecp_nistz384.h
+++ b/crypto/ec/ecp_nistz384.h
@@ -37,10 +37,10 @@ typedef struct {
 
 
 /* Prototypes to avoid -Wmissing-prototypes warnings. */
-void ecp_nistz384_point_double(P384_POINT *r, const P384_POINT *a);
-void ecp_nistz384_point_add(P384_POINT *r, const P384_POINT *a,
+void GFp_nistz384_point_double(P384_POINT *r, const P384_POINT *a);
+void GFp_nistz384_point_add(P384_POINT *r, const P384_POINT *a,
                             const P384_POINT *b);
-void ecp_nistz384_point_add_affine(P384_POINT *r, const P384_POINT *a,
+void GFp_nistz384_point_add_affine(P384_POINT *r, const P384_POINT *a,
                                    const P384_POINT_AFFINE *b);
 
 

--- a/crypto/ec/ecp_nistz384.inl
+++ b/crypto/ec/ecp_nistz384.inl
@@ -37,7 +37,7 @@ static BN_ULONG is_infinity(const BN_ULONG x[P384_LIMBS],
 }
 
 /* Point double: r = 2*a */
-void ecp_nistz384_point_double(P384_POINT *r, const P384_POINT *a) {
+void GFp_nistz384_point_double(P384_POINT *r, const P384_POINT *a) {
   BN_ULONG S[P384_LIMBS];
   BN_ULONG M[P384_LIMBS];
   BN_ULONG Zsqr[P384_LIMBS];
@@ -82,7 +82,7 @@ void ecp_nistz384_point_double(P384_POINT *r, const P384_POINT *a) {
 }
 
 /* Point addition: r = a+b */
-void ecp_nistz384_point_add(P384_POINT *r, const P384_POINT *a,
+void GFp_nistz384_point_add(P384_POINT *r, const P384_POINT *a,
                             const P384_POINT *b) {
   BN_ULONG U2[P384_LIMBS], S2[P384_LIMBS];
   BN_ULONG U1[P384_LIMBS], S1[P384_LIMBS];
@@ -126,7 +126,7 @@ void ecp_nistz384_point_add(P384_POINT *r, const P384_POINT *a,
    * so no constant time violation */
   if (is_equal(U1, U2) && !in1infty && !in2infty) {
     if (is_equal(S1, S2)) {
-      ecp_nistz384_point_double(r, a);
+      GFp_nistz384_point_double(r, a);
     } else {
       memset(r, 0, sizeof(*r));
     }

--- a/crypto/ec/ecp_nistz384_mul.inl
+++ b/crypto/ec/ecp_nistz384_mul.inl
@@ -25,7 +25,7 @@
 
 
 /* Prototypes to avoid -Wmissing-prototypes warnings. */
-void ecp_nistz384_point_mul(P384_POINT *r, const BN_ULONG p_scalar[P384_LIMBS],
+void GFp_nistz384_point_mul(P384_POINT *r, const BN_ULONG p_scalar[P384_LIMBS],
                             const BN_ULONG p_x[P384_LIMBS],
                             const BN_ULONG p_y[P384_LIMBS]);
 
@@ -43,11 +43,11 @@ static void add_precomputed_w5(P384_POINT *r, unsigned wvalue,
   GFp_p384_elem_neg(tmp, h.Y);
   copy_conditional(h.Y, tmp, recoded_is_negative);
 
-  ecp_nistz384_point_add(r, r, &h);
+  GFp_nistz384_point_add(r, r, &h);
 }
 
 /* r = p * p_scalar */
-void ecp_nistz384_point_mul(P384_POINT *r, const BN_ULONG p_scalar[P384_LIMBS],
+void GFp_nistz384_point_mul(P384_POINT *r, const BN_ULONG p_scalar[P384_LIMBS],
                             const BN_ULONG p_x[P384_LIMBS],
                             const BN_ULONG p_y[P384_LIMBS]) {
   static const unsigned kWindowSize = 5;
@@ -71,21 +71,21 @@ void ecp_nistz384_point_mul(P384_POINT *r, const BN_ULONG p_scalar[P384_LIMBS],
   memcpy(row[1 - 1].Y, p_y, P384_LIMBS * BN_BYTES);
   memcpy(row[1 - 1].Z, ONE, P384_LIMBS * BN_BYTES);
 
-  ecp_nistz384_point_double(&row[2 - 1], &row[1 - 1]);
-  ecp_nistz384_point_add(&row[3 - 1], &row[2 - 1], &row[1 - 1]);
-  ecp_nistz384_point_double(&row[4 - 1], &row[2 - 1]);
-  ecp_nistz384_point_double(&row[6 - 1], &row[3 - 1]);
-  ecp_nistz384_point_double(&row[8 - 1], &row[4 - 1]);
-  ecp_nistz384_point_double(&row[12 - 1], &row[6 - 1]);
-  ecp_nistz384_point_add(&row[5 - 1], &row[4 - 1], &row[1 - 1]);
-  ecp_nistz384_point_add(&row[7 - 1], &row[6 - 1], &row[1 - 1]);
-  ecp_nistz384_point_add(&row[9 - 1], &row[8 - 1], &row[1 - 1]);
-  ecp_nistz384_point_add(&row[13 - 1], &row[12 - 1], &row[1 - 1]);
-  ecp_nistz384_point_double(&row[14 - 1], &row[7 - 1]);
-  ecp_nistz384_point_double(&row[10 - 1], &row[5 - 1]);
-  ecp_nistz384_point_add(&row[15 - 1], &row[14 - 1], &row[1 - 1]);
-  ecp_nistz384_point_add(&row[11 - 1], &row[10 - 1], &row[1 - 1]);
-  ecp_nistz384_point_double(&row[16 - 1], &row[8 - 1]);
+  GFp_nistz384_point_double(&row[2 - 1], &row[1 - 1]);
+  GFp_nistz384_point_add(&row[3 - 1], &row[2 - 1], &row[1 - 1]);
+  GFp_nistz384_point_double(&row[4 - 1], &row[2 - 1]);
+  GFp_nistz384_point_double(&row[6 - 1], &row[3 - 1]);
+  GFp_nistz384_point_double(&row[8 - 1], &row[4 - 1]);
+  GFp_nistz384_point_double(&row[12 - 1], &row[6 - 1]);
+  GFp_nistz384_point_add(&row[5 - 1], &row[4 - 1], &row[1 - 1]);
+  GFp_nistz384_point_add(&row[7 - 1], &row[6 - 1], &row[1 - 1]);
+  GFp_nistz384_point_add(&row[9 - 1], &row[8 - 1], &row[1 - 1]);
+  GFp_nistz384_point_add(&row[13 - 1], &row[12 - 1], &row[1 - 1]);
+  GFp_nistz384_point_double(&row[14 - 1], &row[7 - 1]);
+  GFp_nistz384_point_double(&row[10 - 1], &row[5 - 1]);
+  GFp_nistz384_point_add(&row[15 - 1], &row[14 - 1], &row[1 - 1]);
+  GFp_nistz384_point_add(&row[11 - 1], &row[10 - 1], &row[1 - 1]);
+  GFp_nistz384_point_double(&row[16 - 1], &row[8 - 1]);
 
   static const unsigned START_INDEX = 384 - 4;
   unsigned index = START_INDEX;
@@ -112,11 +112,11 @@ void ecp_nistz384_point_mul(P384_POINT *r, const BN_ULONG p_scalar[P384_LIMBS],
 
     index -= kWindowSize;
 
-    ecp_nistz384_point_double(r, r);
-    ecp_nistz384_point_double(r, r);
-    ecp_nistz384_point_double(r, r);
-    ecp_nistz384_point_double(r, r);
-    ecp_nistz384_point_double(r, r);
+    GFp_nistz384_point_double(r, r);
+    GFp_nistz384_point_double(r, r);
+    GFp_nistz384_point_double(r, r);
+    GFp_nistz384_point_double(r, r);
+    GFp_nistz384_point_double(r, r);
   }
 
   /* Final window */

--- a/crypto/ec/gfp_p256.c
+++ b/crypto/ec/gfp_p256.c
@@ -53,7 +53,7 @@ void GFp_p256_scalar_mul_mont(ScalarMont r, const ScalarMont a,
     BN_MONT_CTX_N0(0xccd1c8aa, 0xee00bc4f)
   };
   /* XXX: Inefficient. TODO: optimize with dedicated multiplication routine. */
-  bn_mul_mont(r, a, b, N, N_N0, P256_LIMBS);
+  GFp_bn_mul_mont(r, a, b, N, N_N0, P256_LIMBS);
 }
 #endif
 

--- a/crypto/ec/gfp_p256.c
+++ b/crypto/ec/gfp_p256.c
@@ -34,9 +34,9 @@ void GFp_p256_scalar_sqr_rep_mont(ScalarMont r, const ScalarMont a, int rep);
 
 
 #if defined(OPENSSL_ARM) || defined(OPENSSL_X86)
-void ecp_nistz256_sqr_mont(Elem r, const Elem a) {
+void GFp_nistz256_sqr_mont(Elem r, const Elem a) {
   /* XXX: Inefficient. TODO: optimize with dedicated squaring routine. */
-  ecp_nistz256_mul_mont(r, a, a);
+  GFp_nistz256_mul_mont(r, a, a);
 }
 #endif
 
@@ -84,7 +84,7 @@ OPENSSL_COMPILE_ASSERT(sizeof(size_t) == sizeof(GFp_Limb),
                        size_t_and_gfp_limb_are_different_sizes);
 
 
-void ecp_nistz256_select_w5(P256_POINT *out, const P256_POINT table[16],
+void GFp_nistz256_select_w5(P256_POINT *out, const P256_POINT table[16],
                             int index) {
   assert(index >= 0);
   size_t index_as_size_t = (size_t)index; /* XXX: constant time? */
@@ -107,7 +107,7 @@ void ecp_nistz256_select_w5(P256_POINT *out, const P256_POINT table[16],
   memcpy(&out->Z, z, sizeof(z));
 }
 
-void ecp_nistz256_select_w7(P256_POINT_AFFINE *out,
+void GFp_nistz256_select_w7(P256_POINT_AFFINE *out,
                             const P256_POINT_AFFINE table[64], int index) {
   assert(index >= 0);
   size_t index_as_size_t = (size_t)index; /* XXX: constant time? */

--- a/crypto/ec/gfp_p384.c
+++ b/crypto/ec/gfp_p384.c
@@ -189,7 +189,7 @@ static inline void elem_mul_mont(Elem r, const Elem a, const Elem b) {
   };
   /* XXX: Not (clearly) constant-time; inefficient. TODO: Add a dedicated
    * squaring routine. */
-  bn_mul_mont(r, a, b, Q, Q_N0, P384_LIMBS);
+  GFp_bn_mul_mont(r, a, b, Q, Q_N0, P384_LIMBS);
 }
 
 static inline void elem_mul_by_2(Elem r, const Elem a) {
@@ -242,7 +242,7 @@ void GFp_p384_scalar_mul_mont(ScalarMont r, const ScalarMont a,
     BN_MONT_CTX_N0(0x6ed46089, 0xe88fdc45)
   };
   /* XXX: Inefficient. TODO: Add dedicated multiplication routine. */
-  bn_mul_mont(r, a, b, N, N_N0, P384_LIMBS);
+  GFp_bn_mul_mont(r, a, b, N, N_N0, P384_LIMBS);
 }
 
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -248,11 +248,11 @@ static inline size_t constant_time_select_size_t(size_t mask, size_t a,
 
 /* Bridge to Rust-based SHA-512 implementation. */
 
-extern void SHA512_4(uint8_t *out, size_t out_len,
-                     const uint8_t *part1, size_t part1_len,
-                     const uint8_t *part2, size_t part2_len,
-                     const uint8_t *part3, size_t part3_len,
-                     const uint8_t *part4, size_t part4_len);
+extern void GFp_SHA512_4(uint8_t *out, size_t out_len,
+                         const uint8_t *part1, size_t part1_len,
+                         const uint8_t *part2, size_t part2_len,
+                         const uint8_t *part3, size_t part3_len,
+                         const uint8_t *part4, size_t part4_len);
 
 #define SHA512_DIGEST_LENGTH 64
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -143,8 +143,8 @@ extern "C" {
 
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || defined(OPENSSL_ARM) || \
     defined(OPENSSL_AARCH64)
-/* OPENSSL_cpuid_setup initializes OPENSSL_ia32cap_P. */
-void OPENSSL_cpuid_setup(void);
+/* GFp_cpuid_setup initializes GFp_ia32cap_P. */
+void GFp_cpuid_setup(void);
 #endif
 
 #define OPENSSL_LITTLE_ENDIAN 1

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -56,7 +56,7 @@
 
 #include <openssl/mem.h>
 
-int CRYPTO_memcmp(const void *in_a, const void *in_b, size_t len) {
+int GFp_memcmp(const void *in_a, const void *in_b, size_t len) {
   const uint8_t *a = in_a;
   const uint8_t *b = in_b;
   uint8_t x = 0;

--- a/crypto/modes/asm/aesni-gcm-x86_64.pl
+++ b/crypto/modes/asm/aesni-gcm-x86_64.pl
@@ -397,14 +397,14 @@ _aesni_ctr32_ghash_6x:
 ___
 ######################################################################
 #
-# size_t aesni_gcm_[en|de]crypt(const void *inp, void *out, size_t len,
+# size_t GFp_aesni_gcm_[en|de]crypt(const void *inp, void *out, size_t len,
 #		const AES_KEY *key, unsigned char iv[16],
 #		struct { u128 Xi,H,Htbl[9]; } *Xip);
 $code.=<<___;
-.globl	aesni_gcm_decrypt
-.type	aesni_gcm_decrypt,\@function,6
+.globl	GFp_aesni_gcm_decrypt
+.type	GFp_aesni_gcm_decrypt,\@function,6
 .align	32
-aesni_gcm_decrypt:
+GFp_aesni_gcm_decrypt:
 	xor	$ret,$ret
 
 	# We call |_aesni_ctr32_ghash_6x|, which requires at least 96 (0x60)
@@ -527,7 +527,7 @@ $code.=<<___;
 .Lgcm_dec_abort:
 	mov	$ret,%rax		# return value
 	ret
-.size	aesni_gcm_decrypt,.-aesni_gcm_decrypt
+.size	GFp_aesni_gcm_decrypt,.-GFp_aesni_gcm_decrypt
 ___
 
 $code.=<<___;
@@ -622,10 +622,10 @@ _aesni_ctr32_6x:
 	jmp	.Loop_ctr32
 .size	_aesni_ctr32_6x,.-_aesni_ctr32_6x
 
-.globl	aesni_gcm_encrypt
-.type	aesni_gcm_encrypt,\@function,6
+.globl	GFp_aesni_gcm_encrypt
+.type	GFp_aesni_gcm_encrypt,\@function,6
 .align	32
-aesni_gcm_encrypt:
+GFp_aesni_gcm_encrypt:
 	xor	$ret,$ret
 
 	# We call |_aesni_ctr32_6x| twice, each call consuming 96 bytes of
@@ -921,7 +921,7 @@ $code.=<<___;
 .Lgcm_enc_abort:
 	mov	$ret,%rax		# return value
 	ret
-.size	aesni_gcm_encrypt,.-aesni_gcm_encrypt
+.size	GFp_aesni_gcm_encrypt,.-GFp_aesni_gcm_encrypt
 ___
 
 $code.=<<___;
@@ -1041,13 +1041,13 @@ gcm_se_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_aesni_gcm_decrypt
-	.rva	.LSEH_end_aesni_gcm_decrypt
+	.rva	.LSEH_begin_GFp_aesni_gcm_decrypt
+	.rva	.LSEH_end_GFp_aesni_gcm_decrypt
 	.rva	.LSEH_gcm_dec_info
 
-	.rva	.LSEH_begin_aesni_gcm_encrypt
-	.rva	.LSEH_end_aesni_gcm_encrypt
-	.rva	.LSEH_gcm_enc_info
+	.rva	.LSEH_begin_GFp_aesni_gcm_encrypt
+	.rva	.LSEH_end_GFp_aesni_gcm_encrypt
+	.rva	.LSEH_GFp_gcm_enc_info
 .section	.xdata
 .align	8
 .LSEH_gcm_dec_info:
@@ -1064,19 +1064,19 @@ ___
 $code=<<___;	# assembler is too old
 .text
 
-.globl	aesni_gcm_encrypt
-.type	aesni_gcm_encrypt,\@abi-omnipotent
-aesni_gcm_encrypt:
+.globl	GFp_aesni_gcm_encrypt
+.type	GFp_aesni_gcm_encrypt,\@abi-omnipotent
+GFp_aesni_gcm_encrypt:
 	xor	%eax,%eax
 	ret
-.size	aesni_gcm_encrypt,.-aesni_gcm_encrypt
+.size	GFp_aesni_gcm_encrypt,.-GFp_aesni_gcm_encrypt
 
-.globl	aesni_gcm_decrypt
-.type	aesni_gcm_decrypt,\@abi-omnipotent
-aesni_gcm_decrypt:
+.globl	GFp_aesni_gcm_decrypt
+.type	GFp_aesni_gcm_decrypt,\@abi-omnipotent
+GFp_aesni_gcm_decrypt:
 	xor	%eax,%eax
 	ret
-.size	aesni_gcm_decrypt,.-aesni_gcm_decrypt
+.size	GFp_aesni_gcm_decrypt,.-GFp_aesni_gcm_decrypt
 ___
 }}}
 

--- a/crypto/modes/asm/ghash-armv4.pl
+++ b/crypto/modes/asm/ghash-armv4.pl
@@ -169,10 +169,10 @@ rem_4bit_get:
 	nop
 .size	rem_4bit_get,.-rem_4bit_get
 
-.global	gcm_ghash_4bit
-.type	gcm_ghash_4bit,%function
+.global	GFp_gcm_ghash_4bit
+.type	GFp_gcm_ghash_4bit,%function
 .align	4
-gcm_ghash_4bit:
+GFp_gcm_ghash_4bit:
 #if defined(__thumb2__)
 	adr	r12,rem_4bit
 #else
@@ -283,11 +283,11 @@ $code.=<<___;
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	gcm_ghash_4bit,.-gcm_ghash_4bit
+.size	GFp_gcm_ghash_4bit,.-GFp_gcm_ghash_4bit
 
-.global	gcm_gmult_4bit
-.type	gcm_gmult_4bit,%function
-gcm_gmult_4bit:
+.global	GFp_gcm_gmult_4bit
+.type	GFp_gcm_gmult_4bit,%function
+GFp_gcm_gmult_4bit:
 	stmdb	sp!,{r4-r11,lr}
 	ldrb	$nlo,[$Xi,#15]
 	b	rem_4bit_get
@@ -366,7 +366,7 @@ $code.=<<___;
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	gcm_gmult_4bit,.-gcm_gmult_4bit
+.size	GFp_gcm_gmult_4bit,.-GFp_gcm_gmult_4bit
 ___
 {
 my ($Xl,$Xm,$Xh,$IN)=map("q$_",(0..3));
@@ -421,10 +421,10 @@ $code.=<<___;
 .arch	armv7-a
 .fpu	neon
 
-.global	gcm_init_neon
-.type	gcm_init_neon,%function
+.global	GFp_gcm_init_neon
+.type	GFp_gcm_init_neon,%function
 .align	4
-gcm_init_neon:
+GFp_gcm_init_neon:
 	vld1.64		$IN#hi,[r1]!		@ load H
 	vmov.i8		$t0,#0xe1
 	vld1.64		$IN#lo,[r1]
@@ -440,12 +440,12 @@ gcm_init_neon:
 	vstmia		r0,{$IN}
 
 	ret					@ bx lr
-.size	gcm_init_neon,.-gcm_init_neon
+.size	GFp_gcm_init_neon,.-GFp_gcm_init_neon
 
-.global	gcm_gmult_neon
-.type	gcm_gmult_neon,%function
+.global	GFp_gcm_gmult_neon
+.type	GFp_gcm_gmult_neon,%function
 .align	4
-gcm_gmult_neon:
+GFp_gcm_gmult_neon:
 	vld1.64		$IN#hi,[$Xi]!		@ load Xi
 	vld1.64		$IN#lo,[$Xi]!
 	vmov.i64	$k48,#0x0000ffffffffffff
@@ -458,12 +458,12 @@ gcm_gmult_neon:
 	veor		$Hhl,$Hlo,$Hhi		@ Karatsuba pre-processing
 	mov		$len,#16
 	b		.Lgmult_neon
-.size	gcm_gmult_neon,.-gcm_gmult_neon
+.size	GFp_gcm_gmult_neon,.-GFp_gcm_gmult_neon
 
-.global	gcm_ghash_neon
-.type	gcm_ghash_neon,%function
+.global	GFp_gcm_ghash_neon
+.type	GFp_gcm_ghash_neon,%function
 .align	4
-gcm_ghash_neon:
+GFp_gcm_ghash_neon:
 	vld1.64		$Xl#hi,[$Xi]!		@ load Xi
 	vld1.64		$Xl#lo,[$Xi]!
 	vmov.i64	$k48,#0x0000ffffffffffff
@@ -524,7 +524,7 @@ $code.=<<___;
 	vst1.64		$Xl#lo,[$Xi]
 
 	ret					@ bx lr
-.size	gcm_ghash_neon,.-gcm_ghash_neon
+.size	GFp_gcm_ghash_neon,.-GFp_gcm_ghash_neon
 #endif
 ___
 }

--- a/crypto/modes/asm/ghash-x86.pl
+++ b/crypto/modes/asm/ghash-x86.pl
@@ -261,7 +261,7 @@ sub deposit_rem_4bit {
 
 $suffix = $x86only ? "" : "_x86";
 
-&function_begin("gcm_gmult_4bit".$suffix);
+&function_begin("GFp_gcm_gmult_4bit".$suffix);
 	&stack_push(16+4+1);			# +1 for stack alignment
 	&mov	($inp,&wparam(0));		# load Xi
 	&mov	($Htbl,&wparam(1));		# load Htable
@@ -292,9 +292,9 @@ $suffix = $x86only ? "" : "_x86";
 	&mov	(&DWP(4,$inp),$Zhl);
 	&mov	(&DWP(0,$inp),$Zhh);
 	&stack_pop(16+4+1);
-&function_end("gcm_gmult_4bit".$suffix);
+&function_end("GFp_gcm_gmult_4bit".$suffix);
 
-&function_begin("gcm_ghash_4bit".$suffix);
+&function_begin("GFp_gcm_ghash_4bit".$suffix);
 	&stack_push(16+4+1);			# +1 for 64-bit alignment
 	&mov	($Zll,&wparam(0));		# load Xi
 	&mov	($Htbl,&wparam(1));		# load Htable
@@ -340,7 +340,7 @@ $suffix = $x86only ? "" : "_x86";
 	&mov	(&DWP(4,$inp),$Zhl);
 	&mov	(&DWP(0,$inp),$Zhh);
 	&stack_pop(16+4+1);
-&function_end("gcm_ghash_4bit".$suffix);
+&function_end("GFp_gcm_ghash_4bit".$suffix);
 
 if (!$x86only) {{{
 
@@ -422,7 +422,7 @@ $S=12;		# shift factor for rem_4bit
 }
 &function_end_B("_mmx_gmult_4bit_inner");
 
-&function_begin("gcm_gmult_4bit_mmx");
+&function_begin("GFp_gcm_gmult_4bit_mmx");
 	&mov	($inp,&wparam(0));	# load Xi
 	&mov	($Htbl,&wparam(1));	# load Htable
 
@@ -441,11 +441,11 @@ $S=12;		# shift factor for rem_4bit
 	&mov	(&DWP(4,$inp),$Zhl);
 	&mov	(&DWP(8,$inp),$Zlh);
 	&mov	(&DWP(0,$inp),$Zhh);
-&function_end("gcm_gmult_4bit_mmx");
+&function_end("GFp_gcm_gmult_4bit_mmx");
 
 # Streamed version performs 20% better on P4, 7% on Opteron,
 # 10% on Core2 and PIII...
-&function_begin("gcm_ghash_4bit_mmx");
+&function_begin("GFp_gcm_ghash_4bit_mmx");
 	&mov	($Zhh,&wparam(0));	# load Xi
 	&mov	($Htbl,&wparam(1));	# load Htable
 	&mov	($inp,&wparam(2));	# load in
@@ -495,10 +495,10 @@ $S=12;		# shift factor for rem_4bit
 	&mov	(&DWP(0,$inp),$Zhh);
 
 	&stack_pop(4+1);
-&function_end("gcm_ghash_4bit_mmx");
+&function_end("GFp_gcm_ghash_4bit_mmx");
 
 }} else {{	# "June" MMX version...
-		# ... has slower "April" gcm_gmult_4bit_mmx with folded
+		# ... has slower "April" GFp_gcm_gmult_4bit_mmx with folded
 		# loop. This is done to conserve code size...
 $S=16;		# shift factor for rem_4bit
 
@@ -595,7 +595,7 @@ sub mmx_loop() {
 	&bswap	($Zhh);
 }
 
-&function_begin("gcm_gmult_4bit_mmx");
+&function_begin("GFp_gcm_gmult_4bit_mmx");
 	&mov	($inp,&wparam(0));	# load Xi
 	&mov	($Htbl,&wparam(1));	# load Htable
 
@@ -613,7 +613,7 @@ sub mmx_loop() {
 	&mov	(&DWP(4,$inp),$Zhl);
 	&mov	(&DWP(8,$inp),$Zlh);
 	&mov	(&DWP(0,$inp),$Zhh);
-&function_end("gcm_gmult_4bit_mmx");
+&function_end("GFp_gcm_gmult_4bit_mmx");
 
 ######################################################################
 # Below subroutine is "528B" variant of "4-bit" GCM GHASH function
@@ -622,7 +622,7 @@ sub mmx_loop() {
 
 &static_label("rem_8bit");
 
-&function_begin("gcm_ghash_4bit_mmx");
+&function_begin("GFp_gcm_ghash_4bit_mmx");
 { my ($Zlo,$Zhi) = ("mm7","mm6");
   my $rem_8bit = "esi";
   my $Htbl = "ebx";
@@ -817,7 +817,7 @@ sub mmx_loop() {
     &mov	("esp",&DWP(528+16+12,"esp"));	# restore original %esp
     &emms	();
 }
-&function_end("gcm_ghash_4bit_mmx");
+&function_end("GFp_gcm_ghash_4bit_mmx");
 }}
 
 if ($sse2) {{
@@ -862,7 +862,7 @@ my ($Xhi,$Xi,$Hkey,$HK)=@_;
 sub clmul64x64_T3 {
 # Even though this subroutine offers visually better ILP, it
 # was empirically found to be a tad slower than above version.
-# At least in gcm_ghash_clmul context. But it's just as well,
+# At least in GFp_gcm_ghash_clmul context. But it's just as well,
 # because loop modulo-scheduling is possible only thanks to
 # minimized "register" pressure...
 my ($Xhi,$Xi,$Hkey)=@_;
@@ -923,7 +923,7 @@ my ($Xhi,$Xi) = @_;
 	&pxor		($Xi,$Xhi)		#
 }
 
-&function_begin_B("gcm_init_clmul");
+&function_begin_B("GFp_gcm_init_clmul");
 	&mov		($Htbl,&wparam(0));
 	&mov		($Xip,&wparam(1));
 
@@ -964,9 +964,9 @@ my ($Xhi,$Xi) = @_;
 	&movdqu		(&QWP(32,$Htbl),$T2);	# save Karatsuba "salt"
 
 	&ret		();
-&function_end_B("gcm_init_clmul");
+&function_end_B("GFp_gcm_init_clmul");
 
-&function_begin_B("gcm_gmult_clmul");
+&function_begin_B("GFp_gcm_gmult_clmul");
 	&mov		($Xip,&wparam(0));
 	&mov		($Htbl,&wparam(1));
 
@@ -988,9 +988,9 @@ my ($Xhi,$Xi) = @_;
 	&movdqu		(&QWP(0,$Xip),$Xi);
 
 	&ret	();
-&function_end_B("gcm_gmult_clmul");
+&function_end_B("GFp_gcm_gmult_clmul");
 
-&function_begin("gcm_ghash_clmul");
+&function_begin("GFp_gcm_ghash_clmul");
 	&mov		($Xip,&wparam(0));
 	&mov		($Htbl,&wparam(1));
 	&mov		($inp,&wparam(2));
@@ -1139,7 +1139,7 @@ my ($Xhi,$Xi) = @_;
 &set_label("done");
 	&pshufb		($Xi,$T3);
 	&movdqu		(&QWP(0,$Xip),$Xi);
-&function_end("gcm_ghash_clmul");
+&function_end("GFp_gcm_ghash_clmul");
 
 } else {		# Algorith 5. Kept for reference purposes.
 
@@ -1188,7 +1188,7 @@ my ($Xhi,$Xi)=@_;
 	&pxor		($Xi,$Xhi);		#
 }
 
-&function_begin_B("gcm_init_clmul");
+&function_begin_B("GFp_gcm_init_clmul");
 	&mov		($Htbl,&wparam(0));
 	&mov		($Xip,&wparam(1));
 
@@ -1209,9 +1209,9 @@ my ($Xhi,$Xi)=@_;
 	&movdqu		(&QWP(16,$Htbl),$Xi);	# save H^2
 
 	&ret		();
-&function_end_B("gcm_init_clmul");
+&function_end_B("GFp_gcm_init_clmul");
 
-&function_begin_B("gcm_gmult_clmul");
+&function_begin_B("GFp_gcm_gmult_clmul");
 	&mov		($Xip,&wparam(0));
 	&mov		($Htbl,&wparam(1));
 
@@ -1232,9 +1232,9 @@ my ($Xhi,$Xi)=@_;
 	&movdqu		(&QWP(0,$Xip),$Xi);
 
 	&ret	();
-&function_end_B("gcm_gmult_clmul");
+&function_end_B("GFp_gcm_gmult_clmul");
 
-&function_begin("gcm_ghash_clmul");
+&function_begin("GFp_gcm_ghash_clmul");
 	&mov		($Xip,&wparam(0));
 	&mov		($Htbl,&wparam(1));
 	&mov		($inp,&wparam(2));
@@ -1320,7 +1320,7 @@ my ($Xhi,$Xi)=@_;
 &set_label("done");
 	&pshufb		($Xi,$T3);
 	&movdqu		(&QWP(0,$Xip),$Xi);
-&function_end("gcm_ghash_clmul");
+&function_end("GFp_gcm_ghash_clmul");
 
 }
 

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -212,10 +212,10 @@ $code=<<___;
 .text
 .extern	OPENSSL_ia32cap_P
 
-.globl	gcm_gmult_4bit
-.type	gcm_gmult_4bit,\@function,2
+.globl	GFp_gcm_gmult_4bit
+.type	GFp_gcm_gmult_4bit,\@function,2
 .align	16
-gcm_gmult_4bit:
+GFp_gcm_gmult_4bit:
 	push	%rbx
 	push	%rbp		# %rbp and %r12 are pushed exclusively in
 	push	%r12		# order to reuse Win64 exception handler...
@@ -233,7 +233,7 @@ $code.=<<___;
 	lea	24(%rsp),%rsp
 .Lgmult_epilogue:
 	ret
-.size	gcm_gmult_4bit,.-gcm_gmult_4bit
+.size	GFp_gcm_gmult_4bit,.-GFp_gcm_gmult_4bit
 ___
 
 # per-function register layout
@@ -242,10 +242,10 @@ $len="%rcx";
 $rem_8bit=$rem_4bit;
 
 $code.=<<___;
-.globl	gcm_ghash_4bit
-.type	gcm_ghash_4bit,\@function,4
+.globl	GFp_gcm_ghash_4bit
+.type	GFp_gcm_ghash_4bit,\@function,4
 .align	16
-gcm_ghash_4bit:
+GFp_gcm_ghash_4bit:
 	push	%rbx
 	push	%rbp
 	push	%r12
@@ -390,7 +390,7 @@ $code.=<<___;
 	lea	48(%rsi),%rsp
 .Lghash_epilogue:
 	ret
-.size	gcm_ghash_4bit,.-gcm_ghash_4bit
+.size	GFp_gcm_ghash_4bit,.-GFp_gcm_ghash_4bit
 ___
 
 ######################################################################
@@ -469,14 +469,14 @@ ___
   my $HK="%xmm6";
 
 $code.=<<___;
-.globl	gcm_init_clmul
-.type	gcm_init_clmul,\@abi-omnipotent
+.globl	GFp_gcm_init_clmul
+.type	GFp_gcm_init_clmul,\@abi-omnipotent
 .align	16
-gcm_init_clmul:
+GFp_gcm_init_clmul:
 .L_init_clmul:
 ___
 $code.=<<___ if ($win64);
-.LSEH_begin_gcm_init_clmul:
+.LSEH_begin_GFp_gcm_init_clmul:
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x48,0x83,0xec,0x18		#sub	$0x18,%rsp
 	.byte	0x0f,0x29,0x34,0x24		#movaps	%xmm6,(%rsp)
@@ -538,21 +538,21 @@ ___
 $code.=<<___ if ($win64);
 	movaps	(%rsp),%xmm6
 	lea	0x18(%rsp),%rsp
-.LSEH_end_gcm_init_clmul:
+.LSEH_end_GFp_gcm_init_clmul:
 ___
 $code.=<<___;
 	ret
-.size	gcm_init_clmul,.-gcm_init_clmul
+.size	GFp_gcm_init_clmul,.-GFp_gcm_init_clmul
 ___
 }
 
 { my ($Xip,$Htbl)=@_4args;
 
 $code.=<<___;
-.globl	gcm_gmult_clmul
-.type	gcm_gmult_clmul,\@abi-omnipotent
+.globl	GFp_gcm_gmult_clmul
+.type	GFp_gcm_gmult_clmul,\@abi-omnipotent
 .align	16
-gcm_gmult_clmul:
+GFp_gcm_gmult_clmul:
 .L_gmult_clmul:
 	movdqu		($Xip),$Xi
 	movdqa		.Lbswap_mask(%rip),$T3
@@ -589,7 +589,7 @@ $code.=<<___;
 	pshufb		$T3,$Xi
 	movdqu		$Xi,($Xip)
 	ret
-.size	gcm_gmult_clmul,.-gcm_gmult_clmul
+.size	GFp_gcm_gmult_clmul,.-GFp_gcm_gmult_clmul
 ___
 }
 
@@ -598,15 +598,15 @@ ___
   my ($T1,$T2,$T3)=map("%xmm$_",(8..10));
 
 $code.=<<___;
-.globl	gcm_ghash_clmul
-.type	gcm_ghash_clmul,\@abi-omnipotent
+.globl	GFp_gcm_ghash_clmul
+.type	GFp_gcm_ghash_clmul,\@abi-omnipotent
 .align	32
-gcm_ghash_clmul:
+GFp_gcm_ghash_clmul:
 .L_ghash_clmul:
 ___
 $code.=<<___ if ($win64);
 	lea	-0x88(%rsp),%rax
-.LSEH_begin_gcm_ghash_clmul:
+.LSEH_begin_GFp_gcm_ghash_clmul:
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax),%rsp
 	.byte	0x0f,0x29,0x70,0xe0		#movaps	%xmm6,-0x20(%rax)
@@ -945,26 +945,26 @@ $code.=<<___ if ($win64);
 	movaps	0x80(%rsp),%xmm14
 	movaps	0x90(%rsp),%xmm15
 	lea	0xa8(%rsp),%rsp
-.LSEH_end_gcm_ghash_clmul:
+.LSEH_end_GFp_gcm_ghash_clmul:
 ___
 $code.=<<___;
 	ret
-.size	gcm_ghash_clmul,.-gcm_ghash_clmul
+.size	GFp_gcm_ghash_clmul,.-GFp_gcm_ghash_clmul
 ___
 }
 
 $code.=<<___;
-.globl	gcm_init_avx
-.type	gcm_init_avx,\@abi-omnipotent
+.globl	GFp_gcm_init_avx
+.type	GFp_gcm_init_avx,\@abi-omnipotent
 .align	32
-gcm_init_avx:
+GFp_gcm_init_avx:
 ___
 if ($avx) {
 my ($Htbl,$Xip)=@_4args;
 my $HK="%xmm6";
 
 $code.=<<___ if ($win64);
-.LSEH_begin_gcm_init_avx:
+.LSEH_begin_GFp_gcm_init_avx:
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x48,0x83,0xec,0x18		#sub	$0x18,%rsp
 	.byte	0x0f,0x29,0x34,0x24		#movaps	%xmm6,(%rsp)
@@ -1082,33 +1082,33 @@ ___
 $code.=<<___ if ($win64);
 	movaps	(%rsp),%xmm6
 	lea	0x18(%rsp),%rsp
-.LSEH_end_gcm_init_avx:
+.LSEH_end_GFp_gcm_init_avx:
 ___
 $code.=<<___;
 	ret
-.size	gcm_init_avx,.-gcm_init_avx
+.size	GFp_gcm_init_avx,.-GFp_gcm_init_avx
 ___
 } else {
 $code.=<<___;
 	jmp	.L_init_clmul
-.size	gcm_init_avx,.-gcm_init_avx
+.size	GFp_gcm_init_avx,.-GFp_gcm_init_avx
 ___
 }
 
 $code.=<<___;
-.globl	gcm_gmult_avx
-.type	gcm_gmult_avx,\@abi-omnipotent
+.globl	GFp_gcm_gmult_avx
+.type	GFp_gcm_gmult_avx,\@abi-omnipotent
 .align	32
-gcm_gmult_avx:
+GFp_gcm_gmult_avx:
 	jmp	.L_gmult_clmul
-.size	gcm_gmult_avx,.-gcm_gmult_avx
+.size	GFp_gcm_gmult_avx,.-GFp_gcm_gmult_avx
 ___
 
 $code.=<<___;
-.globl	gcm_ghash_avx
-.type	gcm_ghash_avx,\@abi-omnipotent
+.globl	GFp_gcm_ghash_avx
+.type	GFp_gcm_ghash_avx,\@abi-omnipotent
 .align	32
-gcm_ghash_avx:
+GFp_gcm_ghash_avx:
 ___
 if ($avx) {
 my ($Xip,$Htbl,$inp,$len)=@_4args;
@@ -1119,7 +1119,7 @@ my ($Xlo,$Xhi,$Xmi,
 
 $code.=<<___ if ($win64);
 	lea	-0x88(%rsp),%rax
-.LSEH_begin_gcm_ghash_avx:
+.LSEH_begin_GFp_gcm_ghash_avx:
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax),%rsp
 	.byte	0x0f,0x29,0x70,0xe0		#movaps	%xmm6,-0x20(%rax)
@@ -1517,16 +1517,16 @@ $code.=<<___ if ($win64);
 	movaps	0x80(%rsp),%xmm14
 	movaps	0x90(%rsp),%xmm15
 	lea	0xa8(%rsp),%rsp
-.LSEH_end_gcm_ghash_avx:
+.LSEH_end_GFp_gcm_ghash_avx:
 ___
 $code.=<<___;
 	ret
-.size	gcm_ghash_avx,.-gcm_ghash_avx
+.size	GFp_gcm_ghash_avx,.-GFp_gcm_ghash_avx
 ___
 } else {
 $code.=<<___;
 	jmp	.L_ghash_clmul
-.size	gcm_ghash_avx,.-gcm_ghash_avx
+.size	GFp_gcm_ghash_avx,.-GFp_gcm_ghash_avx
 ___
 }
 
@@ -1679,47 +1679,47 @@ se_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_gcm_gmult_4bit
-	.rva	.LSEH_end_gcm_gmult_4bit
-	.rva	.LSEH_info_gcm_gmult_4bit
+	.rva	.LSEH_begin_GFp_gcm_gmult_4bit
+	.rva	.LSEH_end_GFp_gcm_gmult_4bit
+	.rva	.LSEH_info_GFp_gcm_gmult_4bit
 
-	.rva	.LSEH_begin_gcm_ghash_4bit
-	.rva	.LSEH_end_gcm_ghash_4bit
-	.rva	.LSEH_info_gcm_ghash_4bit
+	.rva	.LSEH_begin_GFp_gcm_ghash_4bit
+	.rva	.LSEH_end_GFp_gcm_ghash_4bit
+	.rva	.LSEH_info_GFp_gcm_ghash_4bit
 
-	.rva	.LSEH_begin_gcm_init_clmul
-	.rva	.LSEH_end_gcm_init_clmul
-	.rva	.LSEH_info_gcm_init_clmul
+	.rva	.LSEH_begin_GFp_gcm_init_clmul
+	.rva	.LSEH_end_GFp_gcm_init_clmul
+	.rva	.LSEH_info_GFp_gcm_init_clmul
 
-	.rva	.LSEH_begin_gcm_ghash_clmul
-	.rva	.LSEH_end_gcm_ghash_clmul
-	.rva	.LSEH_info_gcm_ghash_clmul
+	.rva	.LSEH_begin_GFp_gcm_ghash_clmul
+	.rva	.LSEH_end_GFp_gcm_ghash_clmul
+	.rva	.LSEH_info_GFp_gcm_ghash_clmul
 ___
 $code.=<<___	if ($avx);
-	.rva	.LSEH_begin_gcm_init_avx
-	.rva	.LSEH_end_gcm_init_avx
-	.rva	.LSEH_info_gcm_init_clmul
+	.rva	.LSEH_begin_GFp_gcm_init_avx
+	.rva	.LSEH_end_GFp_gcm_init_avx
+	.rva	.LSEH_info_GFp_gcm_init_clmul
 
-	.rva	.LSEH_begin_gcm_ghash_avx
-	.rva	.LSEH_end_gcm_ghash_avx
-	.rva	.LSEH_info_gcm_ghash_clmul
+	.rva	.LSEH_begin_GFp_gcm_ghash_avx
+	.rva	.LSEH_end_GFp_gcm_ghash_avx
+	.rva	.LSEH_info_GFp_gcm_ghash_clmul
 ___
 $code.=<<___;
 .section	.xdata
 .align	8
-.LSEH_info_gcm_gmult_4bit:
+.LSEH_info_GFp_gcm_gmult_4bit:
 	.byte	9,0,0,0
 	.rva	se_handler
 	.rva	.Lgmult_prologue,.Lgmult_epilogue	# HandlerData
-.LSEH_info_gcm_ghash_4bit:
+.LSEH_info_GFp_gcm_ghash_4bit:
 	.byte	9,0,0,0
 	.rva	se_handler
 	.rva	.Lghash_prologue,.Lghash_epilogue	# HandlerData
-.LSEH_info_gcm_init_clmul:
+.LSEH_info_GFp_gcm_init_clmul:
 	.byte	0x01,0x08,0x03,0x00
 	.byte	0x08,0x68,0x00,0x00	#movaps	0x00(rsp),xmm6
 	.byte	0x04,0x22,0x00,0x00	#sub	rsp,0x18
-.LSEH_info_gcm_ghash_clmul:
+.LSEH_info_GFp_gcm_ghash_clmul:
 	.byte	0x01,0x33,0x16,0x00
 	.byte	0x33,0xf8,0x09,0x00	#movaps 0x90(rsp),xmm15
 	.byte	0x2e,0xe8,0x08,0x00	#movaps 0x80(rsp),xmm14

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -210,7 +210,7 @@ ___
 
 $code=<<___;
 .text
-.extern	OPENSSL_ia32cap_P
+.extern	GFp_ia32cap_P
 
 .globl	GFp_gcm_gmult_4bit
 .type	GFp_gcm_gmult_4bit,\@function,2
@@ -637,7 +637,7 @@ if ($do4xaggr) {
 my ($Xl,$Xm,$Xh,$Hkey3,$Hkey4)=map("%xmm$_",(11..15));
 
 $code.=<<___;
-	mov		OPENSSL_ia32cap_P+4(%rip),%eax
+	mov		GFp_ia32cap_P+4(%rip),%eax
 	cmp		\$0x30,$len
 	jb		.Lskip4x
 

--- a/crypto/modes/asm/ghashv8-armx.pl
+++ b/crypto/modes/asm/ghashv8-armx.pl
@@ -66,7 +66,7 @@ ___
 $code.=".fpu	neon\n.code	32\n"	if ($flavour !~ /64/);
 
 ################################################################################
-# void gcm_init_v8(u128 Htable[16],const u64 H[2]);
+# void GFp_gcm_init_v8(u128 Htable[16],const u64 H[2]);
 #
 # input:	128-bit H - secret parameter E(K,0^128)
 # output:	precomputed table filled with degrees of twisted H;
@@ -76,10 +76,10 @@ $code.=".fpu	neon\n.code	32\n"	if ($flavour !~ /64/);
 #		optimize the code independently);
 #
 $code.=<<___;
-.global	gcm_init_v8
-.type	gcm_init_v8,%function
+.global	GFp_gcm_init_v8
+.type	GFp_gcm_init_v8,%function
 .align	4
-gcm_init_v8:
+GFp_gcm_init_v8:
 	vld1.64		{$t1},[x1]		@ load input H
 	vmov.i8		$xC2,#0xe1
 	vshl.i64	$xC2,$xC2,#57		@ 0xc2.0
@@ -125,20 +125,20 @@ gcm_init_v8:
 	vst1.64		{$Hhl-$H2},[x0]		@ store Htable[1..2]
 
 	ret
-.size	gcm_init_v8,.-gcm_init_v8
+.size	GFp_gcm_init_v8,.-GFp_gcm_init_v8
 ___
 ################################################################################
-# void gcm_gmult_v8(u64 Xi[2],const u128 Htable[16]);
+# void GFp_gcm_gmult_v8(u64 Xi[2],const u128 Htable[16]);
 #
 # input:	Xi - current hash value;
-#		Htable - table precomputed in gcm_init_v8;
+#		Htable - table precomputed in GFp_gcm_init_v8;
 # output:	Xi - next hash value Xi;
 #
 $code.=<<___;
-.global	gcm_gmult_v8
-.type	gcm_gmult_v8,%function
+.global	GFp_gcm_gmult_v8
+.type	GFp_gcm_gmult_v8,%function
 .align	4
-gcm_gmult_v8:
+GFp_gcm_gmult_v8:
 	vld1.64		{$t1},[$Xi]		@ load Xi
 	vmov.i8		$xC2,#0xe1
 	vld1.64		{$H-$Hhl},[$Htbl]	@ load twisted H, ...
@@ -175,22 +175,23 @@ gcm_gmult_v8:
 	vst1.64		{$Xl},[$Xi]		@ write out Xi
 
 	ret
-.size	gcm_gmult_v8,.-gcm_gmult_v8
+.size	GFp_gcm_gmult_v8,.-GFp_gcm_gmult_v8
 ___
 ################################################################################
-# void gcm_ghash_v8(u64 Xi[2],const u128 Htable[16],const u8 *inp,size_t len);
+# void GFp_gcm_ghash_v8(u64 Xi[2], const u128 Htable[16], const u8 *inp,
+#                       size_t len);
 #
-# input:	table precomputed in gcm_init_v8;
+# input:	table precomputed in GFp_gcm_init_v8;
 #		current hash value Xi;
 #		pointer to input data;
 #		length of input data in bytes, but divisible by block size;
 # output:	next hash value Xi;
 #
 $code.=<<___;
-.global	gcm_ghash_v8
-.type	gcm_ghash_v8,%function
+.global	GFp_gcm_ghash_v8
+.type	GFp_gcm_ghash_v8,%function
 .align	4
-gcm_ghash_v8:
+GFp_gcm_ghash_v8:
 ___
 $code.=<<___		if ($flavour !~ /64/);
 	vstmdb		sp!,{d8-d15}		@ 32-bit ABI says so
@@ -337,7 +338,7 @@ $code.=<<___		if ($flavour !~ /64/);
 ___
 $code.=<<___;
 	ret
-.size	gcm_ghash_v8,.-gcm_ghash_v8
+.size	GFp_gcm_ghash_v8,.-GFp_gcm_ghash_v8
 ___
 }
 $code.=<<___;

--- a/crypto/modes/gcm.c
+++ b/crypto/modes/gcm.c
@@ -376,7 +376,7 @@ static void gcm128_init_htable(u128 Htable[GCM128_HTABLE_LEN],
 
 #if defined(GHASH_ASM_X86_OR_64)
   if (GFp_gcm_clmul_enabled()) {
-    if (((OPENSSL_ia32cap_P[1] >> 22) & 0x41) == 0x41) { /* AVX+MOVBE */
+    if (((GFp_ia32cap_P[1] >> 22) & 0x41) == 0x41) { /* AVX+MOVBE */
       GFp_gcm_init_avx(Htable, H);
     } else {
       GFp_gcm_init_clmul(Htable, H);
@@ -405,7 +405,7 @@ static void gcm128_init_gmult_ghash(GCM128_CONTEXT *ctx) {
 
 #if defined(GHASH_ASM_X86_OR_64)
   if (GFp_gcm_clmul_enabled()) {
-    if (((OPENSSL_ia32cap_P[1] >> 22) & 0x41) == 0x41) { /* AVX+MOVBE */
+    if (((GFp_ia32cap_P[1] >> 22) & 0x41) == 0x41) { /* AVX+MOVBE */
       ctx->gmult = GFp_gcm_gmult_avx;
       ctx->ghash = GFp_gcm_ghash_avx;
     } else {
@@ -416,7 +416,7 @@ static void gcm128_init_gmult_ghash(GCM128_CONTEXT *ctx) {
   }
 #endif
 #if defined(GHASH_ASM_X86)
-  if (OPENSSL_ia32cap_P[0] & (1 << 25)) { /* check SSE bit */
+  if (GFp_ia32cap_P[0] & (1 << 25)) { /* check SSE bit */
     ctx->gmult = GFp_gcm_gmult_4bit_mmx;
     ctx->ghash = GFp_gcm_ghash_4bit_mmx;
     return;
@@ -858,8 +858,8 @@ void GFp_gcm128_tag(GCM128_CONTEXT *ctx, uint8_t tag[16]) {
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 int GFp_gcm_clmul_enabled(void) {
 #ifdef GHASH_ASM
-  return OPENSSL_ia32cap_P[0] & (1 << 24) &&  /* check FXSR bit */
-    OPENSSL_ia32cap_P[1] & (1 << 1);  /* check PCLMULQDQ bit */
+  return GFp_ia32cap_P[0] & (1 << 24) &&  /* check FXSR bit */
+    GFp_ia32cap_P[1] & (1 << 1);  /* check PCLMULQDQ bit */
 #else
   return 0;
 #endif

--- a/crypto/modes/internal.h
+++ b/crypto/modes/internal.h
@@ -102,7 +102,7 @@ struct gcm128_context {
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 /* crypto_gcm_clmul_enabled returns one if the CLMUL implementation of GCM is
  * used. */
-int crypto_gcm_clmul_enabled(void);
+int GFp_gcm_clmul_enabled(void);
 #endif
 
 
@@ -122,62 +122,61 @@ typedef void (*aes_ctr_f)(const uint8_t *in, uint8_t *out, size_t blocks,
 
 typedef struct gcm128_context GCM128_CONTEXT;
 
-OPENSSL_EXPORT void CRYPTO_gcm128_init_serialized(
+OPENSSL_EXPORT void GFp_gcm128_init_serialized(
     uint8_t serialized_ctx[GCM128_SERIALIZED_LEN], const AES_KEY *key,
     aes_block_f block);
 
-OPENSSL_EXPORT void CRYPTO_gcm128_init(
+OPENSSL_EXPORT void GFp_gcm128_init(
     GCM128_CONTEXT *ctx, const AES_KEY *key, aes_block_f block,
     const uint8_t serialized_ctx[GCM128_SERIALIZED_LEN], const uint8_t *iv);
 
-/* CRYPTO_gcm128_aad sets the authenticated data for an instance of GCM.
- * This must be called before and data is encrypted. It returns one on success
- * and zero otherwise. */
-OPENSSL_EXPORT int CRYPTO_gcm128_aad(GCM128_CONTEXT *ctx, const uint8_t *aad,
-                                     size_t len);
-
-/* CRYPTO_gcm128_encrypt encrypts |len| bytes from |in| to |out|. The |key|
- * must be the same key that was passed to |CRYPTO_gcm128_init|. It returns one
- * on success and zero otherwise. */
-OPENSSL_EXPORT int CRYPTO_gcm128_encrypt(GCM128_CONTEXT *ctx,
-                                         const AES_KEY *key, const uint8_t *in,
-                                         uint8_t *out, size_t len);
-
-/* CRYPTO_gcm128_decrypt decrypts |len| bytes from |in| to |out|. The |key|
- * must be the same key that was passed to |CRYPTO_gcm128_init|. It returns one
- * on success and zero otherwise. */
-OPENSSL_EXPORT int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
-                                         const AES_KEY *key, const uint8_t *in,
-                                         uint8_t *out, size_t len);
-
-/* CRYPTO_gcm128_encrypt_ctr32 encrypts |len| bytes from |in| to |out| using
- * a CTR function that only handles the bottom 32 bits of the nonce, like
- * |CRYPTO_ctr128_encrypt_ctr32|. The |key| must be the same key that was
- * passed to |CRYPTO_gcm128_init|. It returns one on success and zero
+/* GFp_gcm128_aad sets the authenticated data for an instance of GCM. This must
+ * be called before and data is encrypted. It returns one on success and zero
  * otherwise. */
-OPENSSL_EXPORT int CRYPTO_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx,
-                                               const AES_KEY *key,
-                                               const uint8_t *in, uint8_t *out,
-                                               size_t len, aes_ctr_f stream);
+OPENSSL_EXPORT int GFp_gcm128_aad(GCM128_CONTEXT *ctx, const uint8_t *aad,
+                                  size_t len);
 
-/* CRYPTO_gcm128_decrypt_ctr32 decrypts |len| bytes from |in| to |out| using
- * a CTR function that only handles the bottom 32 bits of the nonce, like
- * |CRYPTO_ctr128_encrypt_ctr32|. The |key| must be the same key that was
- * passed to |CRYPTO_gcm128_init|. It returns one on success and zero
- * otherwise. */
-OPENSSL_EXPORT int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx,
-                                               const AES_KEY *key,
-                                               const uint8_t *in, uint8_t *out,
-                                               size_t len, aes_ctr_f stream);
+/* GFp_gcm128_encrypt encrypts |len| bytes from |in| to |out|. The |key| must
+ * be the same key that was passed to |GFp_gcm128_init|. It returns one on
+ * success and zero otherwise. */
+OPENSSL_EXPORT int GFp_gcm128_encrypt(GCM128_CONTEXT *ctx, const AES_KEY *key,
+                                      const uint8_t *in, uint8_t *out,
+                                      size_t len);
 
-/* CRYPTO_gcm128_tag calculates the authenticator and copies it into |tag|. */
-OPENSSL_EXPORT void CRYPTO_gcm128_tag(GCM128_CONTEXT *ctx, uint8_t tag[16]);
+/* GFp_gcm128_decrypt decrypts |len| bytes from |in| to |out|. The |key| must
+ * be the same key that was passed to |GFp_gcm128_init|. It returns one on
+ * success and zero otherwise. */
+OPENSSL_EXPORT int GFp_gcm128_decrypt(GCM128_CONTEXT *ctx, const AES_KEY *key,
+                                      const uint8_t *in, uint8_t *out,
+                                      size_t len);
+
+/* GFp_gcm128_encrypt_ctr32 encrypts |len| bytes from |in| to |out| using a CTR
+ * function that only handles the bottom 32 bits of the nonce, like
+ * |GFp_ctr128_encrypt_ctr32|. The |key| must be the same key that was passed
+ * to |GFp_gcm128_init|. It returns one on success and zero otherwise. */
+OPENSSL_EXPORT int GFp_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx,
+                                            const AES_KEY *key,
+                                            const uint8_t *in, uint8_t *out,
+                                            size_t len, aes_ctr_f stream);
+
+/* GFp_gcm128_decrypt_ctr32 decrypts |len| bytes from |in| to |out| using a CTR
+ * function that only handles the bottom 32 bits of the nonce, like
+ * |GFp_ctr128_encrypt_ctr32|. The |key| must be the same key that was passed
+ * to |GFp_gcm128_init|. It returns one on success and zero otherwise. */
+OPENSSL_EXPORT int GFp_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx,
+                                            const AES_KEY *key,
+                                            const uint8_t *in, uint8_t *out,
+                                            size_t len, aes_ctr_f stream);
+
+/* GFp_gcm128_tag calculates the authenticator and copies it into |tag|. */
+OPENSSL_EXPORT void GFp_gcm128_tag(GCM128_CONTEXT *ctx, uint8_t tag[16]);
 
 
 #if !defined(OPENSSL_NO_ASM) && \
     (defined(OPENSSL_X86) || defined(OPENSSL_X86_64))
-void aesni_ctr32_encrypt_blocks(const uint8_t *in, uint8_t *out, size_t blocks,
-                                const AES_KEY *key, const uint8_t *ivec);
+void GFp_aesni_ctr32_encrypt_blocks(const uint8_t *in, uint8_t *out,
+                                    size_t blocks, const AES_KEY *key,
+                                    const uint8_t *ivec);
 #endif
 
 #if defined(__cplusplus)

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -170,8 +170,8 @@ sub ::file_end
 	    {	push(@out,"$non_lazy_ptr{$i}:\n.indirect_symbol\t$i\n.long\t0\n");   }
 	}
     }
-    if (0 && grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out) {
-	my $tmp=".comm\t${nmdecor}OPENSSL_ia32cap_P,16";
+    if (0 && grep {/\b${nmdecor}GFp_ia32cap_P\b/i} @out) {
+	my $tmp=".comm\t${nmdecor}GFp_ia32cap_P,16";
 	if ($::macosx)	{ push (@out,"$tmp,2\n"); }
 	elsif ($::elf)	{ push (@out,"$tmp,4\n"); }
 	else		{ push (@out,"$tmp\n"); }
@@ -208,7 +208,7 @@ sub ::picmeup
 	    &::mov($dst,&::DWP("$indirect-$reflabel",$base));
 	    $non_lazy_ptr{"$nmdecor$sym"}=$indirect;
 	}
-	elsif ($sym eq "OPENSSL_ia32cap_P" && $::elf>0)
+	elsif ($sym eq "GFp_ia32cap_P" && $::elf>0)
 	{   &::lea($dst,&::DWP("$sym-$reflabel",$base));   }
 	else
 	{   &::lea($dst,&::DWP("_GLOBAL_OFFSET_TABLE_+[.-$reflabel]",

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -139,14 +139,14 @@ ___
 
     push(@out,"$segment	ENDS\n");
 
-    if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
+    if (grep {/\b${nmdecor}GFp_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
 .bss	SEGMENT 'BSS'
-COMM	${nmdecor}OPENSSL_ia32cap_P:DWORD:4
+COMM	${nmdecor}GFp_ia32cap_P:DWORD:4
 .bss	ENDS
 ___
-	# comment out OPENSSL_ia32cap_P declarations
-	grep {s/(^EXTERN\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;
+	# comment out GFp_ia32cap_P declarations
+	grep {s/(^EXTERN\s+${nmdecor}GFp_ia32cap_P)/\;$1/} @out;
 	push (@out,$comm);
     }
     push (@out,$initseg) if ($initseg);

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -131,13 +131,13 @@ sub ::function_end_B
 }
 
 sub ::file_end
-{   if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
+{   if (grep {/\b${nmdecor}GFp_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
 ${drdecor}segment	.bss
-${drdecor}common	${nmdecor}OPENSSL_ia32cap_P 16
+${drdecor}common	${nmdecor}GFp_ia32cap_P 16
 ___
-	# comment out OPENSSL_ia32cap_P declarations
-	grep {s/(^extern\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;
+	# comment out GFp_ia32cap_P declarations
+	grep {s/(^extern\s+${nmdecor}GFp_ia32cap_P)/\;$1/} @out;
 	push (@out,$comm)
     }
     push (@out,$initseg) if ($initseg);		

--- a/crypto/poly1305/asm/poly1305-armv4.pl
+++ b/crypto/poly1305/asm/poly1305-armv4.pl
@@ -49,12 +49,13 @@ $code.=<<___;
 .code	32
 #endif
 
-.globl	poly1305_emit
-.globl	poly1305_blocks
-.globl	poly1305_init
-.type	poly1305_init,%function
+.globl	GFp_poly1305_emit
+.globl	GFp_poly1305_blocks
+.globl	GFp_poly1305_init_asm
+
+.type	GFp_poly1305_init_asm,%function
 .align	5
-poly1305_init:
+GFp_poly1305_init_asm:
 .Lpoly1305_init:
 	stmdb	sp!,{r4-r11}
 
@@ -111,12 +112,12 @@ poly1305_init:
 	tst	r12,#ARMV7_NEON		@ check for NEON
 # ifdef	__APPLE__
 	adr	r9,poly1305_blocks_neon
-	adr	r11,poly1305_blocks
+	adr	r11,GFp_poly1305_blocks
 #  ifdef __thumb2__
 	it	ne
 #  endif
 	movne	r11,r9
-	adr	r12,poly1305_emit
+	adr	r12,GFp_poly1305_emit
 	adr	r10,poly1305_emit_neon
 #  ifdef __thumb2__
 	it	ne
@@ -126,9 +127,9 @@ poly1305_init:
 #  ifdef __thumb2__
 	itete	eq
 #  endif
-	addeq	r12,r11,#(poly1305_emit-.Lpoly1305_init)
+	addeq	r12,r11,#(GFp_poly1305_emit-.Lpoly1305_init)
 	addne	r12,r11,#(poly1305_emit_neon-.Lpoly1305_init)
-	addeq	r11,r11,#(poly1305_blocks-.Lpoly1305_init)
+	addeq	r11,r11,#(GFp_poly1305_blocks-.Lpoly1305_init)
 	addne	r11,r11,#(poly1305_blocks_neon-.Lpoly1305_init)
 # endif
 # ifdef	__thumb2__
@@ -169,16 +170,16 @@ poly1305_init:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	poly1305_init,.-poly1305_init
+.size	GFp_poly1305_init_asm,.-GFp_poly1305_init_asm
 ___
 {
 my ($h0,$h1,$h2,$h3,$h4,$r0,$r1,$r2,$r3)=map("r$_",(4..12));
 my ($s1,$s2,$s3)=($r1,$r2,$r3);
 
 $code.=<<___;
-.type	poly1305_blocks,%function
+.type	GFp_poly1305_blocks,%function
 .align	5
-poly1305_blocks:
+GFp_poly1305_blocks:
 	stmdb	sp!,{r3-r11,lr}
 
 	ands	$len,$len,#-16
@@ -332,7 +333,7 @@ poly1305_blocks:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	poly1305_blocks,.-poly1305_blocks
+.size	GFp_poly1305_blocks,.-GFp_poly1305_blocks
 ___
 }
 {
@@ -341,9 +342,9 @@ my ($h0,$h1,$h2,$h3,$h4,$g0,$g1,$g2,$g3)=map("r$_",(3..11));
 my $g4=$h4;
 
 $code.=<<___;
-.type	poly1305_emit,%function
+.type	GFp_poly1305_emit,%function
 .align	5
-poly1305_emit:
+GFp_poly1305_emit:
 	stmdb	sp!,{r4-r11}
 .Lpoly1305_emit_enter:
 
@@ -433,7 +434,7 @@ poly1305_emit:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	poly1305_emit,.-poly1305_emit
+.size	GFp_poly1305_emit,.-GFp_poly1305_emit
 ___
 {
 my ($R0,$R1,$S1,$R2,$S2,$R3,$S3,$R4,$S4) = map("d$_",(0..9));
@@ -670,7 +671,7 @@ poly1305_blocks_neon:
 	cmp	$len,#64
 	bhs	.Lenter_neon
 	tst	ip,ip			@ is_base2_26?
-	beq	poly1305_blocks
+	beq	GFp_poly1305_blocks
 
 .Lenter_neon:
 	stmdb	sp!,{r4-r7}

--- a/crypto/poly1305/asm/poly1305-armv4.pl
+++ b/crypto/poly1305/asm/poly1305-armv4.pl
@@ -93,7 +93,7 @@ poly1305_init:
 	and	r4,r4,r10
 
 #if	__ARM_MAX_ARCH__>=7
-	ldr	r12,[r11,r12]		@ OPENSSL_armcap_P
+	ldr	r12,[r11,r12]		@ GFp_armcap_P
 # ifdef	__APPLE__
 	ldr	r12,[r12]
 # endif
@@ -1221,7 +1221,7 @@ poly1305_emit_neon:
 .Lzeros:
 .long	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 .LOPENSSL_armcap:
-.word	OPENSSL_armcap_P-.Lpoly1305_init
+.word	GFp_armcap_P-.Lpoly1305_init
 #endif
 ___
 }	}
@@ -1229,7 +1229,7 @@ $code.=<<___;
 .asciz	"Poly1305 for ARMv4/NEON, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if	__ARM_MAX_ARCH__>=7
-.comm   OPENSSL_armcap_P,4,4
+.comm   GFp_armcap_P,4,4
 #endif
 ___
 

--- a/crypto/poly1305/asm/poly1305-armv8.pl
+++ b/crypto/poly1305/asm/poly1305-armv8.pl
@@ -47,7 +47,7 @@ $code.=<<___;
 .text
 
 // forward "declarations" are required for Apple
-.extern	OPENSSL_armcap_P
+.extern	GFp_armcap_P
 .globl	poly1305_blocks
 .globl	poly1305_emit
 
@@ -63,11 +63,11 @@ poly1305_init:
 	b.eq	.Lno_key
 
 #ifdef	__ILP32__
-	ldrsw	$t1,.LOPENSSL_armcap_P
+	ldrsw	$t1,.LGFp_armcap_P
 #else
-	ldr	$t1,.LOPENSSL_armcap_P
+	ldr	$t1,.LGFp_armcap_P
 #endif
-	adr	$t0,.LOPENSSL_armcap_P
+	adr	$t0,.LGFp_armcap_P
 
 	ldp	$r0,$r1,[$inp]		// load key
 	mov	$s1,#0xfffffffc0fffffff
@@ -905,11 +905,11 @@ poly1305_emit_neon:
 .align	5
 .Lzeros:
 .long	0,0,0,0,0,0,0,0
-.LOPENSSL_armcap_P:
+.LGFp_armcap_P:
 #ifdef	__ILP32__
-.long	OPENSSL_armcap_P-.
+.long	GFp_armcap_P-.
 #else
-.quad	OPENSSL_armcap_P-.
+.quad	GFp_armcap_P-.
 #endif
 .asciz	"Poly1305 for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2

--- a/crypto/poly1305/asm/poly1305-x86.pl
+++ b/crypto/poly1305/asm/poly1305-x86.pl
@@ -65,7 +65,7 @@ if ($sse2) {
 #	unsigned __int32 r[4];		# key value base 2^32
 
 &align(64);
-&function_begin("poly1305_init");
+&function_begin("GFp_poly1305_init_asm");
 	&mov	("edi",&wparam(0));		# context
 	&mov	("esi",&wparam(1));		# key
 	&mov	("ebp",&wparam(2));		# function table
@@ -86,8 +86,8 @@ if ($sse2) {
     &set_label("pic_point");
 	&blindpop("ebx");
 
-	&lea	("eax",&DWP("poly1305_blocks-".&label("pic_point"),"ebx"));
-	&lea	("edx",&DWP("poly1305_emit-".&label("pic_point"),"ebx"));
+	&lea	("eax",&DWP("GFp_poly1305_blocks-".&label("pic_point"),"ebx"));
+	&lea	("edx",&DWP("GFp_poly1305_emit-".&label("pic_point"),"ebx"));
 
 	&picmeup("edi","GFp_ia32cap_P","ebx",&label("pic_point"));
 	&mov	("ecx",&DWP(0,"edi"));
@@ -126,14 +126,14 @@ if ($sse2) {
 
 	&mov	("eax",$sse2);
 &set_label("nokey");
-&function_end("poly1305_init");
+&function_end("GFp_poly1305_init_asm");
 
 ($h0,$h1,$h2,$h3,$h4,
  $d0,$d1,$d2,$d3,
  $r0,$r1,$r2,$r3,
      $s1,$s2,$s3)=map(4*$_,(0..15));
 
-&function_begin("poly1305_blocks");
+&function_begin("GFp_poly1305_blocks");
 	&mov	("edi",&wparam(0));		# ctx
 	&mov	("esi",&wparam(1));		# inp
 	&mov	("ecx",&wparam(2));		# len
@@ -302,9 +302,9 @@ if ($sse2) {
 	&mov	(&DWP(4*3,"edx"),"esi");
 	&mov	(&DWP(4*4,"edx"),"edi");
 &set_label("nodata");
-&function_end("poly1305_blocks");
+&function_end("GFp_poly1305_blocks");
 
-&function_begin("poly1305_emit");
+&function_begin("GFp_poly1305_emit");
 	&mov	("ebp",&wparam(0));		# context
 &set_label("enter_emit");
 	&mov	("edi",&wparam(1));		# output
@@ -355,7 +355,7 @@ if ($sse2) {
 	&mov	(&DWP(4*1,"edi"),"ebx");
 	&mov	(&DWP(4*2,"edi"),"ecx");
 	&mov	(&DWP(4*3,"edi"),"edx");
-&function_end("poly1305_emit");
+&function_end("GFp_poly1305_emit");
 
 if ($sse2) {
 ########################################################################

--- a/crypto/poly1305/asm/poly1305-x86.pl
+++ b/crypto/poly1305/asm/poly1305-x86.pl
@@ -50,7 +50,7 @@ if ($sse2) {
 	&static_label("const_sse2");
 	&static_label("enter_blocks");
 	&static_label("enter_emit");
-	&external_label("OPENSSL_ia32cap_P");
+	&external_label("GFp_ia32cap_P");
 
 	# This may be set to 2, but valgrind can't do AVX2 on 32-bit. Without a
 	# way to verify test coverage, keep it disabled.
@@ -89,7 +89,7 @@ if ($sse2) {
 	&lea	("eax",&DWP("poly1305_blocks-".&label("pic_point"),"ebx"));
 	&lea	("edx",&DWP("poly1305_emit-".&label("pic_point"),"ebx"));
 
-	&picmeup("edi","OPENSSL_ia32cap_P","ebx",&label("pic_point"));
+	&picmeup("edi","GFp_ia32cap_P","ebx",&label("pic_point"));
 	&mov	("ecx",&DWP(0,"edi"));
 	&and	("ecx",1<<26|1<<24);
 	&cmp	("ecx",1<<26|1<<24);		# SSE2 and XMM?

--- a/crypto/poly1305/asm/poly1305-x86_64.pl
+++ b/crypto/poly1305/asm/poly1305-x86_64.pl
@@ -112,16 +112,16 @@ $code.=<<___;
 
 .extern	GFp_ia32cap_P
 
-.globl	poly1305_init
-.hidden	poly1305_init
-.globl	poly1305_blocks
-.hidden	poly1305_blocks
-.globl	poly1305_emit
-.hidden	poly1305_emit
+.globl	GFp_poly1305_init_asm
+.hidden	GFp_poly1305_init_asm
+.globl	GFp_poly1305_blocks
+.hidden	GFp_poly1305_blocks
+.globl	GFp_poly1305_emit
+.hidden	GFp_poly1305_emit
 
-.type	poly1305_init,\@function,3
+.type	GFp_poly1305_init_asm,\@function,3
 .align	32
-poly1305_init:
+GFp_poly1305_init_asm:
 	xor	%rax,%rax
 	mov	%rax,0($ctx)		# initialize hash value
 	mov	%rax,8($ctx)
@@ -130,8 +130,8 @@ poly1305_init:
 	cmp	\$0,$inp
 	je	.Lno_key
 
-	lea	poly1305_blocks(%rip),%r10
-	lea	poly1305_emit(%rip),%r11
+	lea	GFp_poly1305_blocks(%rip),%r10
+	lea	GFp_poly1305_emit(%rip),%r11
 ___
 $code.=<<___	if ($avx);
 	mov	GFp_ia32cap_P+4(%rip),%r9
@@ -166,11 +166,11 @@ $code.=<<___;
 	mov	\$1,%eax
 .Lno_key:
 	ret
-.size	poly1305_init,.-poly1305_init
+.size	GFp_poly1305_init_asm,.-GFp_poly1305_init_asm
 
-.type	poly1305_blocks,\@function,4
+.type	GFp_poly1305_blocks,\@function,4
 .align	32
-poly1305_blocks:
+GFp_poly1305_blocks:
 .Lblocks:
 	shr	\$4,$len
 	jz	.Lno_data		# too short
@@ -225,11 +225,11 @@ $code.=<<___;
 .Lno_data:
 .Lblocks_epilogue:
 	ret
-.size	poly1305_blocks,.-poly1305_blocks
+.size	GFp_poly1305_blocks,.-GFp_poly1305_blocks
 
-.type	poly1305_emit,\@function,3
+.type	GFp_poly1305_emit,\@function,3
 .align	32
-poly1305_emit:
+GFp_poly1305_emit:
 .Lemit:
 	mov	0($ctx),%r8	# load hash value
 	mov	8($ctx),%r9
@@ -250,7 +250,7 @@ poly1305_emit:
 	mov	%rcx,8($mac)
 
 	ret
-.size	poly1305_emit,.-poly1305_emit
+.size	GFp_poly1305_emit,.-GFp_poly1305_emit
 ___
 if ($avx) {
 
@@ -2133,17 +2133,17 @@ avx_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_poly1305_init
-	.rva	.LSEH_end_poly1305_init
-	.rva	.LSEH_info_poly1305_init
+	.rva	.LSEH_begin_GFp_poly1305_init_asm
+	.rva	.LSEH_end_GFp_poly1305_init_asm
+	.rva	.LSEH_info_GFp_poly1305_init_asm
 
-	.rva	.LSEH_begin_poly1305_blocks
-	.rva	.LSEH_end_poly1305_blocks
-	.rva	.LSEH_info_poly1305_blocks
+	.rva	.LSEH_begin_GFp_poly1305_blocks
+	.rva	.LSEH_end_GFp_poly1305_blocks
+	.rva	.LSEH_info_GFp_poly1305_blocks
 
-	.rva	.LSEH_begin_poly1305_emit
-	.rva	.LSEH_end_poly1305_emit
-	.rva	.LSEH_info_poly1305_emit
+	.rva	.LSEH_begin_GFp_poly1305_emit
+	.rva	.LSEH_end_GFp_poly1305_emit
+	.rva	.LSEH_info_GFp_poly1305_emit
 ___
 $code.=<<___ if ($avx);
 	.rva	.LSEH_begin_poly1305_blocks_avx
@@ -2178,20 +2178,20 @@ ___
 $code.=<<___;
 .section	.xdata
 .align	8
-.LSEH_info_poly1305_init:
+.LSEH_info_GFp_poly1305_init_asm:
 	.byte	9,0,0,0
 	.rva	se_handler
-	.rva	.LSEH_begin_poly1305_init,.LSEH_begin_poly1305_init
+	.rva	.LSEH_begin_GFp_poly1305_init_asm,.LSEH_begin_GFp_poly1305_init_asm
 
-.LSEH_info_poly1305_blocks:
+.LSEH_info_GFp_poly1305_blocks:
 	.byte	9,0,0,0
 	.rva	se_handler
 	.rva	.Lblocks_body,.Lblocks_epilogue
 
-.LSEH_info_poly1305_emit:
+.LSEH_info_GFp_poly1305_emit:
 	.byte	9,0,0,0
 	.rva	se_handler
-	.rva	.LSEH_begin_poly1305_emit,.LSEH_begin_poly1305_emit
+	.rva	.LSEH_begin_GFp_poly1305_emit,.LSEH_begin_GFp_poly1305_emit
 ___
 $code.=<<___ if ($avx);
 .LSEH_info_poly1305_blocks_avx_1:

--- a/crypto/poly1305/asm/poly1305-x86_64.pl
+++ b/crypto/poly1305/asm/poly1305-x86_64.pl
@@ -110,7 +110,7 @@ ___
 $code.=<<___;
 .text
 
-.extern	OPENSSL_ia32cap_P
+.extern	GFp_ia32cap_P
 
 .globl	poly1305_init
 .hidden	poly1305_init
@@ -134,7 +134,7 @@ poly1305_init:
 	lea	poly1305_emit(%rip),%r11
 ___
 $code.=<<___	if ($avx);
-	mov	OPENSSL_ia32cap_P+4(%rip),%r9
+	mov	GFp_ia32cap_P+4(%rip),%r9
 	lea	poly1305_blocks_avx(%rip),%rax
 	lea	poly1305_emit_avx(%rip),%rcx
 	bt	\$`60-32`,%r9		# AVX?

--- a/crypto/poly1305/internal.h
+++ b/crypto/poly1305/internal.h
@@ -24,24 +24,22 @@ extern "C" {
 
 typedef uint8_t poly1305_state[256];
 
-/* CRYPTO_poly1305_init sets up |state| so that it can be used to calculate an
+/* GFp_poly1305_init sets up |state| so that it can be used to calculate an
  * authentication tag with the one-time key |key|. Note that |key| is a
  * one-time key and therefore there is no `reset' method because that would
  * enable several messages to be authenticated with the same key. */
-OPENSSL_EXPORT void CRYPTO_poly1305_init(poly1305_state* state,
-                                         const uint8_t key[32]);
+OPENSSL_EXPORT void GFp_poly1305_init(poly1305_state* state,
+                                      const uint8_t key[32]);
 
-/* CRYPTO_poly1305_update processes |in_len| bytes from |in|. It can be called
+/* GFp_poly1305_update processes |in_len| bytes from |in|. It can be called
  * zero or more times after poly1305_init. */
-OPENSSL_EXPORT void CRYPTO_poly1305_update(poly1305_state* state,
-                                           const uint8_t* in,
-                                           size_t in_len);
+OPENSSL_EXPORT void GFp_poly1305_update(poly1305_state* state,
+                                        const uint8_t* in, size_t in_len);
 
-/* CRYPTO_poly1305_finish completes the poly1305 calculation and writes a 16
+/* GFp_poly1305_finish completes the poly1305 calculation and writes a 16
  * byte authentication tag to |mac|. The |mac| address must be 16-byte
  * aligned. */
-OPENSSL_EXPORT void CRYPTO_poly1305_finish(poly1305_state* state,
-                                           uint8_t mac[16]);
+OPENSSL_EXPORT void GFp_poly1305_finish(poly1305_state* state, uint8_t mac[16]);
 
 
 #if defined(__cplusplus)

--- a/crypto/poly1305/poly1305.c
+++ b/crypto/poly1305/poly1305.c
@@ -74,7 +74,7 @@ OPENSSL_COMPILE_ASSERT(sizeof(poly1305_state) >=
                        poly1305_state_too_small);
 
 
-void CRYPTO_poly1305_init(poly1305_state *statep, const uint8_t key[32]) {
+void GFp_poly1305_init(poly1305_state *statep, const uint8_t key[32]) {
   struct poly1305_state_st state;
 
   /* TODO XXX: It seems at least some implementations |poly1305_init| always
@@ -97,8 +97,8 @@ void CRYPTO_poly1305_init(poly1305_state *statep, const uint8_t key[32]) {
   memcpy(statep, &state, sizeof(state));
 }
 
-void CRYPTO_poly1305_update(poly1305_state *statep, const uint8_t *in,
-                            size_t in_len) {
+void GFp_poly1305_update(poly1305_state *statep, const uint8_t *in,
+                         size_t in_len) {
   struct poly1305_state_st state;
   memcpy(&state, statep, sizeof(state));
 
@@ -133,7 +133,7 @@ void CRYPTO_poly1305_update(poly1305_state *statep, const uint8_t *in,
   memcpy(statep, &state, sizeof(state));
 }
 
-void CRYPTO_poly1305_finish(poly1305_state *statep, uint8_t mac[16]) {
+void GFp_poly1305_finish(poly1305_state *statep, uint8_t mac[16]) {
   struct poly1305_state_st state;
   memcpy(&state, statep, sizeof(state));
 
@@ -146,4 +146,4 @@ void CRYPTO_poly1305_finish(poly1305_state *statep, uint8_t mac[16]) {
   state.func.emit(state.opaque, mac, state.nonce);
 }
 
-const size_t CRYPTO_POLY1305_STATE_LEN = sizeof(struct poly1305_state_st);
+const size_t GFp_POLY1305_STATE_LEN = sizeof(struct poly1305_state_st);

--- a/crypto/poly1305/poly1305.c
+++ b/crypto/poly1305/poly1305.c
@@ -53,10 +53,10 @@ OPENSSL_COMPILE_ASSERT(POLY1305_BLOCK_STATE_SIZE >=
  * |POLY1305_BLOCK_STATE_SIZE| is taken from OpenSSL. */
 #endif
 
-int poly1305_init(void *ctx, const uint8_t key[16], void *out_func);
-void poly1305_blocks(void *ctx, const uint8_t *in, size_t len,
-                     uint32_t padbit);
-void poly1305_emit(void *ctx, uint8_t mac[16], const uint32_t nonce[4]);
+int GFp_poly1305_init_asm(void *ctx, const uint8_t key[16], void *out_func);
+void GFp_poly1305_blocks(void *ctx, const uint8_t *in, size_t len,
+                         uint32_t padbit);
+void GFp_poly1305_emit(void *ctx, uint8_t mac[16], const uint32_t nonce[4]);
 
 struct poly1305_state_st {
   alignas(8) uint8_t opaque[POLY1305_BLOCK_STATE_SIZE];
@@ -82,9 +82,9 @@ void GFp_poly1305_init(poly1305_state *statep, const uint8_t key[32]) {
    * And, for platforms that have such conditional logic also in the ASM code,
    * it seems it would be better to move the conditional logic out of the asm
    * and into the higher-level code. */
-  if (!poly1305_init(state.opaque, key, &state.func)) {
-    state.func.blocks = poly1305_blocks;
-    state.func.emit = poly1305_emit;
+  if (!GFp_poly1305_init_asm(state.opaque, key, &state.func)) {
+    state.func.blocks = GFp_poly1305_blocks;
+    state.func.emit = GFp_poly1305_emit;
   }
 
   state.buf_used = 0;

--- a/crypto/rand/sysrand.c
+++ b/crypto/rand/sysrand.c
@@ -35,11 +35,11 @@
 #include <assert.h>
 #include <stddef.h>
 
-/* CRYPTO_sysrand_chunk fills |len| bytes at |buf| with entropy from the
- * operating system. |len| must be no more than |CRYPTO_sysrand_chunk_max_le|.
+/* GFp_sysrand_chunk fills |len| bytes at |buf| with entropy from the
+ * operating system. |len| must be no more than |GFp_sysrand_chunk_max_len|.
  * It returns one on success, -1 if it failed because the operating system
  * doesn't offer such an API, or zero otherwise. */
-int CRYPTO_sysrand_chunk(void *buf, size_t len);
+int GFp_sysrand_chunk(void *buf, size_t len);
 
 #if defined(OPENSSL_WINDOWS)
 
@@ -58,10 +58,10 @@ int CRYPTO_sysrand_chunk(void *buf, size_t len);
 
 #pragma warning(pop)
 
-const size_t CRYPTO_sysrand_chunk_max_len = ULONG_MAX;
+const size_t GFp_sysrand_chunk_max_len = ULONG_MAX;
 
-int CRYPTO_sysrand_chunk(void *out, size_t requested) {
-  assert(requested <= CRYPTO_sysrand_chunk_max_len);
+int GFp_sysrand_chunk(void *out, size_t requested) {
+  assert(requested <= GFp_sysrand_chunk_max_len);
   return RtlGenRandom(out, (ULONG)requested) ? 1 : 0;
 }
 
@@ -92,10 +92,10 @@ int CRYPTO_sysrand_chunk(void *out, size_t requested) {
 /* http://man7.org/linux/man-pages/man2/getrandom.2.html: "Calling
  * getrandom() to read /dev/urandom for small values (<= 256) of buflen is
  * the preferred mode of usage." */
-const size_t CRYPTO_sysrand_chunk_max_len = 256;
+const size_t GFp_sysrand_chunk_max_len = 256;
 
-int CRYPTO_sysrand_chunk(void *out, size_t requested) {
-  assert(requested <= CRYPTO_sysrand_chunk_max_len);
+int GFp_sysrand_chunk(void *out, size_t requested) {
+  assert(requested <= GFp_sysrand_chunk_max_len);
   if (syscall(SYS_getrandom, out, requested, 0u) < 0) {
     if (errno == ENOSYS) {
       return -1;

--- a/crypto/rsa/internal.h
+++ b/crypto/rsa/internal.h
@@ -65,10 +65,11 @@ extern "C" {
 #endif
 
 
-BN_BLINDING *BN_BLINDING_new(void);
-void BN_BLINDING_free(BN_BLINDING *b);
-int BN_BLINDING_convert(BIGNUM *n, BN_BLINDING *b, const RSA *rsa, RAND *rng);
-int BN_BLINDING_invert(BIGNUM *n, const BN_BLINDING *b, BN_MONT_CTX *mont);
+BN_BLINDING *GFp_BN_BLINDING_new(void);
+void GFp_BN_BLINDING_free(BN_BLINDING *b);
+int GFp_BN_BLINDING_convert(BIGNUM *n, BN_BLINDING *b, const RSA *rsa,
+                            RAND *rng);
+int GFp_BN_BLINDING_invert(BIGNUM *n, const BN_BLINDING *b, BN_MONT_CTX *mont);
 
 
 int GFp_rsa_check_modulus_and_exponent(const BIGNUM *n, const BIGNUM *e,

--- a/crypto/rsa/rsa.c
+++ b/crypto/rsa/rsa.c
@@ -68,14 +68,14 @@
 
 
 /* Prototypes to avoid -Wmissing-prototypes warnings. */
-int rsa_new_end(RSA *rsa, const BIGNUM *d, const BIGNUM *n, const BIGNUM *p,
-                const BIGNUM *q);
+int GFp_rsa_new_end(RSA *rsa, const BIGNUM *d, const BIGNUM *n, const BIGNUM *p,
+                    const BIGNUM *q);
 
 static int rsa_check_key(const RSA *rsa, const BIGNUM *d);
 
 
-int rsa_new_end(RSA *rsa, const BIGNUM *n, const BIGNUM *d, const BIGNUM *p,
-                const BIGNUM *q) {
+int GFp_rsa_new_end(RSA *rsa, const BIGNUM *n, const BIGNUM *d, const BIGNUM *p,
+                    const BIGNUM *q) {
   assert(rsa->e != NULL);
   assert(rsa->dmp1 != NULL);
   assert(rsa->dmq1 != NULL);

--- a/crypto/rsa/rsa_impl.c
+++ b/crypto/rsa/rsa_impl.c
@@ -308,7 +308,7 @@ int GFp_rsa_private_transform(RSA *rsa, uint8_t *inout, size_t len,
     goto err;
   }
   if (vrfy.top != base.top ||
-      CRYPTO_memcmp(vrfy.d, base.d, (size_t)vrfy.top * sizeof(vrfy.d[0])) != 0) {
+      GFp_memcmp(vrfy.d, base.d, (size_t)vrfy.top * sizeof(vrfy.d[0])) != 0) {
     OPENSSL_PUT_ERROR(RSA, ERR_R_INTERNAL_ERROR);
     goto err;
   }

--- a/crypto/rsa/rsa_impl.c
+++ b/crypto/rsa/rsa_impl.c
@@ -126,7 +126,7 @@ int GFp_rsa_check_modulus_and_exponent(const BIGNUM *n, const BIGNUM *e,
   return 1;
 }
 
-size_t RSA_size(const RSA *rsa) {
+size_t GFp_RSA_size(const RSA *rsa) {
   return GFp_BN_num_bytes(&rsa->mont_n->N);
 }
 

--- a/crypto/sha/asm/sha-armv8.pl
+++ b/crypto/sha/asm/sha-armv8.pl
@@ -60,7 +60,7 @@ if ($output =~ /512/) {
 	$reg_t="w";
 }
 
-$func="sha${BITS}_block_data_order";
+$func="GFp_sha${BITS}_block_data_order";
 
 ($ctx,$inp,$num,$Ktbl)=map("x$_",(0..2,30));
 

--- a/crypto/sha/asm/sha-armv8.pl
+++ b/crypto/sha/asm/sha-armv8.pl
@@ -162,7 +162,7 @@ $code.=<<___;
 
 .text
 
-.extern	OPENSSL_armcap_P
+.extern	GFp_armcap_P
 .globl	$func
 .type	$func,%function
 .align	6
@@ -170,11 +170,11 @@ $func:
 ___
 $code.=<<___	if ($SZ==4);
 #ifdef	__ILP32__
-	ldrsw	x16,.LOPENSSL_armcap_P
+	ldrsw	x16,.LGFp_armcap_P
 #else
-	ldr	x16,.LOPENSSL_armcap_P
+	ldr	x16,.LGFp_armcap_P
 #endif
-	adr	x17,.LOPENSSL_armcap_P
+	adr	x17,.LGFp_armcap_P
 	add	x16,x16,x17
 	ldr	w16,[x16]
 	tst	w16,#ARMV8_SHA256
@@ -314,11 +314,11 @@ ___
 $code.=<<___;
 .size	.LK$BITS,.-.LK$BITS
 .align	3
-.LOPENSSL_armcap_P:
+.LGFp_armcap_P:
 #ifdef	__ILP32__
-	.long	OPENSSL_armcap_P-.
+	.long	GFp_armcap_P-.
 #else
-	.quad	OPENSSL_armcap_P-.
+	.quad	GFp_armcap_P-.
 #endif
 .asciz	"SHA$BITS block transform for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
@@ -405,7 +405,7 @@ ___
 }
 
 $code.=<<___;
-.comm	OPENSSL_armcap_P,4,4
+.comm	GFp_armcap_P,4,4
 ___
 
 {   my  %opcode = (

--- a/crypto/sha/asm/sha-x86_64.pl
+++ b/crypto/sha/asm/sha-x86_64.pl
@@ -121,7 +121,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 *STDOUT=*OUT;
 
 if ($output =~ /512/) {
-	$func="sha512_block_data_order";
+	$func="GFp_sha512_block_data_order";
 	$TABLE="K512";
 	$SZ=8;
 	@ROT=($A,$B,$C,$D,$E,$F,$G,$H)=("%rax","%rbx","%rcx","%rdx",
@@ -133,7 +133,7 @@ if ($output =~ /512/) {
 	@sigma1=(19,61, 6);
 	$rounds=80;
 } else {
-	$func="sha256_block_data_order";
+	$func="GFp_sha256_block_data_order";
 	$TABLE="K256";
 	$SZ=4;
 	@ROT=($A,$B,$C,$D,$E,$F,$G,$H)=("%eax","%ebx","%ecx","%edx",
@@ -522,9 +522,9 @@ my ($Wi,$ABEF,$CDGH,$TMP,$BSWAP,$ABEF_SAVE,$CDGH_SAVE)=map("%xmm$_",(0..2,7..10)
 my @MSG=map("%xmm$_",(3..6));
 
 $code.=<<___;
-.type	sha256_block_data_order_shaext,\@function,3
+.type	GFp_sha256_block_data_order_shaext,\@function,3
 .align	64
-sha256_block_data_order_shaext:
+GFp_sha256_block_data_order_shaext:
 _shaext_shortcut:
 ___
 $code.=<<___ if ($win64);
@@ -669,7 +669,7 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	ret
-.size	sha256_block_data_order_shaext,.-sha256_block_data_order_shaext
+.size	GFp_sha256_block_data_order_shaext,.-GFp_sha256_block_data_order_shaext
 ___
 }}}
 {{{

--- a/crypto/sha/asm/sha-x86_64.pl
+++ b/crypto/sha/asm/sha-x86_64.pl
@@ -241,14 +241,14 @@ ___
 $code=<<___;
 .text
 
-.extern	OPENSSL_ia32cap_P
+.extern	GFp_ia32cap_P
 .globl	$func
 .type	$func,\@function,3
 .align	16
 $func:
 ___
 $code.=<<___ if ($SZ==4 || $avx);
-	lea	OPENSSL_ia32cap_P(%rip),%r11
+	lea	GFp_ia32cap_P(%rip),%r11
 	mov	0(%r11),%r9d
 	mov	4(%r11),%r10d
 	mov	8(%r11),%r11d

--- a/crypto/sha/asm/sha256-586.pl
+++ b/crypto/sha/asm/sha256-586.pl
@@ -176,7 +176,7 @@ sub BODY_00_15() {
 	 &add	($A,$T);		# h += T
 }
 
-&external_label("OPENSSL_ia32cap_P")		if (!$i386);
+&external_label("GFp_ia32cap_P")		if (!$i386);
 
 &function_begin("sha256_block_data_order");
 	&mov	("esi",wparam(0));	# ctx
@@ -199,7 +199,7 @@ sub BODY_00_15() {
 	&mov	(&DWP(8,"esp"),"eax");	# inp+num*128
 	&mov	(&DWP(12,"esp"),"ebx");	# saved sp
 						if (!$i386 && $xmm) {
-	&picmeup("edx","OPENSSL_ia32cap_P",$K256,&label("K256"));
+	&picmeup("edx","GFp_ia32cap_P",$K256,&label("K256"));
 	&mov	("ecx",&DWP(0,"edx"));
 	&mov	("ebx",&DWP(4,"edx"));
 	&test	("ecx",1<<20);		# check for P4

--- a/crypto/sha/asm/sha256-586.pl
+++ b/crypto/sha/asm/sha256-586.pl
@@ -178,7 +178,7 @@ sub BODY_00_15() {
 
 &external_label("GFp_ia32cap_P")		if (!$i386);
 
-&function_begin("sha256_block_data_order");
+&function_begin("GFp_sha256_block_data_order");
 	&mov	("esi",wparam(0));	# ctx
 	&mov	("edi",wparam(1));	# inp
 	&mov	("eax",wparam(2));	# num
@@ -1273,7 +1273,7 @@ sub bodyx_00_15 () {			# +10%
 						}
 						}
 						}}}
-&function_end_B("sha256_block_data_order");
+&function_end_B("GFp_sha256_block_data_order");
 
 &asm_finish();
 

--- a/crypto/sha/asm/sha256-armv4.pl
+++ b/crypto/sha/asm/sha256-armv4.pl
@@ -205,7 +205,7 @@ K256:
 .word	0				@ terminator
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
 .LOPENSSL_armcap:
-.word	OPENSSL_armcap_P-.Lsha256_block_data_order
+.word	GFp_armcap_P-.Lsha256_block_data_order
 #endif
 .align	5
 
@@ -220,7 +220,7 @@ sha256_block_data_order:
 #endif
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
 	ldr	r12,.LOPENSSL_armcap
-	ldr	r12,[r3,r12]		@ OPENSSL_armcap_P
+	ldr	r12,[r3,r12]		@ GFp_armcap_P
 #ifdef	__APPLE__
 	ldr	r12,[r12]
 #endif
@@ -676,8 +676,8 @@ $code.=<<___;
 .asciz  "SHA256 block transform for ARMv4/NEON/ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
-.comm   OPENSSL_armcap_P,4,4
-.hidden OPENSSL_armcap_P
+.comm   GFp_armcap_P,4,4
+.hidden GFp_armcap_P
 #endif
 ___
 

--- a/crypto/sha/asm/sha256-armv4.pl
+++ b/crypto/sha/asm/sha256-armv4.pl
@@ -209,12 +209,12 @@ K256:
 #endif
 .align	5
 
-.global	sha256_block_data_order
-.type	sha256_block_data_order,%function
-sha256_block_data_order:
+.global	GFp_sha256_block_data_order
+.type	GFp_sha256_block_data_order,%function
+GFp_sha256_block_data_order:
 .Lsha256_block_data_order:
 #if __ARM_ARCH__<7 && !defined(__thumb2__)
-	sub	r3,pc,#8		@ sha256_block_data_order
+	sub	r3,pc,#8		@ GFp_sha256_block_data_order
 #else
 	adr	r3,.Lsha256_block_data_order
 #endif
@@ -286,7 +286,7 @@ $code.=<<___;
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	sha256_block_data_order,.-sha256_block_data_order
+.size	GFp_sha256_block_data_order,.-GFp_sha256_block_data_order
 ___
 ######################################################################
 # NEON stuff
@@ -466,7 +466,6 @@ $code.=<<___;
 .arch	armv7-a
 .fpu	neon
 
-.global	sha256_block_data_order_neon
 .type	sha256_block_data_order_neon,%function
 .align	5
 .skip	16

--- a/crypto/sha/asm/sha512-586.pl
+++ b/crypto/sha/asm/sha512-586.pl
@@ -58,7 +58,7 @@ open STDOUT,">$output";
 $sse2=0;
 for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 
-&external_label("OPENSSL_ia32cap_P") if ($sse2);
+&external_label("GFp_ia32cap_P") if ($sse2);
 
 $Tlo=&DWP(0,"esp");	$Thi=&DWP(4,"esp");
 $Alo=&DWP(8,"esp");	$Ahi=&DWP(8+4,"esp");
@@ -305,7 +305,7 @@ sub BODY_00_15_x86 {
 	&mov	(&DWP(12,"esp"),"ebx");	# saved sp
 
 if ($sse2) {
-	&picmeup("edx","OPENSSL_ia32cap_P",$K512,&label("K512"));
+	&picmeup("edx","GFp_ia32cap_P",$K512,&label("K512"));
 	&mov	("ecx",&DWP(0,"edx"));
 	&test	("ecx",1<<26);
 	&jz	(&label("loop_x86"));

--- a/crypto/sha/asm/sha512-586.pl
+++ b/crypto/sha/asm/sha512-586.pl
@@ -283,7 +283,7 @@ sub BODY_00_15_x86 {
 }
 
 
-&function_begin("sha512_block_data_order");
+&function_begin("GFp_sha512_block_data_order");
 	&mov	("esi",wparam(0));	# ctx
 	&mov	("edi",wparam(1));	# inp
 	&mov	("eax",wparam(2));	# num
@@ -908,7 +908,7 @@ sub BODY_00_15_ssse3 {		# "phase-less" copy of BODY_00_15_sse2
 
 	&data_word(0x04050607,0x00010203);	# byte swap
 	&data_word(0x0c0d0e0f,0x08090a0b);	# mask
-&function_end_B("sha512_block_data_order");
+&function_end_B("GFp_sha512_block_data_order");
 &asciz("SHA512 block transform for x86, CRYPTOGAMS by <appro\@openssl.org>");
 
 &asm_finish();

--- a/crypto/sha/asm/sha512-armv4.pl
+++ b/crypto/sha/asm/sha512-armv4.pl
@@ -266,7 +266,7 @@ WORD64(0x5fcb6fab,0x3ad6faec, 0x6c44198c,0x4a475817)
 .size	K512,.-K512
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
 .LOPENSSL_armcap:
-.word	OPENSSL_armcap_P-.Lsha512_block_data_order
+.word	GFp_armcap_P-.Lsha512_block_data_order
 .skip	32-4
 #else
 .skip	32
@@ -283,7 +283,7 @@ sha512_block_data_order:
 #endif
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
 	ldr	r12,.LOPENSSL_armcap
-	ldr	r12,[r3,r12]		@ OPENSSL_armcap_P
+	ldr	r12,[r3,r12]		@ GFp_armcap_P
 #ifdef	__APPLE__
 	ldr	r12,[r12]
 #endif
@@ -641,8 +641,8 @@ $code.=<<___;
 .asciz	"SHA512 block transform for ARMv4/NEON, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
-.comm	OPENSSL_armcap_P,4,4
-.hidden	OPENSSL_armcap_P
+.comm	GFp_armcap_P,4,4
+.hidden	GFp_armcap_P
 #endif
 ___
 

--- a/crypto/sha/asm/sha512-armv4.pl
+++ b/crypto/sha/asm/sha512-armv4.pl
@@ -272,12 +272,12 @@ WORD64(0x5fcb6fab,0x3ad6faec, 0x6c44198c,0x4a475817)
 .skip	32
 #endif
 
-.global	sha512_block_data_order
-.type	sha512_block_data_order,%function
-sha512_block_data_order:
+.global	GFp_sha512_block_data_order
+.type	GFp_sha512_block_data_order,%function
+GFp_sha512_block_data_order:
 .Lsha512_block_data_order:
 #if __ARM_ARCH__<7 && !defined(__thumb2__)
-	sub	r3,pc,#8		@ sha512_block_data_order
+	sub	r3,pc,#8		@ GFp_sha512_block_data_order
 #else
 	adr	r3,.Lsha512_block_data_order
 #endif
@@ -491,7 +491,7 @@ $code.=<<___;
 	moveq	pc,lr			@ be binary compatible with V4, yet
 	bx	lr			@ interoperable with Thumb ISA:-)
 #endif
-.size	sha512_block_data_order,.-sha512_block_data_order
+.size	GFp_sha512_block_data_order,.-GFp_sha512_block_data_order
 ___
 
 {
@@ -598,7 +598,6 @@ $code.=<<___;
 .arch	armv7-a
 .fpu	neon
 
-.global	sha512_block_data_order_neon
 .type	sha512_block_data_order_neon,%function
 .align	4
 sha512_block_data_order_neon:

--- a/crypto/test/bn_test_convert.c
+++ b/crypto/test/bn_test_convert.c
@@ -71,7 +71,7 @@ static BIGNUM *bn_expand(BIGNUM *bn, size_t bits) {
     OPENSSL_PUT_ERROR(BN, BN_R_BIGNUM_TOO_LONG);
     return NULL;
   }
-  return bn_wexpand(bn, (bits+BN_BITS2-1)/BN_BITS2);
+  return GFp_bn_wexpand(bn, (bits+BN_BITS2-1)/BN_BITS2);
 }
 
 /* decode_hex decodes |in_len| bytes of hex data from |in| and updates |bn|. */
@@ -147,21 +147,21 @@ static int bn_x2bn(BIGNUM **outp, const char *in, decode_func decode, char_test_
 
   /* in is the start of the hex digits, and it is 'i' long */
   if (*outp == NULL) {
-    ret = BN_new();
+    ret = GFp_BN_new();
     if (ret == NULL) {
       return 0;
     }
   } else {
     ret = *outp;
-    BN_zero(ret);
+    GFp_BN_zero(ret);
   }
 
   if (!decode(ret, in, i)) {
     goto err;
   }
 
-  bn_correct_top(ret);
-  if (!BN_is_zero(ret)) {
+  GFp_bn_correct_top(ret);
+  if (!GFp_BN_is_zero(ret)) {
     ret->neg = neg;
   }
 
@@ -170,7 +170,7 @@ static int bn_x2bn(BIGNUM **outp, const char *in, decode_func decode, char_test_
 
 err:
   if (*outp == NULL) {
-    BN_free(ret);
+    GFp_BN_free(ret);
   }
 
   return 0;
@@ -184,7 +184,7 @@ size_t BN_bn2bin(const BIGNUM *in, uint8_t *out) {
   size_t n, i;
   BN_ULONG l;
 
-  n = i = BN_num_bytes(in);
+  n = i = GFp_BN_num_bytes(in);
   while (i--) {
     l = in->d[i / BN_BYTES];
     *(out++) = (unsigned char)(l >> (8 * (i % BN_BYTES))) & 0xff;
@@ -193,7 +193,7 @@ size_t BN_bn2bin(const BIGNUM *in, uint8_t *out) {
 }
 
 void BN_set_negative(BIGNUM *bn, int sign) {
-  if (sign && !BN_is_zero(bn)) {
+  if (sign && !GFp_BN_is_zero(bn)) {
     bn->neg = 1;
   } else {
     bn->neg = 0;

--- a/crypto/test/bn_test_lib.c
+++ b/crypto/test/bn_test_lib.c
@@ -125,7 +125,7 @@ int BN_rand(BIGNUM *rnd, int bits, RAND *rng) {
   }
 
   if (bits == 0) {
-    BN_zero(rnd);
+    GFp_BN_zero(rnd);
     return 1;
   }
 
@@ -148,7 +148,7 @@ int BN_rand(BIGNUM *rnd, int bits, RAND *rng) {
   buf[0] |= (1 << bit);
   buf[0] &= ~mask;
 
-  if (!BN_bin2bn(buf, bytes, rnd)) {
+  if (!GFp_BN_bin2bn(buf, bytes, rnd)) {
     goto err;
   }
 

--- a/crypto/test/scoped_types.h
+++ b/crypto/test/scoped_types.h
@@ -44,7 +44,7 @@ struct OpenSSLDeleter {
 #define SCOPED_OPENSSL_TYPE(Name, T, func) \
         typedef std::unique_ptr<T, OpenSSLDeleter<T, func>> Name
 
-SCOPED_OPENSSL_TYPE(ScopedBIGNUM, BIGNUM, BN_free);
-SCOPED_OPENSSL_TYPE(ScopedBN_MONT_CTX, BN_MONT_CTX, BN_MONT_CTX_free);
+SCOPED_OPENSSL_TYPE(ScopedBIGNUM, BIGNUM, GFp_BN_free);
+SCOPED_OPENSSL_TYPE(ScopedBN_MONT_CTX, BN_MONT_CTX, GFp_BN_MONT_CTX_free);
 
 #endif  // OPENSSL_HEADER_CRYPTO_TEST_SCOPED_TYPES_H

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -75,18 +75,18 @@ struct aes_key_st {
 };
 typedef struct aes_key_st AES_KEY;
 
-/* AES_set_encrypt_key configures |aeskey| to encrypt with the |bits|-bit key,
- * |key|.
+/* GFp_AES_set_encrypt_key configures |aeskey| to encrypt with the |bits|-bit
+ * key, |key|.
  *
  * WARNING: unlike other OpenSSL functions, this returns zero on success and a
  * negative number on error. */
-OPENSSL_EXPORT int AES_set_encrypt_key(const uint8_t *key, unsigned bits,
-                                       AES_KEY *aeskey);
+OPENSSL_EXPORT int GFp_AES_set_encrypt_key(const uint8_t *key, unsigned bits,
+                                           AES_KEY *aeskey);
 
 /* AES_encrypt encrypts a single block from |in| to |out| with |key|. The |in|
  * and |out| pointers may overlap. */
-OPENSSL_EXPORT void AES_encrypt(const uint8_t *in, uint8_t *out,
-                                const AES_KEY *key);
+OPENSSL_EXPORT void GFp_AES_encrypt(const uint8_t *in, uint8_t *out,
+                                    const AES_KEY *key);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -162,68 +162,70 @@ extern "C" {
 
 /* Allocation and freeing. */
 
-/* BN_new creates a new, allocated BIGNUM and initialises it. */
-OPENSSL_EXPORT BIGNUM *BN_new(void);
+/* GFp_BN_new creates a new, allocated BIGNUM and initialises it. */
+OPENSSL_EXPORT BIGNUM *GFp_BN_new(void);
 
-/* BN_init initialises a stack allocated |BIGNUM|. */
-OPENSSL_EXPORT void BN_init(BIGNUM *bn);
+/* GFp_BN_init initialises a stack allocated |BIGNUM|. */
+OPENSSL_EXPORT void GFp_BN_init(BIGNUM *bn);
 
-/* BN_free frees the data referenced by |bn| and, if |bn| was originally
+/* GFp_BN_free frees the data referenced by |bn| and, if |bn| was originally
  * allocated on the heap, frees |bn| also. */
-OPENSSL_EXPORT void BN_free(BIGNUM *bn);
+OPENSSL_EXPORT void GFp_BN_free(BIGNUM *bn);
 
-/* BN_copy sets |dest| equal to |src| and returns |dest| or NULL on allocation
+/* GFp_BN_copy sets |dest| equal to |src| and returns |dest| or NULL on allocation
  * failure. */
-OPENSSL_EXPORT BIGNUM *BN_copy(BIGNUM *dest, const BIGNUM *src);
+OPENSSL_EXPORT BIGNUM *GFp_BN_copy(BIGNUM *dest, const BIGNUM *src);
 
-/* BN_value_one returns a static BIGNUM with value 1. */
-OPENSSL_EXPORT const BIGNUM *BN_value_one(void);
+/* GFp_BN_value_one returns a static BIGNUM with value 1. */
+OPENSSL_EXPORT const BIGNUM *GFp_BN_value_one(void);
 
 
 /* Basic functions. */
 
-/* BN_num_bits returns the minimum number of bits needed to represent the
+/* GFp_BN_num_bits returns the minimum number of bits needed to represent the
  * absolute value of |bn|. */
-OPENSSL_EXPORT unsigned BN_num_bits(const BIGNUM *bn);
+OPENSSL_EXPORT unsigned GFp_BN_num_bits(const BIGNUM *bn);
 
-/* BN_num_bytes returns the minimum number of bytes needed to represent the
+/* GFp_BN_num_bytes returns the minimum number of bytes needed to represent the
  * absolute value of |bn|. */
-OPENSSL_EXPORT unsigned BN_num_bytes(const BIGNUM *bn);
+OPENSSL_EXPORT unsigned GFp_BN_num_bytes(const BIGNUM *bn);
 
-/* BN_zero sets |bn| to zero. */
-OPENSSL_EXPORT void BN_zero(BIGNUM *bn);
+/* GFp_BN_zero sets |bn| to zero. */
+OPENSSL_EXPORT void GFp_BN_zero(BIGNUM *bn);
 
-/* BN_one sets |bn| to one. It returns one on success or zero on allocation
+/* GFp_BN_one sets |bn| to one. It returns one on success or zero on allocation
  * failure. */
-OPENSSL_EXPORT int BN_one(BIGNUM *bn);
+OPENSSL_EXPORT int GFp_BN_one(BIGNUM *bn);
 
-/* BN_set_word sets |bn| to |value|. It returns one on success or zero on
+/* GFp_BN_set_word sets |bn| to |value|. It returns one on success or zero on
  * allocation failure. */
-OPENSSL_EXPORT int BN_set_word(BIGNUM *bn, BN_ULONG value);
+OPENSSL_EXPORT int GFp_BN_set_word(BIGNUM *bn, BN_ULONG value);
 
-/* BN_is_negative returns one if |bn| is negative and zero otherwise. */
-OPENSSL_EXPORT int BN_is_negative(const BIGNUM *bn);
+/* GFp_BN_is_negative returns one if |bn| is negative and zero otherwise. */
+OPENSSL_EXPORT int GFp_BN_is_negative(const BIGNUM *bn);
 
-/* BN_get_flags returns |bn->flags| & |flags|. */
-OPENSSL_EXPORT int BN_get_flags(const BIGNUM *bn, int flags);
+/* GFp_BN_get_flags returns |bn->flags| & |flags|. */
+OPENSSL_EXPORT int GFp_BN_get_flags(const BIGNUM *bn, int flags);
 
-/* BN_set_flags sets |flags| on |bn|. */
-OPENSSL_EXPORT void BN_set_flags(BIGNUM *bn, int flags);
+/* GFp_BN_set_flags sets |flags| on |bn|. */
+OPENSSL_EXPORT void GFp_BN_set_flags(BIGNUM *bn, int flags);
 
 
 /* Conversion functions. */
 
-/* BN_bin2bn sets |*ret| to the value of |len| bytes from |in|, interpreted as
- * a big-endian number, and returns |ret|. If |ret| is NULL then a fresh
+/* GFp_BN_bin2bn sets |*ret| to the value of |len| bytes from |in|, interpreted
+ * as a big-endian number, and returns |ret|. If |ret| is NULL then a fresh
  * |BIGNUM| is allocated and returned. It returns NULL on allocation
  * failure. */
-OPENSSL_EXPORT BIGNUM *BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret);
+OPENSSL_EXPORT BIGNUM *GFp_BN_bin2bn(const uint8_t *in, size_t len,
+                                     BIGNUM *ret);
 
-/* BN_bn2bin_padded serialises the absolute value of |in| to |out| as a
+/* GFp_BN_bn2bin_padded serialises the absolute value of |in| to |out| as a
  * big-endian integer. The integer is padded with leading zeros up to size
- * |len|. If |len| is smaller than |BN_num_bytes|, the function fails and
+ * |len|. If |len| is smaller than |GFp_BN_num_bytes|, the function fails and
  * returns 0. Otherwise, it returns 1. */
-OPENSSL_EXPORT int BN_bn2bin_padded(uint8_t *out, size_t len, const BIGNUM *in);
+OPENSSL_EXPORT int GFp_BN_bn2bin_padded(uint8_t *out, size_t len,
+                                        const BIGNUM *in);
 
 
 /* Internal functions.
@@ -234,125 +236,127 @@ OPENSSL_EXPORT int BN_bn2bin_padded(uint8_t *out, size_t len, const BIGNUM *in);
 
 /* bn_correct_top decrements |bn->top| until |bn->d[top-1]| is non-zero or
  * until |top| is zero. If |bn| is zero, |bn->neg| is set to zero. */
-OPENSSL_EXPORT void bn_correct_top(BIGNUM *bn);
+OPENSSL_EXPORT void GFp_bn_correct_top(BIGNUM *bn);
 
 /* bn_wexpand ensures that |bn| has at least |words| works of space without
  * altering its value. It returns one on success or zero on allocation
  * failure. */
-OPENSSL_EXPORT BIGNUM *bn_wexpand(BIGNUM *bn, size_t words);
+OPENSSL_EXPORT BIGNUM *GFp_bn_wexpand(BIGNUM *bn, size_t words);
 
 
 /* Simple arithmetic */
 
-/* BN_add sets |r| = |a| + |b|, where |r| may be the same pointer as either |a|
- * or |b|. It returns one on success and zero on allocation failure. */
-OPENSSL_EXPORT int BN_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
+/* GFp_BN_add sets |r| = |a| + |b|, where |r| may be the same pointer as either
+ * |a| or |b|. It returns one on success and zero on allocation failure. */
+OPENSSL_EXPORT int GFp_BN_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
 
-/* BN_uadd sets |r| = |a| + |b|, where |a| and |b| are non-negative and |r| may
- * be the same pointer as either |a| or |b|. It returns one on success and zero
- * on allocation failure. */
-OPENSSL_EXPORT int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
+/* GFp_BN_uadd sets |r| = |a| + |b|, where |a| and |b| are non-negative and |r|
+ * may be the same pointer as either |a| or |b|. It returns one on success and
+ * zero on allocation failure. */
+OPENSSL_EXPORT int GFp_BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
 
-/* BN_sub sets |r| = |a| - |b|, where |r| may be the same pointer as either |a|
- * or |b|. It returns one on success and zero on allocation failure. */
-OPENSSL_EXPORT int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
+/* GFp_BN_sub sets |r| = |a| - |b|, where |r| may be the same pointer as either
+ * |a| or |b|. It returns one on success and zero on allocation failure. */
+OPENSSL_EXPORT int GFp_BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
 
-/* BN_usub sets |r| = |a| - |b|, where |a| and |b| are non-negative integers,
- * |b| < |a| and |r| may be the same pointer as either |a| or |b|. It returns
- * one on success and zero on allocation failure. */
-OPENSSL_EXPORT int BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
+/* GFp_BN_usub sets |r| = |a| - |b|, where |a| and |b| are non-negative
+ * integers, |b| < |a| and |r| may be the same pointer as either |a| or |b|. It
+ * returns one on success and zero on allocation failure. */
+OPENSSL_EXPORT int GFp_BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
 
-/* BN_usub_unchecked is line |BN_usub| except it doesn't assert that the
- * preconditions are true. */
-OPENSSL_EXPORT int BN_usub_unchecked(BIGNUM *r, const BIGNUM *a,
-                                     const BIGNUM *b);
+/* GFp_BN_usub_unchecked is line |GFp_BN_usub| except it doesn't assert that
+ * the preconditions are true. */
+OPENSSL_EXPORT int GFp_BN_usub_unchecked(BIGNUM *r, const BIGNUM *a,
+                                         const BIGNUM *b);
 
-/* BN_mul_no_alias sets |r| = |a| * |b|, where |r| must not be the same pointer
+/* GFp_BN_mul_no_alias sets |r| = |a| * |b|, where |r| must not be the same pointer
  * as |a| or |b|. Returns one on success and zero otherwise. */
-OPENSSL_EXPORT int BN_mul_no_alias(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
+OPENSSL_EXPORT int GFp_BN_mul_no_alias(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
 
-/* BN_div divides |numerator| by |divisor| and places the result in |quotient|
- * and the remainder in |rem|. Either of |quotient| or |rem| may be NULL, in
- * which case the respective value is not returned. The result is rounded
- * towards zero; thus if |numerator| is negative, the remainder will be zero or
- * negative. It returns one on success or zero on error. */
-OPENSSL_EXPORT int BN_div(BIGNUM *quotient, BIGNUM *rem,
-                          const BIGNUM *numerator, const BIGNUM *divisor);
+/* GFp_BN_div divides |numerator| by |divisor| and places the result in
+ * |quotient| and the remainder in |rem|. Either of |quotient| or |rem| may be
+ * NULL, in which case the respective value is not returned. The result is
+ * rounded towards zero; thus if |numerator| is negative, the remainder will be
+ * zero or negative. It returns one on success or zero on error. */
+OPENSSL_EXPORT int GFp_BN_div(BIGNUM *quotient, BIGNUM *rem,
+                              const BIGNUM *numerator, const BIGNUM *divisor);
 
 
 /* Comparison functions */
 
-/* BN_cmp returns a value less than, equal to or greater than zero if |a| is
- * less than, equal to or greater than |b|, respectively. */
-OPENSSL_EXPORT int BN_cmp(const BIGNUM *a, const BIGNUM *b);
+/* GFp_BN_cmp returns a value less than, equal to or greater than zero if |a|
+ * is less than, equal to or greater than |b|, respectively. */
+OPENSSL_EXPORT int GFp_BN_cmp(const BIGNUM *a, const BIGNUM *b);
 
-/* BN_cmp_word is like |BN_cmp| except it takes its second argument as a
- * |BN_ULONG| instead of a |BIGNUM|. */
-OPENSSL_EXPORT int BN_cmp_word(const BIGNUM *a, BN_ULONG b);
+/* GFp_BN_cmp_word is like |GFp_BN_cmp| except it takes its second argument as
+ * a |BN_ULONG| instead of a |BIGNUM|. */
+OPENSSL_EXPORT int GFp_BN_cmp_word(const BIGNUM *a, BN_ULONG b);
 
-/* BN_ucmp returns a value less than, equal to or greater than zero if the
+/* GFp_BN_ucmp returns a value less than, equal to or greater than zero if the
  * absolute value of |a| is less than, equal to or greater than the absolute
  * value of |b|, respectively. */
-OPENSSL_EXPORT int BN_ucmp(const BIGNUM *a, const BIGNUM *b);
+OPENSSL_EXPORT int GFp_BN_ucmp(const BIGNUM *a, const BIGNUM *b);
 
-/* BN_abs_is_word returns one if the absolute value of |bn| equals |w| and zero
- * otherwise. */
-OPENSSL_EXPORT int BN_abs_is_word(const BIGNUM *bn, BN_ULONG w);
+/* GFp_BN_abs_is_word returns one if the absolute value of |bn| equals |w| and
+ * zero otherwise. */
+OPENSSL_EXPORT int GFp_BN_abs_is_word(const BIGNUM *bn, BN_ULONG w);
 
-/* BN_is_zero returns one if |bn| is zero and zero otherwise. */
-OPENSSL_EXPORT int BN_is_zero(const BIGNUM *bn);
+/* GFp_BN_is_zero returns one if |bn| is zero and zero otherwise. */
+OPENSSL_EXPORT int GFp_BN_is_zero(const BIGNUM *bn);
 
-/* BN_is_one returns one if |bn| equals one and zero otherwise. */
-OPENSSL_EXPORT int BN_is_one(const BIGNUM *bn);
+/* GFp_BN_is_one returns one if |bn| equals one and zero otherwise. */
+OPENSSL_EXPORT int GFp_BN_is_one(const BIGNUM *bn);
 
-/* BN_is_odd returns one if |bn| is odd and zero otherwise. */
-OPENSSL_EXPORT int BN_is_odd(const BIGNUM *bn);
+/* GFp_BN_is_odd returns one if |bn| is odd and zero otherwise. */
+OPENSSL_EXPORT int GFp_BN_is_odd(const BIGNUM *bn);
 
 
 /* Bitwise operations. */
 
-/* BN_lshift sets |r| equal to |a| << n. The |a| and |r| arguments may be the
- * same |BIGNUM|. It returns one on success and zero on allocation failure. */
-OPENSSL_EXPORT int BN_lshift(BIGNUM *r, const BIGNUM *a, int n);
+/* GFp_BN_lshift sets |r| equal to |a| << n. The |a| and |r| arguments may be
+ * the same |BIGNUM|. It returns one on success and zero on allocation failure.
+ */
+OPENSSL_EXPORT int GFp_BN_lshift(BIGNUM *r, const BIGNUM *a, int n);
 
-/* BN_lshift1 sets |r| equal to |a| << 1, where |r| and |a| may be the same
+/* GFp_BN_lshift1 sets |r| equal to |a| << 1, where |r| and |a| may be the same
  * pointer. It returns one on success and zero on allocation failure. */
-OPENSSL_EXPORT int BN_lshift1(BIGNUM *r, const BIGNUM *a);
+OPENSSL_EXPORT int GFp_BN_lshift1(BIGNUM *r, const BIGNUM *a);
 
-/* BN_rshift sets |r| equal to |a| >> n, where |r| and |a| may be the same
+/* GFp_BN_rshift sets |r| equal to |a| >> n, where |r| and |a| may be the same
  * pointer. It returns one on success and zero on allocation failure. */
-OPENSSL_EXPORT int BN_rshift(BIGNUM *r, const BIGNUM *a, int n);
+OPENSSL_EXPORT int GFp_BN_rshift(BIGNUM *r, const BIGNUM *a, int n);
 
-/* BN_rshift1 sets |r| equal to |a| >> 1, where |r| and |a| may be the same
+/* GFp_BN_rshift1 sets |r| equal to |a| >> 1, where |r| and |a| may be the same
  * pointer. It returns one on success and zero on allocation failure. */
-OPENSSL_EXPORT int BN_rshift1(BIGNUM *r, const BIGNUM *a);
+OPENSSL_EXPORT int GFp_BN_rshift1(BIGNUM *r, const BIGNUM *a);
 
-/* BN_set_bit sets the |n|th, least-significant bit in |a|. For example, if |a|
- * is 2 then setting bit zero will make it 3. It returns one on success or zero
- * on allocation failure. */
-OPENSSL_EXPORT int BN_set_bit(BIGNUM *a, int n);
+/* GFp_BN_set_bit sets the |n|th, least-significant bit in |a|. For example, if
+ * |a| is 2 then setting bit zero will make it 3. It returns one on success or
+ * zero on allocation failure. */
+OPENSSL_EXPORT int GFp_BN_set_bit(BIGNUM *a, int n);
 
-/* BN_is_bit_set returns the value of the |n|th, least-significant bit in |a|,
- * or zero if the bit doesn't exist. */
-OPENSSL_EXPORT int BN_is_bit_set(const BIGNUM *a, int n);
+/* GFp_BN_is_bit_set returns the value of the |n|th, least-significant bit in
+ * |a|, or zero if the bit doesn't exist. */
+OPENSSL_EXPORT int GFp_BN_is_bit_set(const BIGNUM *a, int n);
 
 
 /* Modulo arithmetic. */
 
-/* BN_mod is a helper macro that calls |BN_div| and discards the quotient. */
-#define BN_mod(rem, numerator, divisor) \
-  BN_div(NULL, (rem), (numerator), (divisor))
+/* GFp_BN_mod is a helper macro that calls |GFp_BN_div| and discards the
+ * quotient. */
+#define GFp_BN_mod(rem, numerator, divisor) \
+  GFp_BN_div(NULL, (rem), (numerator), (divisor))
 
-/* BN_nnmod is a non-negative modulo function. It acts like |BN_mod|, but 0 <=
- * |rem| < |divisor| is always true. It returns one on success and zero on
- * error. */
-OPENSSL_EXPORT int BN_nnmod(BIGNUM *rem, const BIGNUM *numerator,
-                            const BIGNUM *divisor);
+/* GFp_BN_nnmod is a non-negative modulo function. It acts like |GFp_BN_mod|,
+ * but 0 <= |rem| < |divisor| is always true. It returns one on success and
+ * zero on error. */
+OPENSSL_EXPORT int GFp_BN_nnmod(BIGNUM *rem, const BIGNUM *numerator,
+                                const BIGNUM *divisor);
 
-/* BN_mod_sub_quick acts like |BN_mod_sub| but requires that |a| and |b| be
- * non-negative and less than |m|. */
-OPENSSL_EXPORT int BN_mod_sub_quick(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
-                                    const BIGNUM *m);
+/* GFp_BN_mod_sub_quick acts like |GFp_BN_mod_sub| but requires that |a| and
+ * |b| be non-negative and less than |m|. */
+OPENSSL_EXPORT int GFp_BN_mod_sub_quick(BIGNUM *r, const BIGNUM *a,
+                                        const BIGNUM *b, const BIGNUM *m);
 
 
 /* Random generation. */
@@ -361,34 +365,35 @@ OPENSSL_EXPORT int BN_mod_sub_quick(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
 extern int GFp_rand_mod(BN_ULONG *dest, const BN_ULONG *max_exclusive,
                         size_t num_limbs, RAND *rand);
 
-/* BN_rand_range_ex sets |rnd| to a random value in [1..max_exclusive). It
+/* GFp_BN_rand_range_ex sets |rnd| to a random value in [1..max_exclusive). It
  * returns one on success and zero otherwise. */
-OPENSSL_EXPORT int BN_rand_range_ex(BIGNUM *r, const BIGNUM *max_exclusive,
-                                    RAND *rng);
+OPENSSL_EXPORT int GFp_BN_rand_range_ex(BIGNUM *r, const BIGNUM *max_exclusive,
+                                        RAND *rng);
 
 
 /* Number theory functions */
 
-/* BN_mod_inverse_blinded sets |out| equal to |a|^-1, mod |n|, where |n| is the
- * Montgomery modulus for |mont|. |a| must be non-negative and must be less
+/* GFp_BN_mod_inverse_blinded sets |out| equal to |a|^-1, mod |n|, where |n| is
+ * the Montgomery modulus for |mont|. |a| must be non-negative and must be less
  * than |n|. |n| must be greater than 1. |a| is blinded (masked by a random
  * value) to protect it against side-channel attacks. On failure, if the
  * failure was caused by |a| having no inverse mod |n| then |*out_no_inverse|
  * will be set to one; otherwise it will be set to zero. */
-int BN_mod_inverse_blinded(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
-                           const BN_MONT_CTX *mont, RAND *rng);
+int GFp_BN_mod_inverse_blinded(BIGNUM *out, int *out_no_inverse,
+                               const BIGNUM *a, const BN_MONT_CTX *mont,
+                               RAND *rng);
 
-/* BN_mod_inverse_odd sets |out| equal to |a|^-1, mod |n|. |a| must be
+/* GFp_BN_mod_inverse_odd sets |out| equal to |a|^-1, mod |n|. |a| must be
  * non-negative and must be less than |n|. |n| must be odd. This function
- * shouldn't be used for secret values; use |BN_mod_inverse_blinded| instead.
- * Or, if |n| is guaranteed to be prime, use
- * |BN_mod_exp_mont_consttime(out, a, m_minus_2, m, ctx, m_mont)|, taking
+ * shouldn't be used for secret values; use |GFp_BN_mod_inverse_blinded|
+ * instead. Or, if |n| is guaranteed to be prime, use
+ * |GFp_BN_mod_exp_mont_consttime(out, a, m_minus_2, m, ctx, m_mont)|, taking
  * advantage of Fermat's Little Theorem. It returns one on success or zero on
  * failure. On failure, if the failure was caused by |a| having no inverse mod
  * |n| then |*out_no_inverse| will be set to one; otherwise it will be set to
  * zero. */
-int BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
-                       const BIGNUM *n);
+int GFp_BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
+                           const BIGNUM *n);
 
 
 /* Montgomery arithmetic. */
@@ -396,50 +401,53 @@ int BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
 /* BN_MONT_CTX contains the precomputed values needed to work in a specific
  * Montgomery domain. */
 
-/* BN_MONT_CTX_new returns a fresh BN_MONT_CTX or NULL on allocation failure. */
-OPENSSL_EXPORT BN_MONT_CTX *BN_MONT_CTX_new(void);
+/* GFp_BN_MONT_CTX_new returns a fresh BN_MONT_CTX or NULL on allocation
+ * failure. */
+OPENSSL_EXPORT BN_MONT_CTX *GFp_BN_MONT_CTX_new(void);
 
-/* BN_MONT_CTX_free frees memory associated with |mont|. */
-OPENSSL_EXPORT void BN_MONT_CTX_free(BN_MONT_CTX *mont);
+/* GFp_BN_MONT_CTX_free frees memory associated with |mont|. */
+OPENSSL_EXPORT void GFp_BN_MONT_CTX_free(BN_MONT_CTX *mont);
 
-/* BN_MONT_CTX_set sets up a Montgomery context given the modulus, |mod|. It
- * returns one on success and zero on error. */
-OPENSSL_EXPORT int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod);
+/* GFp_BN_MONT_CTX_set sets up a Montgomery context given the modulus, |mod|.
+ * It returns one on success and zero on error. */
+OPENSSL_EXPORT int GFp_BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod);
 
-/* BN_to_mont sets |ret| equal to |a| in the Montgomery domain. |a| is assumed
- * to be in the range [0, n), where |n| is the Montgomery modulus. It returns
- * one on success or zero on error. */
-OPENSSL_EXPORT int BN_to_mont(BIGNUM *ret, const BIGNUM *a,
-                              const BN_MONT_CTX *mont);
+/* GFp_BN_to_mont sets |ret| equal to |a| in the Montgomery domain. |a| is
+ * assumed to be in the range [0, n), where |n| is the Montgomery modulus. It
+ * returns one on success or zero on error. */
+OPENSSL_EXPORT int GFp_BN_to_mont(BIGNUM *ret, const BIGNUM *a,
+                                  const BN_MONT_CTX *mont);
 
-/* BN_from_mont sets |ret| equal to |a| * R^-1, i.e. translates values out of
- * the Montgomery domain. |a| is assumed to be in the range [0, n), where |n|
+/* GFp_BN_from_mont sets |ret| equal to |a| * R^-1, i.e. translates values out
+ * of the Montgomery domain. |a| is assumed to be in the range [0, n), where |n|
  * is the Montgomery modulus. It returns one on success or zero on error. */
-OPENSSL_EXPORT int BN_from_mont(BIGNUM *ret, const BIGNUM *a,
-                                const BN_MONT_CTX *mont);
+OPENSSL_EXPORT int GFp_BN_from_mont(BIGNUM *ret, const BIGNUM *a,
+                                    const BN_MONT_CTX *mont);
 
-/* BN_mod_mul_mont set |r| equal to |a| * |b|, in the Montgomery domain. Both
- * |a| and |b| must already be in the Montgomery domain (by |BN_to_mont|). In
- * particular, |a| and |b| are assumed to be in the range [0, n), where |n| is
- * the Montgomery modulus. It returns one on success or zero on error. */
-OPENSSL_EXPORT int BN_mod_mul_mont(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
-                                   const BN_MONT_CTX *mont);
+/* GFp_BN_mod_mul_mont set |r| equal to |a| * |b|, in the Montgomery domain.
+ * Both |a| and |b| must already be in the Montgomery domain (by
+ * |GFp_BN_to_mont|). In particular, |a| and |b| are assumed to be in the range
+ * [0, n), where |n| is the Montgomery modulus. It returns one on success or
+ * zero on error. */
+OPENSSL_EXPORT int GFp_BN_mod_mul_mont(BIGNUM *r, const BIGNUM *a,
+                                       const BIGNUM *b,
+                                       const BN_MONT_CTX *mont);
 
-/* BN_reduce_montgomery returns |a % n| in constant-ish time using Montgomery
- * reduction. |a| is assumed to be in the range [0, n**2), where |n| is the
- * Montgomery modulus. It returns one on success or zero on error. */
-int BN_reduce_mont(BIGNUM *r, const BIGNUM *a, const BN_MONT_CTX *mont);
+/* GFp_BN_reduce_montgomery returns |a % n| in constant-ish time using
+ * Montgomery reduction. |a| is assumed to be in the range [0, n**2), where |n|
+ * is the Montgomery modulus. It returns one on success or zero on error. */
+int GFp_BN_reduce_mont(BIGNUM *r, const BIGNUM *a, const BN_MONT_CTX *mont);
 
 
 /* Exponentiation. */
 
-OPENSSL_EXPORT int BN_mod_exp_mont_vartime(BIGNUM *r, const BIGNUM *a,
-                                           const BIGNUM *p, const BIGNUM *m,
-                                           const BN_MONT_CTX *mont);
+OPENSSL_EXPORT int GFp_BN_mod_exp_mont_vartime(BIGNUM *r, const BIGNUM *a,
+                                               const BIGNUM *p, const BIGNUM *m,
+                                               const BN_MONT_CTX *mont);
 
-OPENSSL_EXPORT int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a,
-                                             const BIGNUM *p,
-                                             const BN_MONT_CTX *mont);
+OPENSSL_EXPORT int GFp_BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a,
+                                                 const BIGNUM *p,
+                                                 const BN_MONT_CTX *mont);
 
 
 /* Private functions */
@@ -464,7 +472,7 @@ struct bn_mont_ctx_st {
   BN_ULONG n0[2];
 };
 
-OPENSSL_EXPORT unsigned BN_num_bits_word(BN_ULONG l);
+OPENSSL_EXPORT unsigned GFp_BN_num_bits_word(BN_ULONG l);
 
 #define BN_FLG_MALLOCED 0x01
 #define BN_FLG_STATIC_DATA 0x02

--- a/include/openssl/cpu.h
+++ b/include/openssl/cpu.h
@@ -72,7 +72,7 @@ extern "C" {
 
 
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
-/* OPENSSL_ia32cap_P contains the Intel CPUID bits when running on an x86 or
+/* GFp_ia32cap_P contains the Intel CPUID bits when running on an x86 or
  * x86-64 system.
  *
  *   Index 0:
@@ -90,7 +90,7 @@ extern "C" {
  *
  * Note: the CPUID bits are pre-adjusted for the OSXSAVE bit and the YMM and XMM
  * bits in XCR0, so it is not necessary to check those. */
-extern uint32_t OPENSSL_ia32cap_P[4];
+extern uint32_t GFp_ia32cap_P[4];
 #endif
 
 #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)

--- a/include/openssl/cpu.h
+++ b/include/openssl/cpu.h
@@ -110,14 +110,14 @@ extern uint32_t OPENSSL_ia32cap_P[4];
 
 #if !defined(OPENSSL_STATIC_ARMCAP)
 
-/* CRYPTO_is_NEON_capable_at_runtime returns true if the current CPU has a NEON
+/* GFp_is_NEON_capable_at_runtime returns true if the current CPU has a NEON
  * unit. Note that |OPENSSL_armcap_P| also exists and contains the same
  * information in a form that's easier for assembly to use. */
-OPENSSL_EXPORT char CRYPTO_is_NEON_capable_at_runtime(void);
+OPENSSL_EXPORT char GFp_is_NEON_capable_at_runtime(void);
 
-/* CRYPTO_is_NEON_capable returns true if the current CPU has a NEON unit. If
+/* GFp_is_NEON_capable returns true if the current CPU has a NEON unit. If
  * this is known statically then it returns one immediately. */
-static inline int CRYPTO_is_NEON_capable(void) {
+static inline int GFp_is_NEON_capable(void) {
   /* Only statically skip the runtime lookup on aarch64. On arm, one CPU is
    * known to have a broken NEON unit which is known to fail with on some
    * hand-written NEON assembly. For now, continue to apply the workaround even
@@ -126,27 +126,27 @@ static inline int CRYPTO_is_NEON_capable(void) {
 #if defined(__ARM_NEON__) && !defined(OPENSSL_ARM)
   return 1;
 #else
-  return CRYPTO_is_NEON_capable_at_runtime();
+  return GFp_is_NEON_capable_at_runtime();
 #endif
 }
 
 #if defined(OPENSSL_ARM)
-/* CRYPTO_has_broken_NEON returns one if the current CPU is known to have a
+/* GFp_has_broken_NEON returns one if the current CPU is known to have a
  * broken NEON unit. See https://crbug.com/341598. */
-OPENSSL_EXPORT int CRYPTO_has_broken_NEON(void);
+OPENSSL_EXPORT int GFp_has_broken_NEON(void);
 #endif
 
-/* CRYPTO_is_ARMv8_AES_capable returns true if the current CPU supports the
+/* GFp_is_ARMv8_AES_capable returns true if the current CPU supports the
  * ARMv8 AES instruction. */
-int CRYPTO_is_ARMv8_AES_capable(void);
+int GFp_is_ARMv8_AES_capable(void);
 
-/* CRYPTO_is_ARMv8_PMULL_capable returns true if the current CPU supports the
+/* GFp_is_ARMv8_PMULL_capable returns true if the current CPU supports the
  * ARMv8 PMULL instruction. */
-int CRYPTO_is_ARMv8_PMULL_capable(void);
+int GFp_is_ARMv8_PMULL_capable(void);
 
 #else
 
-static inline int CRYPTO_is_NEON_capable(void) {
+static inline int GFp_is_NEON_capable(void) {
 #if defined(OPENSSL_STATIC_ARMCAP_NEON) || defined(__ARM_NEON__)
   return 1;
 #else
@@ -154,7 +154,7 @@ static inline int CRYPTO_is_NEON_capable(void) {
 #endif
 }
 
-static inline int CRYPTO_is_ARMv8_AES_capable(void) {
+static inline int GFp_is_ARMv8_AES_capable(void) {
 #if defined(OPENSSL_STATIC_ARMCAP_AES)
   return 1;
 #else
@@ -162,7 +162,7 @@ static inline int CRYPTO_is_ARMv8_AES_capable(void) {
 #endif
 }
 
-static inline int CRYPTO_is_ARMv8_PMULL_capable(void) {
+static inline int GFp_is_ARMv8_PMULL_capable(void) {
 #if defined(OPENSSL_STATIC_ARMCAP_PMULL)
   return 1;
 #else

--- a/include/openssl/mem.h
+++ b/include/openssl/mem.h
@@ -78,12 +78,12 @@ extern "C" {
 #define OPENSSL_realloc realloc
 #define OPENSSL_free free
 
-/* CRYPTO_memcmp returns zero iff the |len| bytes at |a| and |b| are equal. It
+/* GFp_memcmp returns zero iff the |len| bytes at |a| and |b| are equal. It
  * takes an amount of time dependent on |len|, but independent of the contents
  * of |a| and |b|. Unlike memcmp, it cannot be used to put elements into a
  * defined order as the return value when a != b is undefined, other than to be
  * non-zero. */
-OPENSSL_EXPORT int CRYPTO_memcmp(const void *a, const void *b, size_t len);
+OPENSSL_EXPORT int GFp_memcmp(const void *a, const void *b, size_t len);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -80,7 +80,7 @@ typedef struct bn_blinding_st BN_BLINDING;
 
 /* RSA_size returns the number of bytes in the modulus, which is also the size
  * of a signature or encrypted value using |rsa|. */
-OPENSSL_EXPORT size_t RSA_size(const RSA *rsa);
+OPENSSL_EXPORT size_t GFp_RSA_size(const RSA *rsa);
 
 
 /* Private functions. */

--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -277,7 +277,7 @@ const TAG_LEN: usize = 128 / 8;
 const NONCE_LEN: usize = 96 / 8;
 
 
-/// |CRYPTO_chacha_20| uses a 32-bit block counter, so we disallow individual
+/// |GFp_chacha_20| uses a 32-bit block counter, so we disallow individual
 /// operations that work on more than 256GB at a time, for all AEADs.
 fn check_per_nonce_max_bytes(in_out_len: usize)
                              -> Result<(), error::Unspecified> {

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -61,8 +61,8 @@ pub static AES_256_GCM: aead::Algorithm = aead::Algorithm {
 fn aes_gcm_init(ctx_buf: &mut [u8], key: &[u8])
                 -> Result<(), error::Unspecified> {
     bssl::map_result(unsafe {
-        evp_aead_aes_gcm_init(ctx_buf.as_mut_ptr(),
-                              ctx_buf.len(), key.as_ptr(), key.len())
+        GFp_aes_gcm_init(ctx_buf.as_mut_ptr(), ctx_buf.len(), key.as_ptr(),
+                         key.len())
     })
 }
 
@@ -72,9 +72,9 @@ fn aes_gcm_seal(ctx: &[u64; aead::KEY_CTX_BUF_ELEMS],
                 -> Result<(), error::Unspecified> {
     let ctx = polyfill::slice::u64_as_u8(ctx);
     bssl::map_result(unsafe {
-        evp_aead_aes_gcm_seal(ctx.as_ptr(), in_out.as_mut_ptr(), in_out.len(),
-                              tag.as_mut_ptr(), nonce.as_ptr(), ad.as_ptr(),
-                              ad.len())
+        GFp_aes_gcm_seal(ctx.as_ptr(), in_out.as_mut_ptr(), in_out.len(),
+                         tag.as_mut_ptr(), nonce.as_ptr(), ad.as_ptr(),
+                         ad.len())
     })
 }
 
@@ -84,30 +84,26 @@ fn aes_gcm_open(ctx: &[u64; aead::KEY_CTX_BUF_ELEMS],
                 ad: &[u8]) -> Result<(), error::Unspecified> {
     let ctx = polyfill::slice::u64_as_u8(ctx);
     bssl::map_result(unsafe {
-        evp_aead_aes_gcm_open(ctx.as_ptr(), in_out.as_mut_ptr(),
-                              in_out.len() - in_prefix_len,
-                              tag_out.as_mut_ptr(), nonce.as_ptr(),
-                              in_out[in_prefix_len..].as_ptr(), ad.as_ptr(),
-                              ad.len())
+        GFp_aes_gcm_open(ctx.as_ptr(), in_out.as_mut_ptr(),
+                         in_out.len() - in_prefix_len, tag_out.as_mut_ptr(),
+                         nonce.as_ptr(), in_out[in_prefix_len..].as_ptr(),
+                         ad.as_ptr(), ad.len())
     })
 }
 
 extern {
-    fn evp_aead_aes_gcm_init(ctx_buf: *mut u8, ctx_buf_len: c::size_t,
-                             key: *const u8, key_len: c::size_t) -> c::int;
+    fn GFp_aes_gcm_init(ctx_buf: *mut u8, ctx_buf_len: c::size_t,
+                        key: *const u8, key_len: c::size_t) -> c::int;
 
-    fn evp_aead_aes_gcm_seal(ctx_buf: *const u8, in_out: *mut u8,
-                             in_out_len: c::size_t,
-                             tag_out: *mut u8/*[TAG_LEN]*/,
-                             nonce: *const u8/*[TAG_LEN]*/, ad: *const u8,
-                             ad_len: c::size_t) -> c::int;
+    fn GFp_aes_gcm_seal(ctx_buf: *const u8, in_out: *mut u8,
+                        in_out_len: c::size_t, tag_out: *mut u8/*[TAG_LEN]*/,
+                        nonce: *const u8/*[TAG_LEN]*/, ad: *const u8,
+                        ad_len: c::size_t) -> c::int;
 
-    fn evp_aead_aes_gcm_open(ctx_buf: *const u8, out: *mut u8,
-                             in_out_len: c::size_t,
-                             tag_out: *mut u8/*[TAG_LEN]*/,
-                             nonce: *const u8/*[NONCE_LEN]*/,
-                             in_: *const u8, ad: *const u8, ad_len: c::size_t)
-                             -> c::int;
+    fn GFp_aes_gcm_open(ctx_buf: *const u8, out: *mut u8,
+                        in_out_len: c::size_t, tag_out: *mut u8/*[TAG_LEN]*/,
+                        nonce: *const u8/*[NONCE_LEN]*/, in_: *const u8,
+                        ad: *const u8, ad_len: c::size_t) -> c::int;
 }
 
 

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -217,34 +217,37 @@ fn poly1305_update_length(ctx: &mut [u8; POLY1305_STATE_LEN], len: usize) {
 }
 
 
-/// Safe wrapper around |CRYPTO_poly1305_init|.
 #[inline(always)]
 fn poly1305_init(state: &mut [u8; POLY1305_STATE_LEN],
                  key: &[u8; POLY1305_KEY_LEN]) {
-    unsafe { CRYPTO_poly1305_init(state, key) }
+    unsafe {
+        GFp_poly1305_init(state, key)
+    }
 }
 
-/// Safe wrapper around |CRYPTO_poly1305_finish|.
 #[inline(always)]
 fn poly1305_finish(state: &mut [u8; POLY1305_STATE_LEN],
                    tag_out: &mut [u8; aead::TAG_LEN]) {
-    unsafe { CRYPTO_poly1305_finish(state, tag_out) }
+    unsafe {
+        GFp_poly1305_finish(state, tag_out)
+    }
 }
 
-/// Safe wrapper around |CRYPTO_poly1305_update|.
 #[inline(always)]
 fn poly1305_update(state: &mut [u8; POLY1305_STATE_LEN], in_: &[u8]) {
-    unsafe { CRYPTO_poly1305_update(state, in_.as_ptr(), in_.len()) }
+    unsafe {
+        GFp_poly1305_update(state, in_.as_ptr(), in_.len())
+    }
 }
 
 extern {
     fn ChaCha20_ctr32(out: *mut u8, in_: *const u8, in_len: c::size_t,
                       key: &[u32; CHACHA20_KEY_LEN / 4], counter: &[u32; 4]);
-    fn CRYPTO_poly1305_init(state: &mut [u8; POLY1305_STATE_LEN],
+    fn GFp_poly1305_init(state: &mut [u8; POLY1305_STATE_LEN],
                             key: &[u8; POLY1305_KEY_LEN]);
-    fn CRYPTO_poly1305_finish(state: &mut [u8; POLY1305_STATE_LEN],
+    fn GFp_poly1305_finish(state: &mut [u8; POLY1305_STATE_LEN],
                               mac: &mut [u8; aead::TAG_LEN]);
-    fn CRYPTO_poly1305_update(state: &mut [u8; POLY1305_STATE_LEN],
+    fn GFp_poly1305_update(state: &mut [u8; POLY1305_STATE_LEN],
                               in_: *const u8, in_len: c::size_t);
 }
 
@@ -270,7 +273,7 @@ mod tests {
     #[test]
     pub fn test_poly1305_state_len() {
         assert_eq!((super::POLY1305_STATE_LEN + 255) / 256,
-                   (CRYPTO_POLY1305_STATE_LEN + 255) / 256);
+                   (GFp_POLY1305_STATE_LEN + 255) / 256);
     }
 
     // This verifies the encryption functionality provided by ChaCha20_ctr32
@@ -355,6 +358,6 @@ mod tests {
     }
 
     extern {
-        static CRYPTO_POLY1305_STATE_LEN: c::size_t;
+        static GFp_POLY1305_STATE_LEN: c::size_t;
     }
 }

--- a/src/c.rs
+++ b/src/c.rs
@@ -36,8 +36,8 @@ macro_rules! define_metrics_tests {
                               $get_c_size_fn, 1);
     };
 
-    ( $name:ident, $test_c_metrics:ident, $get_c_align_fn:ident,
-      $get_c_size_fn:ident, $expected_align_factor:expr ) =>
+    ( $name:ident, $test_c_metrics:ident, $c_align:ident, $c_size:ident,
+      $expected_align_factor:expr ) =>
     {
         #[cfg(test)]
         extern {
@@ -46,8 +46,8 @@ macro_rules! define_metrics_tests {
             // because even 8-bit and 16-bit microcontrollers have no trouble
             // with it, and because `u16` is always as smaller or smaller than
             // `usize`.
-            fn $get_c_align_fn() -> u16;
-            fn $get_c_size_fn() -> u16;
+            static $c_align: u16;
+            static $c_size: u16;
         }
 
         #[cfg(test)]
@@ -56,8 +56,8 @@ macro_rules! define_metrics_tests {
         fn $test_c_metrics() {
             use std::mem;
 
-            let c_align = unsafe { $get_c_align_fn() };
-            let c_size = unsafe { $get_c_size_fn() };
+            let c_align = $c_align;
+            let c_size = $c_size;
 
             // XXX: Remove these assertions and these uses of `as` when Rust
             // supports implicit coercion of `u16` to `usize`.
@@ -80,11 +80,11 @@ macro_rules! define_metrics_tests {
     }
 }
 
-define_type!(int, i32, test_int_metrics, ring_int_align, ring_int_size,
+define_type!(int, i32, test_int_metrics, GFp_int_align, GFp_int_size,
              "The C `int` type. Equivalent to `libc::int`.");
 
 define_type!(
-  size_t, usize, test_size_t_metrics, ring_size_t_align, ring_size_t_size,
+  size_t, usize, test_size_t_metrics, GFp_size_t_align, GFp_size_t_size,
   "The C `size_t` type from `<stdint.h>`.
 
   ISO C's `size_t` is defined to be the type of the result of the
@@ -123,19 +123,19 @@ define_type!(
     should have explicit casts using `num::cast` or other methods that avoid
     unintended truncation. Such code will then work on all platforms.");
 
-define_metrics_tests!(i8, test_i8_metrics, ring_int8_t_align, ring_int8_t_size);
-define_metrics_tests!(u8, test_u8_metrics, ring_uint8_t_align,
-                      ring_uint8_t_size);
+define_metrics_tests!(i8, test_i8_metrics, GFp_int8_t_align, GFp_int8_t_size);
+define_metrics_tests!(u8, test_u8_metrics, GFp_uint8_t_align,
+                      GFp_uint8_t_size);
 
-define_metrics_tests!(i16, test_i16_metrics, ring_int16_t_align,
-                      ring_int16_t_size);
-define_metrics_tests!(u16, test_u16_metrics, ring_uint16_t_align,
-                      ring_uint16_t_size);
+define_metrics_tests!(i16, test_i16_metrics, GFp_int16_t_align,
+                      GFp_int16_t_size);
+define_metrics_tests!(u16, test_u16_metrics, GFp_uint16_t_align,
+                      GFp_uint16_t_size);
 
-define_metrics_tests!(i32, test_i32_metrics, ring_int32_t_align,
-                      ring_int32_t_size);
-define_metrics_tests!(u32, test_u32_metrics, ring_uint32_t_align,
-                      ring_uint32_t_size);
+define_metrics_tests!(i32, test_i32_metrics, GFp_int32_t_align,
+                      GFp_int32_t_size);
+define_metrics_tests!(u32, test_u32_metrics, GFp_uint32_t_align,
+                      GFp_uint32_t_size);
 
 #[cfg(all(test,
           not(all(target_arch = "x86",
@@ -150,7 +150,7 @@ const SIXTY_FOUR_BIT_ALIGNMENT_FACTOR: usize = 1;
                       target_os = "ios")))]
 const SIXTY_FOUR_BIT_ALIGNMENT_FACTOR: usize = 2;
 
-define_metrics_tests!(i64, test_i64_metrics, ring_int64_t_align,
-                      ring_int64_t_size, SIXTY_FOUR_BIT_ALIGNMENT_FACTOR);
-define_metrics_tests!(u64, test_u64_metrics, ring_uint64_t_align,
-                      ring_uint64_t_size, SIXTY_FOUR_BIT_ALIGNMENT_FACTOR);
+define_metrics_tests!(i64, test_i64_metrics, GFp_int64_t_align,
+                      GFp_int64_t_size, SIXTY_FOUR_BIT_ALIGNMENT_FACTOR);
+define_metrics_tests!(u64, test_u64_metrics, GFp_uint64_t_align,
+                      GFp_uint64_t_size, SIXTY_FOUR_BIT_ALIGNMENT_FACTOR);

--- a/src/constant_time.rs
+++ b/src/constant_time.rs
@@ -27,7 +27,7 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8])
     if a.len() != b.len() {
         return Err(error::Unspecified);
     }
-    let result = unsafe { CRYPTO_memcmp(a.as_ptr(), b.as_ptr(), a.len()) };
+    let result = unsafe { GFp_memcmp(a.as_ptr(), b.as_ptr(), a.len()) };
     match result {
         0 => Ok(()),
         _ => Err(error::Unspecified),
@@ -35,5 +35,5 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8])
 }
 
 extern {
-    fn CRYPTO_memcmp(a: *const u8, b: *const u8, len: c::size_t) -> c::int;
+    fn GFp_memcmp(a: *const u8, b: *const u8, len: c::size_t) -> c::int;
 }

--- a/src/digest/digest.rs
+++ b/src/digest/digest.rs
@@ -341,7 +341,7 @@ pub static SHA256: Algorithm = Algorithm {
     chaining_len: 256 / 8,
     block_len: 512 / 8,
     len_len: 64 / 8,
-    block_data_order: sha256_block_data_order,
+    block_data_order: GFp_sha256_block_data_order,
     format_output: sha256_format_output,
     initial_state: [
         u32x2!(0x6a09e667u32, 0xbb67ae85u32),
@@ -360,7 +360,7 @@ pub static SHA384: Algorithm = Algorithm {
     chaining_len: 512 / 8,
     block_len: 1024 / 8,
     len_len: 128 / 8,
-    block_data_order: sha512_block_data_order,
+    block_data_order: GFp_sha512_block_data_order,
     format_output: sha512_format_output,
     initial_state: [
         0xcbbb9d5dc1059ed8,
@@ -382,7 +382,7 @@ pub static SHA512: Algorithm = Algorithm {
     chaining_len: 512 / 8,
     block_len: 1024 / 8,
     len_len: 128 / 8,
-    block_data_order: sha512_block_data_order,
+    block_data_order: GFp_sha512_block_data_order,
     format_output: sha512_format_output,
     initial_state: [
         0x6a09e667f3bcc908,
@@ -467,10 +467,10 @@ pub extern fn GFp_SHA512_4(out: *mut u8, out_len: c::size_t,
 }
 
 extern {
-    fn sha256_block_data_order(state: &mut [u64; MAX_CHAINING_LEN / 8],
-                               data: *const u8, num: c::size_t);
-    fn sha512_block_data_order(state: &mut [u64; MAX_CHAINING_LEN / 8],
-                               data: *const u8, num: c::size_t);
+    fn GFp_sha256_block_data_order(state: &mut [u64; MAX_CHAINING_LEN / 8],
+                                   data: *const u8, num: c::size_t);
+    fn GFp_sha512_block_data_order(state: &mut [u64; MAX_CHAINING_LEN / 8],
+                                   data: *const u8, num: c::size_t);
 }
 
 #[cfg(test)]

--- a/src/digest/digest.rs
+++ b/src/digest/digest.rs
@@ -443,11 +443,11 @@ fn sha512_format_output(input: &[u64; MAX_CHAINING_LEN / 8])
 #[allow(non_snake_case)]
 #[doc(hidden)]
 #[no_mangle]
-pub extern fn SHA512_4(out: *mut u8, out_len: c::size_t,
-                       part1: *const u8, part1_len: c::size_t,
-                       part2: *const u8, part2_len: c::size_t,
-                       part3: *const u8, part3_len: c::size_t,
-                       part4: *const u8, part4_len: c::size_t) {
+pub extern fn GFp_SHA512_4(out: *mut u8, out_len: c::size_t,
+                           part1: *const u8, part1_len: c::size_t,
+                           part2: *const u8, part2_len: c::size_t,
+                           part3: *const u8, part3_len: c::size_t,
+                           part4: *const u8, part4_len: c::size_t) {
     fn maybe_update(ctx: &mut Context, part: *const u8, part_len: c::size_t) {
         if part_len != 0 {
             assert!(!part.is_null());

--- a/src/ec/suite_b/ops/ops.rs
+++ b/src/ec/suite_b/ops/ops.rs
@@ -75,7 +75,7 @@ pub struct Point {
     // `ops.num_limbs` elements are the X coordinate, the next
     // `ops.num_limbs` elements are the Y coordinate, and the next
     // `ops.num_limbs` elements are the Z coordinate. This layout is dictated
-    // by the requirements of the ecp_nistz256 code.
+    // by the requirements of the GFp_nistz256 code.
     xyz: [Limb; 3 * MAX_LIMBS],
 }
 
@@ -628,7 +628,7 @@ mod tests {
         })
     }
 
-    // XXX: There's no `ecp_nistz256_sub` in *ring*; it's logic is inlined into
+    // XXX: There's no `GFp_nistz256_sub` in *ring*; it's logic is inlined into
     // the point arithmetic functions. Thus, we can't test it.
 
     #[test]
@@ -669,7 +669,7 @@ mod tests {
         })
     }
 
-    // XXX: There's no `ecp_nistz256_div_by_2` in *ring*; it's logic is inlined
+    // XXX: There's no `GFp_nistz256_div_by_2` in *ring*; it's logic is inlined
     // into the point arithmetic functions. Thus, we can't test it.
 
     #[test]
@@ -706,9 +706,9 @@ mod tests {
     #[test]
     fn p256_elem_neg_test() {
         extern {
-            fn ecp_nistz256_neg(r: *mut Limb, a: *const Limb);
+            fn GFp_nistz256_neg(r: *mut Limb, a: *const Limb);
         }
-        elem_neg_test(&p256::COMMON_OPS, ecp_nistz256_neg,
+        elem_neg_test(&p256::COMMON_OPS, GFp_nistz256_neg,
                       "src/ec/suite_b/ops/p256_neg_tests.txt");
     }
 

--- a/src/ec/suite_b/ops/p256.rs
+++ b/src/ec/suite_b/ops/p256.rs
@@ -50,11 +50,11 @@ pub static COMMON_OPS: CommonOps = CommonOps {
                            0xacf005cd, 0x78843090, 0xd89cdf62, 0x29c4bddf],
     },
 
-    elem_add_impl: ecp_nistz256_add,
-    elem_mul_mont: ecp_nistz256_mul_mont,
-    elem_sqr_mont: ecp_nistz256_sqr_mont,
+    elem_add_impl: GFp_nistz256_add,
+    elem_mul_mont: GFp_nistz256_mul_mont,
+    elem_sqr_mont: GFp_nistz256_sqr_mont,
 
-    point_add_jacobian_impl: ecp_nistz256_point_add,
+    point_add_jacobian_impl: GFp_nistz256_point_add,
 };
 
 
@@ -62,7 +62,7 @@ pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
     common: &COMMON_OPS,
     elem_inv: p256_elem_inv,
     point_mul_base_impl: p256_point_mul_base_impl,
-    point_mul_impl: ecp_nistz256_point_mul,
+    point_mul_impl: GFp_nistz256_point_mul,
 };
 
 fn p256_elem_inv(a: &ElemUnreduced) -> ElemUnreduced {
@@ -119,7 +119,7 @@ fn p256_elem_inv(a: &ElemUnreduced) -> ElemUnreduced {
 fn p256_point_mul_base_impl(g_scalar: &Scalar) -> Point {
     let mut r = Point::new_at_infinity();
     unsafe {
-        ecp_nistz256_point_mul_base(r.xyz.as_mut_ptr(),
+        GFp_nistz256_point_mul_base(r.xyz.as_mut_ptr(),
                                     g_scalar.limbs.as_ptr());
     }
     r
@@ -270,23 +270,23 @@ fn p256_scalar_inv_to_mont(a: &Scalar) -> ScalarMont {
 
 
 extern {
-    fn ecp_nistz256_add(r: *mut Limb/*[COMMON_OPS.num_limbs]*/,
+    fn GFp_nistz256_add(r: *mut Limb/*[COMMON_OPS.num_limbs]*/,
                         a: *const Limb/*[COMMON_OPS.num_limbs]*/,
                         b: *const Limb/*[COMMON_OPS.num_limbs]*/);
-    fn ecp_nistz256_mul_mont(r: *mut Limb/*[COMMON_OPS.num_limbs]*/,
+    fn GFp_nistz256_mul_mont(r: *mut Limb/*[COMMON_OPS.num_limbs]*/,
                              a: *const Limb/*[COMMON_OPS.num_limbs]*/,
                              b: *const Limb/*[COMMON_OPS.num_limbs]*/);
-    fn ecp_nistz256_sqr_mont(r: *mut Limb/*[COMMON_OPS.num_limbs]*/,
+    fn GFp_nistz256_sqr_mont(r: *mut Limb/*[COMMON_OPS.num_limbs]*/,
                              a: *const Limb/*[COMMON_OPS.num_limbs]*/);
 
-    fn ecp_nistz256_point_add(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
+    fn GFp_nistz256_point_add(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
                               a: *const Limb/*[3][COMMON_OPS.num_limbs]*/,
                               b: *const Limb/*[3][COMMON_OPS.num_limbs]*/);
-    fn ecp_nistz256_point_mul(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
+    fn GFp_nistz256_point_mul(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
                               p_scalar: *const Limb/*[COMMON_OPS.num_limbs]*/,
                               p_x: *const Limb/*[COMMON_OPS.num_limbs]*/,
                               p_y: *const Limb/*[COMMON_OPS.num_limbs]*/);
-    fn ecp_nistz256_point_mul_base(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
+    fn GFp_nistz256_point_mul_base(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
                                    g_scalar: *const Limb/*[COMMON_OPS.num_limbs]*/);
 
     fn GFp_p256_scalar_mul_mont(r: *mut Limb/*[COMMON_OPS.num_limbs]*/,

--- a/src/ec/suite_b/ops/p384.rs
+++ b/src/ec/suite_b/ops/p384.rs
@@ -58,7 +58,7 @@ pub static COMMON_OPS: CommonOps = CommonOps {
     elem_mul_mont: GFp_p384_elem_mul_mont,
     elem_sqr_mont: GFp_p384_elem_sqr_mont,
 
-    point_add_jacobian_impl: ecp_nistz384_point_add,
+    point_add_jacobian_impl: GFp_nistz384_point_add,
 };
 
 
@@ -66,7 +66,7 @@ pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
     common: &COMMON_OPS,
     elem_inv: p384_elem_inv,
     point_mul_base_impl: p384_point_mul_base_impl,
-    point_mul_impl: ecp_nistz384_point_mul,
+    point_mul_impl: GFp_nistz384_point_mul,
 };
 
 fn p384_elem_inv(a: &ElemUnreduced) -> ElemUnreduced {
@@ -339,10 +339,10 @@ extern {
                               a: *const Limb/*[COMMON_OPS.num_limbs]*/,
                               b: *const Limb/*[COMMON_OPS.num_limbs]*/);
 
-    fn ecp_nistz384_point_add(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
+    fn GFp_nistz384_point_add(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
                               a: *const Limb/*[3][COMMON_OPS.num_limbs]*/,
                               b: *const Limb/*[3][COMMON_OPS.num_limbs]*/);
-    fn ecp_nistz384_point_mul(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
+    fn GFp_nistz384_point_mul(r: *mut Limb/*[3][COMMON_OPS.num_limbs]*/,
                               p_scalar: *const Limb/*[COMMON_OPS.num_limbs]*/,
                               p_x: *const Limb/*[COMMON_OPS.num_limbs]*/,
                               p_y: *const Limb/*[COMMON_OPS.num_limbs]*/);

--- a/src/init.rs
+++ b/src/init.rs
@@ -18,12 +18,12 @@
 pub fn init_once() {
     extern crate std;
     static INIT: std::sync::Once = std::sync::ONCE_INIT;
-    INIT.call_once(|| unsafe { OPENSSL_cpuid_setup() });
+    INIT.call_once(|| unsafe { GFp_cpuid_setup() });
 }
 
 #[cfg(not(all(target_arch = "aarch64", target_os = "ios")))]
 extern {
-    fn OPENSSL_cpuid_setup();
+    fn GFp_cpuid_setup();
 }
 
 #[cfg(all(target_arch = "aarch64", target_os = "ios"))]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -124,9 +124,9 @@ mod sysrand {
     use {bssl, error};
 
     pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        for mut chunk in dest.chunks_mut(super::CRYPTO_sysrand_chunk_max_len) {
+        for mut chunk in dest.chunks_mut(super::GFp_sysrand_chunk_max_len) {
             try!(bssl::map_result(unsafe {
-                super::CRYPTO_sysrand_chunk(chunk.as_mut_ptr(), chunk.len())
+                super::GFp_sysrand_chunk(chunk.as_mut_ptr(), chunk.len())
             }));
         }
         Ok(())
@@ -173,7 +173,7 @@ mod sysrand_or_urandom {
             static ref MECHANISM: Mechanism = {
                 let mut dummy = [0u8; 1];
                 if unsafe {
-                    super::CRYPTO_sysrand_chunk(dummy.as_mut_ptr(),
+                    super::GFp_sysrand_chunk(dummy.as_mut_ptr(),
                                                dummy.len()) } == -1 {
                     Mechanism::DevURandom
                 } else {
@@ -218,8 +218,8 @@ pub unsafe extern fn RAND_bytes(rng: *mut RAND, dest: *mut u8,
 
 #[cfg(any(target_os = "linux", windows))]
 extern {
-    static CRYPTO_sysrand_chunk_max_len: c::size_t;
-    fn CRYPTO_sysrand_chunk(buf: *mut u8, len: c::size_t) -> c::int;
+    static GFp_sysrand_chunk_max_len: c::size_t;
+    fn GFp_sysrand_chunk(buf: *mut u8, len: c::size_t) -> c::int;
 }
 
 
@@ -335,7 +335,7 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", windows))]
-    fn max_chunk_len() -> usize { super::CRYPTO_sysrand_chunk_max_len }
+    fn max_chunk_len() -> usize { super::GFp_sysrand_chunk_max_len }
 
     #[cfg(not(any(target_os = "linux", windows)))]
     fn max_chunk_len() -> usize {

--- a/src/rsa/rsa.rs
+++ b/src/rsa/rsa.rs
@@ -125,7 +125,7 @@ impl PositiveInteger {
                 -> Result<PositiveInteger, error::Unspecified> {
         let bytes = try!(der::positive_integer(input)).as_slice_less_safe();
         let res = unsafe {
-            BN_bin2bn(bytes.as_ptr(), bytes.len(), core::ptr::null_mut())
+            GFp_BN_bin2bn(bytes.as_ptr(), bytes.len(), core::ptr::null_mut())
         };
         if res.is_null() {
             return Err(error::Unspecified);
@@ -148,7 +148,7 @@ impl Drop for PositiveInteger {
     fn drop(&mut self) {
         match self.value {
             Some(val) => unsafe {
-                BN_free(val);
+                GFp_BN_free(val);
             },
             None => {},
         }
@@ -171,8 +171,8 @@ pub mod signing;
 
 #[cfg(feature = "rsa_signing")]
 extern {
-    fn BN_bin2bn(in_: *const u8, len: c::size_t, ret: *mut BIGNUM)
-                 -> *mut BIGNUM;
-    fn BN_free(bn: *mut BIGNUM);
-    fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
+    fn GFp_BN_bin2bn(in_: *const u8, len: c::size_t, ret: *mut BIGNUM)
+                     -> *mut BIGNUM;
+    fn GFp_BN_free(bn: *mut BIGNUM);
+    fn GFp_BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -127,8 +127,8 @@ impl RSAKeyPair {
                     iqmp_mont: std::ptr::null_mut(),
                 };
                 try!(bssl::map_result(unsafe {
-                    rsa_new_end(&mut rsa, n.as_ref(), d.as_ref(), p.as_ref(),
-                                q.as_ref())
+                    GFp_rsa_new_end(&mut rsa, n.as_ref(), d.as_ref(),
+                                    p.as_ref(), q.as_ref())
                 }));
                 Ok(RSAKeyPair { rsa: rsa })
             })
@@ -138,7 +138,9 @@ impl RSAKeyPair {
     /// Returns the length in bytes of the key pair's public modulus.
     ///
     /// A signature has the same length as the public modulus.
-    pub fn public_modulus_len(&self) -> usize { unsafe { RSA_size(&self.rsa) } }
+    pub fn public_modulus_len(&self) -> usize {
+        unsafe { GFp_RSA_size(&self.rsa) }
+    }
 }
 
 impl Drop for RSAKeyPair {
@@ -284,9 +286,9 @@ struct BN_BLINDING {
 extern {
     fn GFp_BN_BLINDING_new() -> *mut BN_BLINDING;
     fn GFp_BN_BLINDING_free(b: *mut BN_BLINDING);
-    fn rsa_new_end(rsa: *mut RSA, n: &BIGNUM, d: &BIGNUM, p: &BIGNUM,
-                   q: &BIGNUM) -> c::int;
-    fn RSA_size(rsa: *const RSA) -> c::size_t;
+    fn GFp_rsa_new_end(rsa: *mut RSA, n: &BIGNUM, d: &BIGNUM, p: &BIGNUM,
+                       q: &BIGNUM) -> c::int;
+    fn GFp_RSA_size(rsa: *const RSA) -> c::size_t;
 }
 
 #[allow(improper_ctypes)]

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -21,9 +21,9 @@ use rand;
 use std;
 use super::{
     BIGNUM,
-    BN_free,
+    GFp_BN_free,
     BN_MONT_CTX,
-    BN_MONT_CTX_free,
+    GFp_BN_MONT_CTX_free,
     PositiveInteger,
 
     RSAPadding,
@@ -144,16 +144,16 @@ impl RSAKeyPair {
 impl Drop for RSAKeyPair {
     fn drop(&mut self) {
         unsafe {
-            BN_free(self.rsa.e);
-            BN_free(self.rsa.dmp1);
-            BN_free(self.rsa.dmq1);
-            BN_free(self.rsa.iqmp);
-            BN_MONT_CTX_free(self.rsa.mont_n);
-            BN_MONT_CTX_free(self.rsa.mont_p);
-            BN_MONT_CTX_free(self.rsa.mont_q);
-            BN_MONT_CTX_free(self.rsa.mont_qq);
-            BN_free(self.rsa.qmn_mont);
-            BN_free(self.rsa.iqmp_mont);
+            GFp_BN_free(self.rsa.e);
+            GFp_BN_free(self.rsa.dmp1);
+            GFp_BN_free(self.rsa.dmq1);
+            GFp_BN_free(self.rsa.iqmp);
+            GFp_BN_MONT_CTX_free(self.rsa.mont_n);
+            GFp_BN_MONT_CTX_free(self.rsa.mont_p);
+            GFp_BN_MONT_CTX_free(self.rsa.mont_q);
+            GFp_BN_MONT_CTX_free(self.rsa.mont_qq);
+            GFp_BN_free(self.rsa.qmn_mont);
+            GFp_BN_free(self.rsa.iqmp_mont);
         }
     }
 }
@@ -212,7 +212,7 @@ impl RSASigningState {
     /// Construct an `RSASigningState` for the given `RSAKeyPair`.
     pub fn new(key_pair: std::sync::Arc<RSAKeyPair>)
                -> Result<Self, error::Unspecified> {
-        let blinding = unsafe { BN_BLINDING_new() };
+        let blinding = unsafe { GFp_BN_BLINDING_new() };
         if blinding.is_null() {
             return Err(error::Unspecified);
         }
@@ -266,7 +266,7 @@ struct Blinding {
 }
 
 impl Drop for Blinding {
-    fn drop(&mut self) { unsafe { BN_BLINDING_free(self.blinding) } }
+    fn drop(&mut self) { unsafe { GFp_BN_BLINDING_free(self.blinding) } }
 }
 
 unsafe impl Send for Blinding {}
@@ -282,8 +282,8 @@ struct BN_BLINDING {
 
 
 extern {
-    fn BN_BLINDING_new() -> *mut BN_BLINDING;
-    fn BN_BLINDING_free(b: *mut BN_BLINDING);
+    fn GFp_BN_BLINDING_new() -> *mut BN_BLINDING;
+    fn GFp_BN_BLINDING_free(b: *mut BN_BLINDING);
     fn rsa_new_end(rsa: *mut RSA, n: &BIGNUM, d: &BIGNUM, p: &BIGNUM,
                    q: &BIGNUM) -> c::int;
     fn RSA_size(rsa: *const RSA) -> c::size_t;


### PR DESCRIPTION
This series of commits will rename every single extern C symbol in *ring* so that each one has a different name from any OpenSSL function. This should allow *ring* and rust-openssl to be linked together into the same program.