### PR TITLE
Add tests for maximum input length for digests

### DIFF
--- a/src/digest/digest.rs
+++ b/src/digest/digest.rs
@@ -772,4 +772,53 @@ mod tests {
                             digest::digest(&digest::SHA512, b"hello, world")));
 
     }
+
+    mod max_input {
+        macro_rules! max_input_tests {
+            ( $algorithm_name:ident ) => {
+                #[allow(unused_results)]
+                #[allow(non_snake_case)]
+                mod $algorithm_name {
+                    use super::super::super::super::digest;
+
+                    fn nearly_full_context() -> digest::Context {
+                        // All implementations currently support up to 2^64-1 bits
+                        // of input; according to the spec, SHA-384 and SHA-512
+                        // support up to 2^128-1, but that's not implemented yet.
+                        let max_bytes = 1u64 << (64 - 3);
+                        let max_blocks = max_bytes / (digest::$algorithm_name.block_len as u64);
+                        digest::Context {
+                            algorithm: &digest::$algorithm_name,
+                            state: digest::$algorithm_name.initial_state,
+                            completed_data_blocks: max_blocks - 1,
+                            pending: [0u8; digest::MAX_BLOCK_LEN],
+                            num_pending: 0,
+                        }
+                    }
+
+                    #[test]
+                    fn max_input_test() {
+                        let mut context = nearly_full_context();
+                        let next_input = vec![0u8; digest::$algorithm_name.block_len - 1];
+                        context.update(&next_input);
+                        context.finish(); // no panic
+                    }
+
+                    #[test]
+                    #[should_panic]
+                    fn too_long_input_test() {
+                        let mut context = nearly_full_context();
+                        let next_input = vec![0u8; digest::$algorithm_name.block_len];
+                        context.update(&next_input);
+                        context.finish(); // should panic
+                    }
+                }
+            }
+        }
+
+        max_input_tests!(SHA1);
+        max_input_tests!(SHA256);
+        max_input_tests!(SHA384);
+        max_input_tests!(SHA512);
+    }
 }


### PR DESCRIPTION
Fixes #341 - kind of. The `completed_data_blocks` / `completed_data_bits` tracking appears to already effectively implement the strategy suggested in that issue, so this just adds tests. If we (~ @briansmith) aren't satisfied with a panic with an obscure message, it appears we need to change the `digest::digest` API, and it wasn't clear to me whether that's in scope.

(Also, if we do that, I wonder if we need to make the check less lazy, in case people end up relying on it for DOS-protection.)