### PR TITLE
Use a more specific error instead of unspecified::Error for DER encoding errors, as per #379

### DIFF
--- a/src/ec/suite_b/ops/ops.rs
+++ b/src/ec/suite_b/ops/ops.rs
@@ -338,7 +338,7 @@ pub struct PublicScalarOps {
 impl PublicScalarOps {
     pub fn scalar_parse(&self, input: &mut untrusted::Reader)
                         -> Result<Scalar, error::Unspecified> {
-        let encoded_value = try!(der::positive_integer(input));
+        let encoded_value = try!(der::positive_integer(input).map_err(|_| error::Unspecified));
         let limbs = try!(parse_big_endian_value_in_range(
                             encoded_value, 1,
                             &self.public_key_ops.common.n.limbs[

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -88,7 +88,7 @@ impl Positive {
     // Parses a single ASN.1 DER-encoded `Integer`, which most be positive.
     pub fn from_der(input: &mut untrusted::Reader)
                     -> Result<Positive, error::Unspecified> {
-        Self::from_be_bytes(try!(der::positive_integer(input)))
+        Self::from_be_bytes(try!(der::positive_integer(input).map_err(|_| error::Unspecified)))
     }
 
     // Turns a sequence of big-endian bytes into a Positive Integer.

--- a/src/rsa/rsa.rs
+++ b/src/rsa/rsa.rs
@@ -57,8 +57,8 @@ fn parse_public_key(input: untrusted::Input)
                               error::Unspecified> {
     input.read_all(error::Unspecified, |input| {
         der::nested(input, der::Tag::Sequence, error::Unspecified, |input| {
-            let n = try!(der::positive_integer(input));
-            let e = try!(der::positive_integer(input));
+            let n = try!(der::positive_integer(input).map_err(|_| error::Unspecified));
+            let e = try!(der::positive_integer(input).map_err(|_| error::Unspecified));
             Ok((n, e))
         })
     })

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -84,7 +84,8 @@ impl RSAKeyPair {
                     -> Result<RSAKeyPair, error::Unspecified> {
         input.read_all(error::Unspecified, |input| {
             der::nested(input, der::Tag::Sequence, error::Unspecified, |input| {
-                let version = try!(der::small_nonnegative_integer(input));
+                let version = try!(der::small_nonnegative_integer(input)
+                    .map_err(|_| error::Unspecified));
                 if version != 0 {
                     return Err(error::Unspecified);
                 }

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -154,7 +154,7 @@ pub fn verify_rsa(params: &RSAParameters,
 mod tests {
     // We intentionally avoid `use super::*` so that we are sure to use only
     // the public API; this ensures that enough of the API is public.
-    use {der, error, signature, test};
+    use {der, signature, test};
     use untrusted;
 
     #[test]
@@ -178,8 +178,8 @@ mod tests {
             // Sanity check that we correctly DER-encoded the originally-
             // provided separate (n, e) components. When we add test vectors
             // for improperly-encoded signatures, we'll have to revisit this.
-            assert!(public_key.read_all(error::Unspecified, |input| {
-                der::nested(input, der::Tag::Sequence, error::Unspecified,
+            assert!(public_key.read_all(der::ASN1Error, |input| {
+                der::nested(input, der::Tag::Sequence, der::ASN1Error,
                             |input| {
                     let _ = try!(der::positive_integer(input));
                     let _ = try!(der::positive_integer(input));
@@ -222,8 +222,8 @@ mod tests {
             // Sanity check that we correctly DER-encoded the originally-
             // provided separate (n, e) components. When we add test vectors
             // for improperly-encoded signatures, we'll have to revisit this.
-            assert!(public_key.read_all(error::Unspecified, |input| {
-                der::nested(input, der::Tag::Sequence, error::Unspecified,
+            assert!(public_key.read_all(der::ASN1Error, |input| {
+                der::nested(input, der::Tag::Sequence, der::ASN1Error,
                             |input| {
                     let _ = try!(der::positive_integer(input));
                     let _ = try!(der::positive_integer(input));


### PR DESCRIPTION
I agree to license my contributions to each file under the terms given
at the top of each file I changed.