### PR TITLE
Fix function name typos in doc comments.

### DIFF
--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -79,13 +79,13 @@ impl OpeningKey {
 /// Authenticates and decrypts (&ldquo;opens&rdquo;) data in place.
 ///
 /// The input is `in_out[in_prefix_len..]`; i.e. the input is the part of
-/// `in_out` after the prefix. When `open` returns `Ok(out_len)`, the decrypted
-/// output is `in_out[..out_len]`; i.e. the output has been written over the
-/// top of the prefix and the input. To put it a different way, the output
-/// overwrites the input, shifted by `in_prefix_len` bytes. To have the output
-/// overwrite the input without shifting, pass 0 as `in_prefix_len`. (The
-/// input/output buffer is expressed this way because Rust's type system does
-/// not allow us to have two slices, one mutable and one immutable, that
+/// `in_out` after the prefix. When `open_in_place` returns `Ok(out_len)`, the
+/// decrypted output is `in_out[..out_len]`; i.e. the output has been written
+/// over the top of the prefix and the input. To put it a different way, the
+/// output overwrites the input, shifted by `in_prefix_len` bytes. To have the
+/// output overwrite the input without shifting, pass 0 as `in_prefix_len`.
+/// (The input/output buffer is expressed this way because Rust's type system
+/// does not allow us to have two slices, one mutable and one immutable, that
 /// reference overlapping memory at the same time.)
 ///
 /// C analog: `EVP_AEAD_CTX_open`
@@ -162,13 +162,13 @@ impl SealingKey {
 /// `nonce` must be unique for every use of the key to seal data.
 ///
 /// The input is `in_out[..(in_out.len() - out_suffix_capacity)]`; i.e. the
-/// input is the part of `in_out` that precedes the suffix. When `seal` returns
-/// `Ok(out_len)`, the encrypted and signed output is `in_out[..out_len]`; i.e.
-/// the output has been written over input and at least part of the data
-/// reserved for the suffix. (The input/output buffer is expressed this way
-/// because Rust's type system does not allow us to have two slices, one
-/// mutable and one immutable, that reference overlapping memory at the same
-/// time.)
+/// input is the part of `in_out` that precedes the suffix. When
+/// `seal_in_place` returns `Ok(out_len)`, the encrypted and signed output is
+/// `in_out[..out_len]`; i.e.  the output has been written over input and at
+/// least part of the data reserved for the suffix. (The input/output buffer
+/// is expressed this way because Rust's type system does not allow us to have
+/// two slices, one mutable and one immutable, that reference overlapping
+/// memory at the same time.)
 ///
 /// `out_suffix_capacity` must be at least `key.algorithm.max_overhead_len()`.
 /// See also `MAX_OVERHEAD_LEN`.


### PR DESCRIPTION
`open` -> `open_in_place`
`seal` -> `seal_in_place`

I agree to license my contributions to each file under the terms given
at the top of each file I changed.