### PR TITLE
Add tests of non-aligned digest inputs

### DIFF
--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -400,24 +400,20 @@ mod tests {
                 257, // 16 AES blocks or 8 ChaCha20 blocks, plus 1.
             ];
 
-            let mut more_comprehensive_in_prefix_lenghts = [0; 4096];
+            let mut more_comprehensive_in_prefix_lengths = [0; 4096];
             let in_prefix_lengths;
             if cfg!(debug_assertions) {
                 in_prefix_lengths = &MINIMAL_IN_PREFIX_LENS[..];
             } else {
-                for b in 0..more_comprehensive_in_prefix_lenghts.len() {
-                    more_comprehensive_in_prefix_lenghts[b] = b;
+                for b in 0..more_comprehensive_in_prefix_lengths.len() {
+                    more_comprehensive_in_prefix_lengths[b] = b;
                 }
-                in_prefix_lengths = &more_comprehensive_in_prefix_lenghts[..];
+                in_prefix_lengths = &more_comprehensive_in_prefix_lengths[..];
             }
-            let mut o_in_out = vec![123u8; 4096];
+            let mut o_in_out = test::PrefixedByteVec::with_capacity(4096);
 
             for in_prefix_len in in_prefix_lengths.iter() {
-                o_in_out.truncate(0);
-                for _ in 0..*in_prefix_len {
-                    o_in_out.push(123);
-                }
-                o_in_out.extend_from_slice(&ct[..]);
+                o_in_out.replace_from(*in_prefix_len, &ct[..]);
                 let o_result = aead::open_in_place(&o_key, &nonce[..],
                                                    *in_prefix_len,
                                                    &mut o_in_out[..], &ad);

--- a/src/test.rs
+++ b/src/test.rs
@@ -122,6 +122,7 @@ use bits;
 use {digest, error};
 
 use std;
+use std::ops::{Deref, DerefMut};
 use std::string::String;
 use std::vec::Vec;
 use std::io::BufRead;
@@ -367,6 +368,73 @@ fn parse_test_case(current_section: &mut String, lines: &mut FileLines)
                 attributes.push((String::from(key), String::from(value), false));
             },
         }
+    }
+}
+
+/// A container that stores a byte sequence preceded by a prefix of zero
+/// or more dummy bytes.  This is useful for test cases that need to exercise
+/// vectorized implementations with non-aligned inputs.
+pub struct PrefixedByteVec {
+    prefix_len: usize,
+    vec: Vec<u8>,
+}
+
+impl PrefixedByteVec {
+    /// Create an empty PrefixedByteVec that can hold `size` bytes of
+    /// prefix+data.
+    pub fn with_capacity(size: usize) -> PrefixedByteVec {
+        PrefixedByteVec {
+            prefix_len: 0,
+            vec: Vec::with_capacity(size),
+        }
+    }
+
+    /// Create an PrefixedByteVec containing a copy of the provided slice,
+    /// preceded by `prefix_len` dummy bytes.
+    pub fn from(prefix_len: usize, data: &[u8]) -> PrefixedByteVec {
+        let mut v = PrefixedByteVec {
+            prefix_len: prefix_len,
+            vec: Vec::with_capacity(prefix_len + data.len()),
+        };
+        v.replace_from(prefix_len, data);
+        v
+    }
+
+    /// Replace a PrefixedByteVec's contents with a copy of the provided
+    /// slice, preceded by `prefix_len` dummy bytes.
+    pub fn replace_from(&mut self, prefix_len: usize, data: &[u8]) {
+        self.vec.clear();
+        for _ in 0..prefix_len {
+            self.vec.push(123);
+        }
+        self.vec.extend(data.iter());
+        self.prefix_len = prefix_len;
+        assert_eq!(self.vec.len(), self.prefix_len + data.len());
+    }
+
+    /// Return a slice containing the full contents, including the prefix.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.vec.as_slice()
+    }
+
+    /// Return a slice containing just the data, excluding the prefix.
+    pub fn data(&self) -> &[u8] {
+        &self.vec.as_slice()[self.prefix_len..]
+    }
+
+}
+
+impl Deref for PrefixedByteVec {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        self.vec.deref()
+    }
+}
+
+impl DerefMut for PrefixedByteVec {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        self.vec.deref_mut()
     }
 }
 


### PR DESCRIPTION
Add tests of non-aligned digest inputs, and reuse the supporting`PrefixedByteVec` class for the AEAD tests.
(fixes #178)

I agree to license my contributions to each file under the terms given
at the top of each file I changed.