### PR TITLE
Fixes #287 (Add specification of make/gmake/&c.)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,6 +43,9 @@ Note in particular that if you are cross-compiling an x86 build on a 64-bit
 version of Linux, then you need to have the proper gcc-multilibs and
 g++-multilibs packages or equivalent installed.
 
+Moreover, when building on OpenBSD, NetBSD, or FreeBSD either `make` or `gmake`
+can be used to build. When building, `MAKE_COMMAND` can be provided to specify
+which build automation tool is preferred.
 
 
 This Sucks. What are you doing to fix it?

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,7 +43,7 @@ Note in particular that if you are cross-compiling an x86 build on a 64-bit
 version of Linux, then you need to have the proper gcc-multilibs and
 g++-multilibs packages or equivalent installed.
 
-Moreover, when building on OpenBSD, NetBSD, or FreeBSD either `make` or `gmake`
+Moreover, when building on OpenBSD, NetBSD, or FreeBSD, either `make` or `gmake`
 can be used to build. When building, `MAKE_COMMAND` can be provided to specify
 which build automation tool is preferred.
 

--- a/build.rs
+++ b/build.rs
@@ -115,7 +115,13 @@ fn build_c_code(out_dir: &str) -> Result<(), std::env::VarError> {
             format!("CMAKE_BUILD_TYPE={}", cmake_build_type),
             format!("BUILD_PREFIX={}/", out_dir),
         ];
-        run_command_with_args(&"make", &args);
+
+        // If `MAKE_COMMAND` is set, we will use the env target to build with.
+        // Otherwise, we will default to using `make`.
+        match env::var("MAKE_COMMAND") {
+            Ok(command) => run_command_with_args(&command, &args),
+            _ => run_command_with_args(&"make", &args),
+        }
     } else {
         let arch = target_triple[0];
         let (platform, optional_amd64) = match arch {

--- a/mk/top_of_makefile.mk
+++ b/mk/top_of_makefile.mk
@@ -42,6 +42,10 @@ TARGET_ABI = $(TARGET_SYS)
 TARGET_VENDOR = unknow
 TARGET_SYS = linux
 else
+	
+# If we find `bsd` in the target system, we can assume a target triple is OK,
+# so skip the error here.
+ifeq (,$(findstring bsd,$(TARGET_SYS)))
 define NEWLINE
 
 
@@ -56,6 +60,7 @@ $(error TARGET must be of the form \
         Android example:	TARGET=arm-linux-androideabi $(NEWLINE)\
 \
         NOTE: Use "i586" instead of "x86")
+endif
 endif
 endif
 


### PR DESCRIPTION
ADD:
  - build.rs:build_c_code() Updated detecting of which build automation tool
    (`make` or `gmake`, typically) to be used. The `MAKE_COMMAND` flag can now
    be set which will dictate the user's choice for which build system to be
    used.
  - BUILDING.md Added a new note about the `MAKE_COMMAND` flag which can be
    set.

CHANGE:
  - mk/top_of_makefile.mk BSD systems are now allowed to only provide a target
    triple whenever building.