### PR TITLE
Fix issue #287, #311 - Support building on *BSD

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,6 +43,10 @@ Note in particular that if you are cross-compiling an x86 build on a 64-bit
 version of Linux, then you need to have the proper gcc-multilibs and
 g++-multilibs packages or equivalent installed.
 
+On some platforms, you may need to specify `MAKE` variable for pointing to
+correct GNU make command. By default, *ring* uses `gmake` on BSD systems, and
+`make` on other platforms including Linux and Mac OS X.
+
 
 
 This Sucks. What are you doing to fix it?

--- a/build.rs
+++ b/build.rs
@@ -113,7 +113,17 @@ fn build_c_code(out_dir: &str) -> Result<(), std::env::VarError> {
             format!("CMAKE_BUILD_TYPE={}", cmake_build_type),
             format!("BUILD_PREFIX={}/", out_dir),
         ];
-        run_command_with_args(&"make", &args);
+        // If $MAKE is given, use it as the make command. If not, use `gmake` for
+        // BSD systems and `make` for other systems.
+        let make = env::var_os("MAKE").unwrap_or_else(|| {
+            let m = if target_triple[2].contains("bsd") {
+                "gmake"
+            } else {
+                "make"
+            };
+            std::ffi::OsString::from(m)
+        });
+        run_command_with_args(&make, &args);
     } else {
         let arch = target_triple[0];
         let (platform, optional_amd64) = match arch {

--- a/mk/top_of_makefile.mk
+++ b/mk/top_of_makefile.mk
@@ -39,9 +39,13 @@ TARGET_ABI = macho
 # Set the correct VENDOR, SYS and ABI when building for Android.
 else ifeq ($(findstring linux-android,$(TARGET_VENDOR)-$(TARGET_SYS)),linux-android)
 TARGET_ABI = $(TARGET_SYS)
-TARGET_VENDOR = unknow
+TARGET_VENDOR = unknown
 TARGET_SYS = linux
 else
+
+# If we find `bsd` in the target system, we can assume a target triple is OK,
+# so skip the error here.
+ifeq (,$(findstring bsd,$(TARGET_SYS)))
 define NEWLINE
 
 
@@ -56,6 +60,7 @@ $(error TARGET must be of the form \
         Android example:	TARGET=arm-linux-androideabi $(NEWLINE)\
 \
         NOTE: Use "i586" instead of "x86")
+endif
 endif
 endif
 


### PR DESCRIPTION
- build.rs
  * Default to `gmake` on BSD systems
  * Support optional `MAKE` variable for pointing to correct `make`
- mk/top_of_makefile.mk
  * Allow target triple on *BSD not to have abi (e.g. x86_64-unknown-freebsd)
- BUILDING.md
  * Add descriptions about `MAKE` variable.

This is take 2 of PR #290 created by @GrappigPanda, and will address the build issue on *BSD systems:
- [Cross compilation on *BSD #287](https://github.com/briansmith/ring/issues/287)
- [FreeBSD compilation error #311](https://github.com/briansmith/ring/issues/311)

Tested on FreeBSD 10.3-RELEASE (amd64) using `cargo test`.

@briansmith @oherrala Can you please review?