### PR TITLE
Verify RSA PKCS#1 1.5 signatures by encode-then-check.

### DIFF
--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -17,6 +17,11 @@
 
 use core;
 
+// A better name for the `&*` idiom for removing the mutability from a
+// reference.
+#[inline(always)]
+pub fn ref_from_mut_ref<'a, T: ?Sized>(x: &'a mut T) -> &'a T { x }
+
 #[inline(always)]
 pub fn u64_from_usize(x: usize) -> u64 { x as u64 }
 


### PR DESCRIPTION
When we first implemented PKCS#1 1.5 signature verification we had not
implemented signature generation, so we implemented verification by
parsing the padding. Now that we have generation we can save some code
and arguably make verification safer. Also, this is the way RFC 3447
recommends to do it.