### PR TITLE
Remove use of compatibility lint `match_of_unit_variant_via_paren_dotdot`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,6 @@
     exceeding_bitshifts,
     fat_ptr_transmutes,
     improper_ctypes,
-    match_of_unit_variant_via_paren_dotdot,
     missing_copy_implementations,
     missing_debug_implementations,
     mutable_transmutes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@
     exceeding_bitshifts,
     fat_ptr_transmutes,
     improper_ctypes,
-    match_of_unit_variant_via_paren_dotdot,
     missing_docs,
     mutable_transmutes,
     no_mangle_const_items,


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/36871 removes this compatibility lint and therefore breaks ring (but not its dependencies) because ring uses `#![deny(unknown_lints)]`.
FYI, `#![deny(future_incompatible)]` can be used instead of concrete compatibility lints, it's not going to be removed.