### PR TITLE
use neon on armv7

### DIFF
--- a/mk/top_of_makefile.mk
+++ b/mk/top_of_makefile.mk
@@ -141,6 +141,9 @@ IOS_VERSION_FLAG = -mios-version-min=$(IOS_MIN_VERSION)
 ifeq ($(TARGET_ARCH_BASE),aarch64)
 CFLAGS += -arch arm64
 CXXFLAGS += -arch arm64
+else ifeq ($(TARGET_ARCH_BASE),armv7)
+CFLAGS += -arch $(TARGET_ARCH_BASE) -mfpu=neon
+CXXFLAGS += -arch $(TARGET_ARCH_BASE) -mfpu=neon
 else
 CFLAGS += -arch $(TARGET_ARCH_BASE)
 CXXFLAGS += -arch $(TARGET_ARCH_BASE)


### PR DESCRIPTION
enable neon support on armv7 platforms.

An alternative was to disable neon code altogether, but part of the code already assumes it's there. I know most devices will have it, but I'm not sure whether or there exist neon-less armv7 around. As far as I can tell, all phones and mainstream stuff should have it.

see also briansmith/ring#312