### PR TITLE
Allow calling `getrandom` with 257-byte buffer

### DIFF
--- a/crypto/rand/sysrand.c
+++ b/crypto/rand/sysrand.c
@@ -59,7 +59,6 @@ int GFp_sysrand_chunk(void *buf, size_t len);
 #pragma warning(pop)
 
 int GFp_sysrand_chunk(void *out, size_t requested) {
-  assert(requested <= GFp_sysrand_chunk_max_len);
   return RtlGenRandom(out, (ULONG)requested) ? 1 : 0;
 }
 

--- a/crypto/rand/sysrand.c
+++ b/crypto/rand/sysrand.c
@@ -101,8 +101,8 @@ int GFp_sysrand_chunk(void *out, size_t requested) {
 
   int r = syscall(SYS_getrandom, out, requested, 0u);
   if (r < 0) {
-    // EINTR and EAGAIN are normal, and we can try again. Other error codes are fatal.
-    if (errno == EINTR || errno == EAGAIN) {
+    // EINTR is normal, and we can try again. Other error codes are fatal.
+    if (errno == EINTR) {
       return 0;
     }
     return -1;

--- a/crypto/rand/sysrand.c
+++ b/crypto/rand/sysrand.c
@@ -58,8 +58,6 @@ int GFp_sysrand_chunk(void *buf, size_t len);
 
 #pragma warning(pop)
 
-const size_t GFp_sysrand_chunk_max_len = ULONG_MAX;
-
 int GFp_sysrand_chunk(void *out, size_t requested) {
   assert(requested <= GFp_sysrand_chunk_max_len);
   return RtlGenRandom(out, (ULONG)requested) ? 1 : 0;
@@ -88,21 +86,16 @@ int GFp_sysrand_chunk(void *out, size_t requested) {
 #endif
 #endif
 
-
-/* http://man7.org/linux/man-pages/man2/getrandom.2.html: "Calling
- * getrandom() to read /dev/urandom for small values (<= 256) of buflen is
- * the preferred mode of usage." */
-const size_t GFp_sysrand_chunk_max_len = 256;
-
 int GFp_sysrand_chunk(void *out, size_t requested) {
-  assert(requested <= GFp_sysrand_chunk_max_len);
-  if (syscall(SYS_getrandom, out, requested, 0u) < 0) {
-    if (errno == ENOSYS) {
-      return -1;
+  int r = syscall(SYS_getrandom, out, requested, 0u);
+  if (r < 0) {
+    // EINTR and EAGAIN are normal, and we can try again. Other error codes are fatal.
+    if (errno == EINTR || errno == EAGAIN) {
+      return 0;
     }
-    return 0;
+    return -1;
   }
-  return 1;
+  return r;
 }
 
 #endif

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -328,12 +328,12 @@ mod tests {
             }
 
             // Make sure we didn't forget to finish filling in the rest of the
-            // buffer after we filled in the first chunk, especially in the
+            // buffer after we filled in the first chunk.
             // case in the `SysRandOrDevURandom::Undecided` case. As above, we
             // only do this when there are at least 96 bytes after the first
             // chunk to avoid false positives.
-            if *len > 256 + 96 {
-                assert!(buf[256..].iter().any(|x| *x != 0));
+            if *len > 96 {
+                assert!(buf[buf.len() - 96 ..].iter().any(|x| *x != 0));
             }
         }
     }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -119,14 +119,19 @@ use self::sysrand_or_urandom::fill as fill_impl;
 
 #[cfg(any(target_os = "linux", windows))]
 mod sysrand {
-    use {bssl, error};
+    use error;
 
     pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        let chunk_len = unsafe { super::GFp_sysrand_chunk_max_len };
-        for mut chunk in dest.chunks_mut(chunk_len) {
-            try!(bssl::map_result(unsafe {
-                super::GFp_sysrand_chunk(chunk.as_mut_ptr(), chunk.len())
-            }));
+        let mut read_len = 0;
+        while read_len < dest.len() {
+            let r = unsafe {
+                super::GFp_sysrand_chunk(dest[read_len ..].as_mut_ptr(), dest.len() - read_len)
+            };
+            if r < 0 {
+                return Err(error::Unspecified);
+            } else {
+                read_len += r as usize;
+            }
         }
         Ok(())
     }
@@ -217,7 +222,6 @@ pub unsafe extern fn RAND_bytes(rng: *mut RAND, dest: *mut u8,
 
 #[cfg(any(target_os = "linux", windows))]
 extern {
-    static GFp_sysrand_chunk_max_len: c::size_t;
     fn GFp_sysrand_chunk(buf: *mut u8, len: c::size_t) -> c::int;
 }
 
@@ -327,18 +331,9 @@ mod tests {
             // case in the `SysRandOrDevURandom::Undecided` case. As above, we
             // only do this when there are at least 96 bytes after the first
             // chunk to avoid false positives.
-            if *len > 96 && *len - 96 > max_chunk_len() {
-                assert!(buf[max_chunk_len()..].iter().any(|x| *x != 0));
+            if *len > 256 + 96 {
+                assert!(buf[256..].iter().any(|x| *x != 0));
             }
         }
-    }
-
-    #[cfg(any(target_os = "linux", windows))]
-    fn max_chunk_len() -> usize { unsafe { super::GFp_sysrand_chunk_max_len } }
-
-    #[cfg(not(any(target_os = "linux", windows)))]
-    fn max_chunk_len() -> usize {
-        use core;
-        core::usize::MAX
     }
 }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -129,9 +129,10 @@ mod sysrand {
             };
             if r < 0 {
                 return Err(error::Unspecified);
-            } else {
-                read_len += r as usize;
             }
+            // XXX: If r == 0 then this is a busy wait loop waiting for the
+            //      kernel entropy pool to be initialized
+            read_len += r as usize;
         }
         Ok(())
     }


### PR DESCRIPTION
Fixed issue #353.

Now `rand::sysrand::fill` does not loop with fixed 256-byte chunks,
but calls `getrandom` to fill the whole buffer.