### PR TITLE
Fix subkey order in chacha20-poly1305@openssh.com

### DIFF
--- a/src/aead/chacha20_poly1305_openssh.rs
+++ b/src/aead/chacha20_poly1305_openssh.rs
@@ -137,14 +137,15 @@ struct Key {
 
 impl Key {
     pub fn new(key_material: &[u8; KEY_LEN]) -> Key {
+        // The first half becomes K_2 and the second half becomes K_1.
         Key {
             k_1: chacha::key_from_bytes(
                     slice_as_array_ref!(
-                        &key_material[..chacha::KEY_LEN_IN_BYTES],
+                        &key_material[chacha::KEY_LEN_IN_BYTES..],
                         chacha::KEY_LEN_IN_BYTES).unwrap()),
             k_2: chacha::key_from_bytes(
                     slice_as_array_ref!(
-                        &key_material[chacha::KEY_LEN_IN_BYTES..],
+                        &key_material[..chacha::KEY_LEN_IN_BYTES],
                         chacha::KEY_LEN_IN_BYTES).unwrap()),
         }
     }


### PR DESCRIPTION
[From the protocol docs:](http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD)

> 37: The first 256 bits consitute K_2 and the second 256 bits become
> 38: K_1.

Ran into this while moving away from libsodium in my SSH library. Any ideas why they chose this backwards order?
