### PR TITLE
Disable `unused_unsafe` (until Rust 1.13 goes stable).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,11 @@
 
 #![doc(html_root_url="https://briansmith.org/rustdoc/")]
 
+// Bring back `unused_unsafe` when Rust 1.13 goes stable.
 #![allow(
     missing_copy_implementations,
     missing_debug_implementations,
+    unused_unsafe,
 )]
 #![deny(
     const_err,
@@ -82,7 +84,6 @@
     unused_parens,
     unused_qualifications,
     unused_results,
-    unused_unsafe,
     unused_variables,
     variant_size_differences,
     warnings,


### PR DESCRIPTION
See changes in 8b7bb0cf6b649870bdf3150a3122e6ebe2962d24 for more info.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.