### PR TITLE
Remove last usage of <stdarg.h> and vararg by reimplement test printer

### DIFF
--- a/crypto/bn/bn_test.cc
+++ b/crypto/bn/bn_test.cc
@@ -115,7 +115,7 @@ static ScopedBIGNUM GetBIGNUM(FileTest *t, const char *attribute) {
 
   ScopedBIGNUM ret;
   if (HexToBIGNUM(&ret, hex.c_str()) != static_cast<int>(hex.size())) {
-    t->PrintLine("Could not decode '%s'.", hex.c_str());
+    t->PrintLine("Could not decode '", hex.c_str(), "'.");
     return nullptr;
   }
   return ret;
@@ -148,7 +148,7 @@ static bool ExpectBIGNUMsEqual(FileTest *t, const char *operation,
   if (GFp_BN_cmp(expected, actual) == 0) {
     return true;
   }
-  t->PrintLine("Got wrong value for %s", operation);
+  t->PrintLine("Got wrong value for ", operation);
   return false;
 }
 
@@ -542,7 +542,7 @@ static bool RunTest(FileTest *t, void *) {
     }
     return test.func(t);
   }
-  t->PrintLine("Unknown test type: %s", t->GetType().c_str());
+  t->PrintLine("Unknown test type: ", t->GetType().c_str());
   return false;
 }
 

--- a/crypto/poly1305/poly1305_test.cc
+++ b/crypto/poly1305/poly1305_test.cc
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #include <vector>
+#include <string>
 
 #include "internal.h"
 #include "../internal.h"
@@ -72,7 +73,7 @@ static bool TestSIMD(FileTest *t, unsigned excess,
   alignas(16) uint8_t out[16];
   GFp_poly1305_finish(&state, out);
   if (!t->ExpectBytesEqual(mac.data(), mac.size(), out, 16)) {
-    t->PrintLine("SIMD pattern %u failed.", excess);
+    t->PrintLine("SIMD pattern ", std::to_string(excess).c_str(), " failed.");
     return false;
   }
 

--- a/crypto/test/file_test.cc
+++ b/crypto/test/file_test.cc
@@ -24,7 +24,6 @@
 
 #include <ctype.h>
 #include <errno.h>
-#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -78,7 +77,7 @@ FileTest::ReadResult FileTest::ReadNext() {
   // If the previous test had unused attributes, it is an error.
   if (!unused_attributes_.empty()) {
     for (const std::string &key : unused_attributes_) {
-      PrintLine("Unused attribute: %s", key.c_str());
+      PrintLine("Unused attribute: ", key.c_str());
     }
     return kReadError;
   }
@@ -135,15 +134,8 @@ FileTest::ReadResult FileTest::ReadNext() {
   }
 }
 
-void FileTest::PrintLine(const char *format, ...) {
-  va_list args;
-  va_start(args, format);
-
-  fprintf(stderr, "Line %u: ", start_line_);
-  vfprintf(stderr, format, args);
-  fprintf(stderr, "\n");
-
-  va_end(args);
+void FileTest::PrintLine(const char *p1, const char *p2, const char *p3) {
+  fprintf(stderr, "Line %u: %s%s%s\n", start_line_, p1, p2, p3);
 }
 
 const std::string &FileTest::GetType() {
@@ -155,7 +147,7 @@ bool FileTest::GetAttribute(std::string *out_value, const std::string &key) {
   OnKeyUsed(key);
   auto iter = attributes_.find(key);
   if (iter == attributes_.end()) {
-    PrintLine("Missing attribute '%s'.", key.c_str());
+    PrintLine("Missing attribute '", key.c_str(), "'.");
     return false;
   }
   *out_value = iter->second;
@@ -196,14 +188,14 @@ bool FileTest::GetBytesOrDefault(std::vector<uint8_t> *out, bool *is_default,
   }
 
   if (value.size() % 2 != 0) {
-    PrintLine("Error decoding value: %s", value.c_str());
+    PrintLine("Error decoding value: ", value.c_str());
     return false;
   }
   out->reserve(value.size() / 2);
   for (size_t i = 0; i < value.size(); i += 2) {
     uint8_t hi, lo;
     if (!FromHexDigit(&hi, value[i]) || !FromHexDigit(&lo, value[i+1])) {
-      PrintLine("Error decoding value: %s", value.c_str());
+      PrintLine("Error decoding value: ", value.c_str());
       return false;
     }
     out->push_back((hi << 4) | lo);
@@ -242,8 +234,8 @@ bool FileTest::ExpectBytesEqual(const uint8_t *expected, size_t expected_len,
 
   std::string expected_hex = EncodeHex(expected, expected_len);
   std::string actual_hex = EncodeHex(actual, actual_len);
-  PrintLine("Expected: %s", expected_hex.c_str());
-  PrintLine("Actual:   %s", actual_hex.c_str());
+  PrintLine("Expected: ", expected_hex.c_str());
+  PrintLine("Actual:   ", actual_hex.c_str());
   return false;
 }
 

--- a/crypto/test/file_test.h
+++ b/crypto/test/file_test.h
@@ -82,13 +82,10 @@ class FileTest {
   // |kReadError|.
   ReadResult ReadNext();
 
-  // PrintLine is a variant of printf which prepends the line number and appends
-  // a trailing newline.
-  void PrintLine(const char *format, ...)
-#ifdef __GNUC__
-      __attribute__((__format__(__printf__, 2, 3)))
-#endif
-  ;
+  // PrintLine is a simple printer that prints strings |*p1|, |*p2| and |*p3|
+  // prepending the line number and appending a trailing newline. Is based on
+  // an assumption that there is no need for more than 3 parts of test print.
+  void PrintLine(const char *p1, const char *p2 = "", const char *p3 = "");
 
   unsigned start_line() const { return start_line_; }
 

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -131,6 +131,10 @@ impl<'a> EphemeralPrivateKey {
         }
     }
 
+    /// The key exchange algorithm.
+    #[inline]
+    pub fn algorithm(&self) -> &'static Algorithm { self.alg }
+
     /// The size in bytes of the encoded public key.
     #[inline(always)]
     pub fn public_key_len(&self) -> usize { self.alg.i.public_key_len }


### PR DESCRIPTION
Fix for #143 . Assumed that it's enough for test-printer function to accept only up to 3 string parts.