### PR TITLE
[WIP] Issue #316 - Replace `/dev/urandom` usage on OpenBSD

### DIFF
--- a/crypto/rand/sysrand.c
+++ b/crypto/rand/sysrand.c
@@ -105,4 +105,24 @@ int GFp_sysrand_chunk(void *out, size_t requested) {
   return 1;
 }
 
+#elif defined(__OpenBSD__) || defined(__FreeBSD__)
+
+#include <limits.h>
+#include <stdlib.h>
+
+// DEBUG:
+#include <stdio.h>
+
+const size_t GFp_sysrand_chunk_max_len = ULONG_MAX;
+
+int GFp_sysrand_chunk(void *out, size_t requested) {
+    // DEBUG:
+    printf("calling arc4rand_buf()\n");
+
+    assert(requested <= GFp_sysrand_chunk_max_len);
+    // This function never fails so let's always return 1.
+    arc4random_buf(out, requested);
+    return 1;
+}
+
 #endif

--- a/mk/ring.mk
+++ b/mk/ring.mk
@@ -14,7 +14,12 @@
 
 RING_PREFIX ?= ring/
 
-RING_CPPFLAGS = -I$(RING_PREFIX)include -D_XOPEN_SOURCE=700
+RING_CPPFLAGS = -I$(RING_PREFIX)include
+ifneq (, $(filter openbsd freebsd, $(TARGET_SYS)))
+RING_CPPFLAGS += -D_BSD_SOURCE
+else
+RING_CPPFLAGS += -D_XOPEN_SOURCE=700
+endif
 
 RING_SRCS = $(addprefix $(RING_PREFIX), \
   crypto/aes/aes.c \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,10 @@
 #[cfg(feature = "internal_benches")]
 extern crate test as bench;
 
-#[cfg(any(all(unix,
-              any(not(target_os = "linux"),
-                  feature = "dev_urandom_fallback"))))]
+#[cfg(all(unix,
+          any(not(target_os = "linux"), feature = "dev_urandom_fallback"),
+          not(any(target_os = "openbsd",
+                  target_os = "freebsd"))))]
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
**Work In Progress. Please do not merge this PR yet.**

I started to work on issue [#136 "Replace `/dev/urandom` usage on *BSD"](https://github.com/briansmith/ring/issues/316). I have replaced `/dev/urandom` usage in OpenBSD and FreeBSD with `arc4rand_buf()` function in their C stdlib.

I am testing this on OpenBSD 6.0 (amd64) and FreeBSD 10.3-RELEASE (amd64).

**TODOs:**
- [ ] Update docs.
- [ ] Remove debug print in crypt/rand/sysrand.c.
- [x] Ensure FreeBSD's `arc4rand_buf()` is as safe as OpenBSD's. -> (Nov 1, 2016). It is ***not*** as safe as OpenBSD's. I will revert changes for FreeBSD. For more details, see [this comment](https://github.com/briansmith/ring/issues/316#issuecomment-257479426).
