### PR TITLE
Detect cpu features on ARM with getauxval()

### DIFF
--- a/crypto/cpu-arm-linux.c
+++ b/crypto/cpu-arm-linux.c
@@ -16,6 +16,8 @@
 
 #ifdef __linux__
 
+#include <errno.h>
+
 /* |getauxval| is not available on Android until API level 20. Link it as a weak
  * symbol and use other methods as fallback. As of Rust 1.14 this weak linkage
  * isn't supported, so we do it in C.
@@ -24,24 +26,15 @@ unsigned long getauxval(unsigned long type) __attribute__((weak));
 
 /*
  * If getauxval is not available, or an error occurs, return 0.
- * Otherwise, return the value found.
+ * Otherwise, return the value found (which may be zero).
  */
 unsigned long getauxval_wrapper(unsigned long type);
-
-#include <errno.h>
 
 unsigned long getauxval_wrapper(unsigned long type) {
     if (getauxval == NULL) {
         return 0;
     }
 
-    unsigned long auxval = getauxval(type);
-    // map errors to a zero value
-    if (errno != 0) {
-        errno = 0;
-        return 0;
-    }
-
-    return auxval;
+    return getauxval(type);
 }
 #endif

--- a/crypto/cpu-arm-linux.c
+++ b/crypto/cpu-arm-linux.c
@@ -1,3 +1,17 @@
+/* Copyright (c) 2016, Google Inc.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+
 #include <openssl/cpu.h>
 
 #ifdef __linux__

--- a/crypto/cpu-arm-linux.c
+++ b/crypto/cpu-arm-linux.c
@@ -13,10 +13,9 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 
 #include <openssl/cpu.h>
+#include <errno.h>
 
 #ifdef __linux__
-
-#include <errno.h>
 
 /* |getauxval| is not available on Android until API level 20. Link it as a weak
  * symbol and use other methods as fallback. As of Rust 1.14 this weak linkage

--- a/crypto/cpu-arm-linux.c
+++ b/crypto/cpu-arm-linux.c
@@ -1,358 +1,45 @@
-/* Copyright (c) 2016, Google Inc.
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
- * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
- * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
-
 #include <openssl/cpu.h>
 
-#if defined(OPENSSL_ARM) && !defined(OPENSSL_STATIC_ARMCAP)
-
-#include <errno.h>
-#include <fcntl.h>
-#include <string.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#include <openssl/arm_arch.h>
-#include <openssl/mem.h>
-
-#include "internal.h"
-
-
-#define AT_HWCAP 16
-#define AT_HWCAP2 26
-
-#define HWCAP_NEON (1 << 12)
-
-/* See /usr/include/asm/hwcap.h on an ARM installation for the source of
- * these values. */
-#define HWCAP2_AES (1 << 0)
-#define HWCAP2_PMULL (1 << 1)
-#define HWCAP2_SHA1 (1 << 2)
-#define HWCAP2_SHA2 (1 << 3)
+#ifdef __linux__
 
 /* |getauxval| is not available on Android until API level 20. Link it as a weak
- * symbol and use other methods as fallback. */
+ * symbol and use other methods as fallback. As of Rust 1.14 this weak linkage
+ * isn't supported, so we do it in C.
+ */
 unsigned long getauxval(unsigned long type) __attribute__((weak));
 
-static int open_eintr(const char *path, int flags) {
-  int ret;
-  do {
-    ret = open(path, flags);
-  } while (ret < 0 && errno == EINTR);
-  return ret;
-}
+/*
+ * getauxval() may or may not be available. In addition, it may not find
+ * the type requested.
+ * - If getauxval() is not available, this returns -1.
+ * - If getauxval() is available but the requested type is not found or another
+ *   error occurs, this returns 0.
+ * - If getauxval() is available but a different error occurs, this returns -2.
+ * - If getauxval() is available and the requested type is found, this returns
+ *   1 and also writes to the result pointer param.
+ */
+int32_t getauxval_wrapper(unsigned long type, unsigned long *result);
 
-static ssize_t read_eintr(int fd, void *out, size_t len) {
-  ssize_t ret;
-  do {
-    ret = read(fd, out, len);
-  } while (ret < 0 && errno == EINTR);
-  return ret;
-}
+#include <errno.h>
 
-/* read_full reads exactly |len| bytes from |fd| to |out|. On error or end of
- * file, it returns zero. */
-static int read_full(int fd, void *out, size_t len) {
-  while (len > 0) {
-    ssize_t ret = read_eintr(fd, out, len);
-    if (ret <= 0) {
-      return 0;
-    }
-    out = (uint8_t *)out + ret;
-    len -= ret;
-  }
-  return 1;
-}
-
-/* read_file opens |path| and reads until end-of-file. On success, it returns
- * one and sets |*out_ptr| and |*out_len| to a newly-allocated buffer with the
- * contents. Otherwise, it returns zero. */
-static int read_file(char **out_ptr, size_t *out_len, const char *path) {
-  int fd = open_eintr(path, O_RDONLY);
-  if (fd < 0) {
-    return 0;
-  }
-
-  static const size_t kReadSize = 1024;
-  int ret = 0;
-  size_t cap = kReadSize, len = 0;
-  char *buf = OPENSSL_malloc(cap);
-  if (buf == NULL) {
-    goto err;
-  }
-
-  for (;;) {
-    if (cap - len < kReadSize) {
-      size_t new_cap = cap * 2;
-      if (new_cap < cap) {
-        goto err;
-      }
-      char *new_buf = OPENSSL_realloc(buf, new_cap);
-      if (new_buf == NULL) {
-        goto err;
-      }
-      buf = new_buf;
-      cap = new_cap;
+int32_t getauxval_wrapper(unsigned long type, unsigned long *result) {
+    if (getauxval == NULL) {
+        return -1;
     }
 
-    ssize_t bytes_read = read_eintr(fd, buf + len, kReadSize);
-    if (bytes_read < 0) {
-      goto err;
+    unsigned long auxval = getauxval(type);
+    if (errno == ENOENT) {
+        // as of glibc 2.19, errno is ENOENT if the type is not found.
+        errno = 0;
+        return 0;
+    } else if (errno != 0) {
+        // as of glibc 2.23 the only error is enoent, but more errors
+        // may be added
+        errno = 0;
+        return -2;
     }
-    if (bytes_read == 0) {
-      break;
-    }
-    len += bytes_read;
-  }
 
-  *out_ptr = buf;
-  *out_len = len;
-  ret = 1;
-  buf = NULL;
-
-err:
-  OPENSSL_free(buf);
-  close(fd);
-  return ret;
+    *result = auxval;
+    return 1;
 }
-
-/* getauxval_proc behaves like |getauxval| but reads from /proc/self/auxv. */
-static unsigned long getauxval_proc(unsigned long type) {
-  int fd = open_eintr("/proc/self/auxv", O_RDONLY);
-  if (fd < 0) {
-    return 0;
-  }
-
-  struct {
-    unsigned long tag;
-    unsigned long value;
-  } entry;
-
-  for (;;) {
-    if (!read_full(fd, &entry, sizeof(entry)) ||
-        (entry.tag == 0 && entry.value == 0)) {
-      break;
-    }
-    if (entry.tag == type) {
-      close(fd);
-      return entry.value;
-    }
-  }
-  close(fd);
-  return 0;
-}
-
-typedef struct {
-  const char *data;
-  size_t len;
-} STRING_PIECE;
-
-static int STRING_PIECE_equals(const STRING_PIECE *a, const char *b) {
-  size_t b_len = strlen(b);
-  return a->len == b_len && memcmp(a->data, b, b_len) == 0;
-}
-
-/* STRING_PIECE_split finds the first occurence of |sep| in |in| and, if found,
- * sets |*out_left| and |*out_right| to |in| split before and after it. It
- * returns one if |sep| was found and zero otherwise. */
-static int STRING_PIECE_split(STRING_PIECE *out_left, STRING_PIECE *out_right,
-                              const STRING_PIECE *in, char sep) {
-  const char *p = memchr(in->data, sep, in->len);
-  if (p == NULL) {
-    return 0;
-  }
-  /* |out_left| or |out_right| may alias |in|, so make a copy. */
-  STRING_PIECE in_copy = *in;
-  out_left->data = in_copy.data;
-  out_left->len = p - in_copy.data;
-  out_right->data = in_copy.data + out_left->len + 1;
-  out_right->len = in_copy.len - out_left->len - 1;
-  return 1;
-}
-
-/* STRING_PIECE_trim removes leading and trailing whitespace from |s|. */
-static void STRING_PIECE_trim(STRING_PIECE *s) {
-  while (s->len != 0 && (s->data[0] == ' ' || s->data[0] == '\t')) {
-    s->data++;
-    s->len--;
-  }
-  while (s->len != 0 &&
-         (s->data[s->len - 1] == ' ' || s->data[s->len - 1] == '\t')) {
-    s->len--;
-  }
-}
-
-/* extract_cpuinfo_field extracts a /proc/cpuinfo field named |field| from
- * |in|.  If found, it sets |*out| to the value and returns one. Otherwise, it
- * returns zero. */
-static int extract_cpuinfo_field(STRING_PIECE *out, const STRING_PIECE *in,
-                                 const char *field) {
-  /* Process |in| one line at a time. */
-  STRING_PIECE remaining = *in, line;
-  while (STRING_PIECE_split(&line, &remaining, &remaining, '\n')) {
-    STRING_PIECE key, value;
-    if (!STRING_PIECE_split(&key, &value, &line, ':')) {
-      continue;
-    }
-    STRING_PIECE_trim(&key);
-    if (STRING_PIECE_equals(&key, field)) {
-      STRING_PIECE_trim(&value);
-      *out = value;
-      return 1;
-    }
-  }
-
-  return 0;
-}
-
-static int cpuinfo_field_equals(const STRING_PIECE *cpuinfo, const char *field,
-                                const char *value) {
-  STRING_PIECE extracted;
-  return extract_cpuinfo_field(&extracted, cpuinfo, field) &&
-         STRING_PIECE_equals(&extracted, value);
-}
-
-/* has_list_item treats |list| as a space-separated list of items and returns
- * one if |item| is contained in |list| and zero otherwise. */
-static int has_list_item(const STRING_PIECE *list, const char *item) {
-  STRING_PIECE remaining = *list, feature;
-  while (STRING_PIECE_split(&feature, &remaining, &remaining, ' ')) {
-    if (STRING_PIECE_equals(&feature, item)) {
-      return 1;
-    }
-  }
-  return 0;
-}
-
-static unsigned long get_hwcap_cpuinfo(const STRING_PIECE *cpuinfo) {
-  if (cpuinfo_field_equals(cpuinfo, "CPU architecture", "8")) {
-    /* This is a 32-bit ARM binary running on a 64-bit kernel. NEON is always
-     * available on ARMv8. Linux omits required features, so reading the
-     * "Features" line does not work. (For simplicity, use strict equality. We
-     * assume everything running on future ARM architectures will have a
-     * working |getauxval|.) */
-    return HWCAP_NEON;
-  }
-
-  STRING_PIECE features;
-  if (extract_cpuinfo_field(&features, cpuinfo, "Features") &&
-      has_list_item(&features, "neon")) {
-    return HWCAP_NEON;
-  }
-  return 0;
-}
-
-static unsigned long get_hwcap2_cpuinfo(const STRING_PIECE *cpuinfo) {
-  STRING_PIECE features;
-  if (!extract_cpuinfo_field(&features, cpuinfo, "Features")) {
-    return 0;
-  }
-
-  unsigned long ret = 0;
-  if (has_list_item(&features, "aes")) {
-    ret |= HWCAP2_AES;
-  }
-  if (has_list_item(&features, "pmull")) {
-    ret |= HWCAP2_PMULL;
-  }
-  if (has_list_item(&features, "sha1")) {
-    ret |= HWCAP2_SHA1;
-  }
-  if (has_list_item(&features, "sha2")) {
-    ret |= HWCAP2_SHA2;
-  }
-  return ret;
-}
-
-/* has_broken_neon returns one if |in| matches a CPU known to have a broken
- * NEON unit. See https://crbug.com/341598. */
-static int has_broken_neon(const STRING_PIECE *cpuinfo) {
-  return cpuinfo_field_equals(cpuinfo, "CPU implementer", "0x51") &&
-         cpuinfo_field_equals(cpuinfo, "CPU architecture", "7") &&
-         cpuinfo_field_equals(cpuinfo, "CPU variant", "0x1") &&
-         cpuinfo_field_equals(cpuinfo, "CPU part", "0x04d") &&
-         cpuinfo_field_equals(cpuinfo, "CPU revision", "0");
-}
-
-extern uint32_t GFp_armcap_P;
-
-static int g_has_broken_neon;
-
-void GFp_cpuid_setup(void) {
-  char *cpuinfo_data;
-  size_t cpuinfo_len;
-  if (!read_file(&cpuinfo_data, &cpuinfo_len, "/proc/cpuinfo")) {
-    return;
-  }
-  STRING_PIECE cpuinfo;
-  cpuinfo.data = cpuinfo_data;
-  cpuinfo.len = cpuinfo_len;
-
-  /* |getauxval| is not available on Android until API level 20. If it is
-   * unavailable, read from /proc/self/auxv as a fallback. This is unreadable
-   * on some versions of Android, so further fall back to /proc/cpuinfo.
-   *
-   * See
-   * https://android.googlesource.com/platform/ndk/+/882ac8f3392858991a0e1af33b4b7387ec856bd2
-   * and b/13679666 (Google-internal) for details. */
-  unsigned long hwcap = 0;
-  if (getauxval != NULL) {
-    hwcap = getauxval(AT_HWCAP);
-  }
-  if (hwcap == 0) {
-    hwcap = getauxval_proc(AT_HWCAP);
-  }
-  if (hwcap == 0) {
-    hwcap = get_hwcap_cpuinfo(&cpuinfo);
-  }
-
-  /* Clear NEON support if known broken. */
-  g_has_broken_neon = has_broken_neon(&cpuinfo);
-  if (g_has_broken_neon) {
-    hwcap &= ~HWCAP_NEON;
-  }
-
-  /* Matching OpenSSL, only report other features if NEON is present. */
-  if (hwcap & HWCAP_NEON) {
-    GFp_armcap_P |= ARMV7_NEON;
-
-    /* Some ARMv8 Android devices don't expose AT_HWCAP2. Fall back to
-     * /proc/cpuinfo. See https://crbug.com/596156. */
-    unsigned long hwcap2 = 0;
-    if (getauxval != NULL) {
-      hwcap2 = getauxval(AT_HWCAP2);
-    }
-    if (hwcap2 == 0) {
-      hwcap2 = get_hwcap2_cpuinfo(&cpuinfo);
-    }
-
-    if (hwcap2 & HWCAP2_AES) {
-      GFp_armcap_P |= ARMV8_AES;
-    }
-    if (hwcap2 & HWCAP2_PMULL) {
-      GFp_armcap_P |= ARMV8_PMULL;
-    }
-    if (hwcap2 & HWCAP2_SHA1) {
-      GFp_armcap_P |= ARMV8_SHA1;
-    }
-    if (hwcap2 & HWCAP2_SHA2) {
-      GFp_armcap_P |= ARMV8_SHA256;
-    }
-  }
-
-  OPENSSL_free(cpuinfo_data);
-}
-
-int GFp_has_broken_NEON(void) { return g_has_broken_neon; }
-
-#endif /* OPENSSL_ARM && !OPENSSL_STATIC_ARMCAP */
+#endif

--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -82,23 +82,24 @@ uint32_t GFp_armcap_P = 0;
 /* These allow tests in other languages to verify that their understanding of
  * the C types matches the C compiler's understanding. */
 
-#define DEFINE_METRICS(ty) \
-  OPENSSL_EXPORT uint16_t GFp_##ty##_align = alignof(ty); \
-  OPENSSL_EXPORT uint16_t GFp_##ty##_size = sizeof(ty);
+#define DEFINE_METRICS(ty, ty_ident) \
+  OPENSSL_EXPORT uint16_t GFp_##ty_ident##_align = alignof(ty); \
+  OPENSSL_EXPORT uint16_t GFp_##ty_ident##_size = sizeof(ty);
 
-DEFINE_METRICS(int8_t)
-DEFINE_METRICS(uint8_t)
+DEFINE_METRICS(int8_t, int8_t)
+DEFINE_METRICS(uint8_t, uint8_t)
 
-DEFINE_METRICS(int16_t)
-DEFINE_METRICS(uint16_t)
+DEFINE_METRICS(int16_t, int16_t)
+DEFINE_METRICS(uint16_t, uint16_t)
 
-DEFINE_METRICS(int32_t)
-DEFINE_METRICS(uint32_t)
+DEFINE_METRICS(int32_t, int32_t)
+DEFINE_METRICS(uint32_t, uint32_t)
 
-DEFINE_METRICS(int64_t)
-DEFINE_METRICS(uint64_t)
+DEFINE_METRICS(int64_t, int64_t)
+DEFINE_METRICS(uint64_t, uint64_t)
 
-DEFINE_METRICS(int)
-DEFINE_METRICS(long)
+DEFINE_METRICS(int, int)
+DEFINE_METRICS(long, long)
+DEFINE_METRICS(unsigned long, unsigned_long)
 
-DEFINE_METRICS(size_t)
+DEFINE_METRICS(size_t, size_t)

--- a/include/openssl/arm_arch.h
+++ b/include/openssl/arm_arch.h
@@ -104,7 +104,7 @@
 #define __ARM_MAX_ARCH__ 8
 #endif
 
-/* Keep in sync with src/cpu_feature/arm_linux/arm_linux.rs */
+/* Keep in sync with src/cpu_feature/arm_linux/arm_linux.rs. */
 
 /* ARMV7_NEON is true when a NEON unit is present in the current CPU. */
 #define ARMV7_NEON (1 << 0)

--- a/include/openssl/arm_arch.h
+++ b/include/openssl/arm_arch.h
@@ -104,6 +104,8 @@
 #define __ARM_MAX_ARCH__ 8
 #endif
 
+/* Keep in sync with src/cpu_feature/arm_linux/arm_linux.rs */
+
 /* ARMV7_NEON is true when a NEON unit is present in the current CPU. */
 #define ARMV7_NEON (1 << 0)
 

--- a/mk/ring.mk
+++ b/mk/ring.mk
@@ -32,6 +32,7 @@ RING_SRCS = $(addprefix $(RING_PREFIX), \
   crypto/bn/random.c \
   crypto/bn/shift.c \
   crypto/cipher/e_aes.c \
+  crypto/cpu-arm-linux.c \
   crypto/crypto.c \
   crypto/curve25519/curve25519.c \
   crypto/ec/ecp_nistz.c \
@@ -89,7 +90,6 @@ RING_x86_64_SRCS = $(addprefix $(RING_PREFIX), \
 
 RING_ARM_SHARED_SRCS = $(addprefix $(RING_PREFIX), \
   crypto/cpu-arm.c \
-  crypto/cpu-arm-linux.c \
   \
   crypto/aes/asm/aesv8-armx.pl \
   crypto/modes/asm/ghashv8-armx.pl \

--- a/src/c.rs
+++ b/src/c.rs
@@ -109,7 +109,7 @@ define_type!(long, i32, test_long_metrics, GFp_long_align, GFp_long_size,
 
 #[cfg(any(target_os = "windows", target_pointer_width = "32"))]
 define_type!(unsigned_long, u32, test_unsigned_long_metrics,
-    GFp_long_align, GFp_unsigned_long_size,
+    GFp_long_align, GFp_long_size,
     "The C `unsigned long` type. Equivalent to `libc::c_ulong`.");
 
 #[cfg(not(any(target_os = "windows", target_pointer_width = "32")))]

--- a/src/c.rs
+++ b/src/c.rs
@@ -41,6 +41,17 @@ macro_rules! define_metrics_tests {
       $expected_align_factor:expr ) =>
     {
         #[cfg(test)]
+        extern {
+            // We can't use `size_t` because we need to test that our
+            // definition of `size_t` is correct using this code! We use `u16`
+            // because even 8-bit and 16-bit microcontrollers have no trouble
+            // with it, and because `u16` is always as smaller or smaller than
+            // `usize`.
+            static $c_align: u16;
+            static $c_size: u16;
+        }
+
+        #[cfg(test)]
         #[test]
         fn $test_c_metrics() {
             use std::mem;
@@ -69,37 +80,6 @@ macro_rules! define_metrics_tests {
     }
 }
 
-#[cfg(test)]
-extern {
-    // We can't use `size_t` because we need to test that our
-    // definition of `size_t` is correct using this code! We use `u16`
-    // because even 8-bit and 16-bit microcontrollers have no trouble
-    // with it, and because `u16` is always as smaller or smaller than
-    // `usize`.
-    static GFp_int_align: u16;
-    static GFp_int_size: u16;
-    static GFp_long_align: u16;
-    static GFp_long_size: u16;
-    static GFp_size_t_align: u16;
-    static GFp_size_t_size: u16;
-    static GFp_int64_t_size: u16;
-    static GFp_int64_t_align: u16;
-    static GFp_uint64_t_size: u16;
-    static GFp_uint64_t_align: u16;
-    static GFp_int32_t_size: u16;
-    static GFp_int32_t_align: u16;
-    static GFp_uint32_t_size: u16;
-    static GFp_uint32_t_align: u16;
-    static GFp_int16_t_size: u16;
-    static GFp_int16_t_align: u16;
-    static GFp_uint16_t_size: u16;
-    static GFp_uint16_t_align: u16;
-    static GFp_int8_t_size: u16;
-    static GFp_int8_t_align: u16;
-    static GFp_uint8_t_size: u16;
-    static GFp_uint8_t_align: u16;
-}
-
 define_type!(int, i32, test_int_metrics, GFp_int_align, GFp_int_size,
              "The C `int` type. Equivalent to `libc::c_int`.");
 
@@ -109,7 +89,7 @@ define_type!(long, i32, test_long_metrics, GFp_long_align, GFp_long_size,
 
 #[cfg(any(target_os = "windows", target_pointer_width = "32"))]
 define_type!(unsigned_long, u32, test_unsigned_long_metrics,
-    GFp_long_align, GFp_long_size,
+    GFp_unsigned_long_align, GFp_unsigned_long_size,
     "The C `unsigned long` type. Equivalent to `libc::c_ulong`.");
 
 #[cfg(not(any(target_os = "windows", target_pointer_width = "32")))]
@@ -118,7 +98,7 @@ define_type!(long, i64, test_long_metrics, GFp_long_align, GFp_long_size,
 
 #[cfg(not(any(target_os = "windows", target_pointer_width = "32")))]
 define_type!(unsigned_long, u64, test_unsigned_long_metrics,
-    GFp_long_align, GFp_long_size,
+    GFp_unsigned_long_align, GFp_unsigned_long_size,
     "The C `unsigned long` type. Equivalent to `libc::c_ulong`.");
 
 define_type!(

--- a/src/c.rs
+++ b/src/c.rs
@@ -41,17 +41,6 @@ macro_rules! define_metrics_tests {
       $expected_align_factor:expr ) =>
     {
         #[cfg(test)]
-        extern {
-            // We can't use `size_t` because we need to test that our
-            // definition of `size_t` is correct using this code! We use `u16`
-            // because even 8-bit and 16-bit microcontrollers have no trouble
-            // with it, and because `u16` is always as smaller or smaller than
-            // `usize`.
-            static $c_align: u16;
-            static $c_size: u16;
-        }
-
-        #[cfg(test)]
         #[test]
         fn $test_c_metrics() {
             use std::mem;
@@ -80,6 +69,37 @@ macro_rules! define_metrics_tests {
     }
 }
 
+#[cfg(test)]
+extern {
+    // We can't use `size_t` because we need to test that our
+    // definition of `size_t` is correct using this code! We use `u16`
+    // because even 8-bit and 16-bit microcontrollers have no trouble
+    // with it, and because `u16` is always as smaller or smaller than
+    // `usize`.
+    static GFp_int_align: u16;
+    static GFp_int_size: u16;
+    static GFp_long_align: u16;
+    static GFp_long_size: u16;
+    static GFp_size_t_align: u16;
+    static GFp_size_t_size: u16;
+    static GFp_int64_t_size: u16;
+    static GFp_int64_t_align: u16;
+    static GFp_uint64_t_size: u16;
+    static GFp_uint64_t_align: u16;
+    static GFp_int32_t_size: u16;
+    static GFp_int32_t_align: u16;
+    static GFp_uint32_t_size: u16;
+    static GFp_uint32_t_align: u16;
+    static GFp_int16_t_size: u16;
+    static GFp_int16_t_align: u16;
+    static GFp_uint16_t_size: u16;
+    static GFp_uint16_t_align: u16;
+    static GFp_int8_t_size: u16;
+    static GFp_int8_t_align: u16;
+    static GFp_uint8_t_size: u16;
+    static GFp_uint8_t_align: u16;
+}
+
 define_type!(int, i32, test_int_metrics, GFp_int_align, GFp_int_size,
              "The C `int` type. Equivalent to `libc::c_int`.");
 
@@ -87,10 +107,19 @@ define_type!(int, i32, test_int_metrics, GFp_int_align, GFp_int_size,
 define_type!(long, i32, test_long_metrics, GFp_long_align, GFp_long_size,
              "The C `long` type. Equivalent to `libc::c_long`.");
 
+#[cfg(any(target_os = "windows", target_pointer_width = "32"))]
+define_type!(unsigned_long, u32, test_unsigned_long_metrics,
+    GFp_long_align, GFp_unsigned_long_size,
+    "The C `unsigned long` type. Equivalent to `libc::c_ulong`.");
+
 #[cfg(not(any(target_os = "windows", target_pointer_width = "32")))]
 define_type!(long, i64, test_long_metrics, GFp_long_align, GFp_long_size,
              "The C `long` type. Equivalent to `libc::c_long`.");
 
+#[cfg(not(any(target_os = "windows", target_pointer_width = "32")))]
+define_type!(unsigned_long, u64, test_unsigned_long_metrics,
+    GFp_long_align, GFp_long_size,
+    "The C `unsigned long` type. Equivalent to `libc::c_ulong`.");
 
 define_type!(
   size_t, usize, test_size_t_metrics, GFp_size_t_align, GFp_size_t_size,

--- a/src/cpu_feature/arm_linux/arm_linux.rs
+++ b/src/cpu_feature/arm_linux/arm_linux.rs
@@ -65,7 +65,7 @@ fn armcap_for_hwcap2(hwcap2: auxv::Type) -> u32 {
     ret
 }
 
-mod auxv;
+pub mod auxv;
 
 #[cfg(test)]
 mod tests {

--- a/src/cpu_feature/arm_linux/arm_linux.rs
+++ b/src/cpu_feature/arm_linux/arm_linux.rs
@@ -1,0 +1,176 @@
+use self::auxv::AuxvUnsignedLong;
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_os="linux"))]
+use self::auxv::NativeGetauxvalProvider;
+use self::auxv::{AT_HWCAP, AT_HWCAP2, GetauxvalProvider};
+
+// Bits exposed in HWCAP and HWCAP2 auxv values
+const ARM_HWCAP2_AES: AuxvUnsignedLong = 1 << 0;
+const ARM_HWCAP2_PMULL: AuxvUnsignedLong = 1 << 1;
+const ARM_HWCAP2_SHA1: AuxvUnsignedLong = 1 << 2;
+const ARM_HWCAP2_SHA2: AuxvUnsignedLong = 1 << 3;
+
+const ARM_HWCAP_NEON: AuxvUnsignedLong = 1 << 12;
+
+// Constants used in GFp_armcap_P
+// from include/openssl/arm_arch.h
+const ARMV7_NEON: u32 = 1 << 0;
+// not a typo; there is no constant for 1 << 1
+const ARMV8_AES: u32 = 1 << 2;
+const ARMV8_SHA1: u32 = 1 << 3;
+const ARMV8_SHA256: u32 = 1 << 4;
+const ARMV8_PMULL: u32 = 1 << 5;
+
+extern "C" {
+    #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
+        target_os="linux"))]
+    #[allow(non_upper_case_globals)]
+    pub static mut GFp_armcap_P: u32;
+}
+
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
+    target_os="linux"))]
+pub fn arm_linux_set_cpu_features() {
+    let getauxval = NativeGetauxvalProvider{};
+
+    unsafe {
+        GFp_armcap_P |= armcap_from_features(getauxval);
+    }
+}
+
+/// returns a u32 with bits set for use in GFp_armcap_P
+fn armcap_from_features<G: GetauxvalProvider> (getauxval_provider: G) -> u32 {
+    let mut hwcap: AuxvUnsignedLong = 0;
+    
+    if let Ok(v) = getauxval_provider.getauxval(AT_HWCAP) {
+        hwcap = v;
+    }
+
+    // Matching OpenSSL, only report other features if NEON is present
+    let mut armcap: u32 = 0;
+    if hwcap & ARM_HWCAP_NEON > 0 {
+        armcap |= ARMV7_NEON;
+
+        let mut hwcap2 = 0;
+        if let Ok(v) = getauxval_provider.getauxval(AT_HWCAP2) {
+            hwcap2 = v;
+        }
+
+        armcap |= armcap_for_hwcap2(hwcap2);
+    }
+
+    return armcap;
+}
+
+fn armcap_for_hwcap2(hwcap2: AuxvUnsignedLong) -> u32 {
+    let mut ret: u32 = 0;
+    if hwcap2 & ARM_HWCAP2_AES > 0 {
+        ret |= ARMV8_AES;
+    }
+    if hwcap2 & ARM_HWCAP2_PMULL > 0 {
+        ret |= ARMV8_PMULL;
+    }
+    if hwcap2 & ARM_HWCAP2_SHA1 > 0 {
+        ret |= ARMV8_SHA1;
+    }
+    if hwcap2 & ARM_HWCAP2_SHA2 > 0 {
+        ret |= ARMV8_SHA256;
+    }
+
+    return ret;
+}
+
+mod auxv;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{armcap_from_features, ARMV7_NEON,
+        ARMV8_AES, ARMV8_PMULL, ARMV8_SHA1, ARMV8_SHA256, ARM_HWCAP2_AES,
+        ARM_HWCAP2_PMULL, ARM_HWCAP2_SHA1, ARM_HWCAP2_SHA2,
+        ARM_HWCAP_NEON};
+    #[cfg(target_os="linux")]
+    use super::auxv::NativeGetauxvalProvider;
+    use super::auxv::{AuxvUnsignedLong, GetauxvalError,
+        GetauxvalProvider, AT_HWCAP, AT_HWCAP2};
+
+    struct StubGetauxvalProvider {
+        auxv: HashMap<AuxvUnsignedLong, AuxvUnsignedLong>
+    }
+
+    impl GetauxvalProvider for StubGetauxvalProvider {
+        fn getauxval(&self, auxv_type: AuxvUnsignedLong)
+                -> Result<AuxvUnsignedLong, GetauxvalError> {
+            self.auxv.get(&auxv_type).map(|v| *v).ok_or(GetauxvalError::NotFound)
+        }
+    }
+
+    #[test]
+    #[cfg(target_os="linux")]
+    fn armcap_from_env_doesnt_crash() {
+        let getauxval = NativeGetauxvalProvider{};
+
+        // can't really say anything useful about its result
+        let _ = armcap_from_features(getauxval);
+    }
+
+    #[test]
+    fn armcap_bits_ok_neon_with_neon_getauxv_yields_neon_armcap() {
+        do_armcap_bits_test(hwcap_neon_getauxv(), ARMV7_NEON);
+    }
+
+    #[test]
+    fn armcap_bits_arm_8_with_neon_only_getauxv_hwcap_and_all_getauxv_hwcap2_yields_all_features_armcap() {
+        let mut auxv = HashMap::new();
+        let _ = auxv.insert(AT_HWCAP, ARM_HWCAP_NEON);
+        let _ = auxv.insert(AT_HWCAP2, ARM_HWCAP2_AES | ARM_HWCAP2_PMULL | ARM_HWCAP2_SHA1 | ARM_HWCAP2_SHA2);
+        let getauxv = StubGetauxvalProvider {
+            auxv: auxv
+        };
+
+        do_armcap_bits_test(getauxv, ARMV7_NEON | ARMV8_AES | ARMV8_SHA1 | ARMV8_SHA256 | ARMV8_PMULL);
+    }
+
+
+    #[test]
+    fn armcap_bits_arm_8_with_neon_only_getauxv_hwcap_and_aes_getauxv_hwcap2_yields_only_neon_aes_armcap() {
+        let mut auxv = HashMap::new();
+        let _ = auxv.insert(AT_HWCAP, ARM_HWCAP_NEON);
+        let _ = auxv.insert(AT_HWCAP2, ARM_HWCAP2_AES);
+        let getauxv = StubGetauxvalProvider {
+            auxv: auxv
+        };
+
+        do_armcap_bits_test(getauxv, ARMV7_NEON | ARMV8_AES);
+    }
+
+    #[test]
+    fn armcap_for_hwcap2_zero_returns_zero() {
+        assert_eq!(0, super::armcap_for_hwcap2(0));
+    }
+
+    #[test]
+    fn armcap_for_hwcap2_all_hwcap2_returns_all_armcap() {
+        assert_eq!(ARMV8_AES | ARMV8_PMULL | ARMV8_SHA1 | ARMV8_SHA256,
+            super::armcap_for_hwcap2(ARM_HWCAP2_AES
+                                        | ARM_HWCAP2_PMULL
+                                        | ARM_HWCAP2_SHA1
+                                        | ARM_HWCAP2_SHA2));
+    }
+
+    fn do_armcap_bits_test(getauxval: StubGetauxvalProvider,
+                           expected_armcap: u32) {
+        assert_eq!(expected_armcap,
+            armcap_from_features::<StubGetauxvalProvider>(getauxval));
+    }
+
+    fn hwcap_neon_getauxv() -> StubGetauxvalProvider {
+        let mut auxv = HashMap::new();
+        let _ = auxv.insert(AT_HWCAP,
+                            ARM_HWCAP_NEON);
+
+        StubGetauxvalProvider {
+            auxv: auxv
+        }
+    }
+}

--- a/src/cpu_feature/arm_linux/arm_linux.rs
+++ b/src/cpu_feature/arm_linux/arm_linux.rs
@@ -22,9 +22,9 @@ const ARM_HWCAP2_SHA2: auxv::Type = 1 << 3;
 const ARM_HWCAP_NEON: auxv::Type = 1 << 12;
 
 // Constants used in GFp_armcap_P
-// Keep in sync with include/openssl/arm_arch.h
+// Keep in sync with include/openssl/arm_arch.h.
 const ARMV7_NEON: u32 = 1 << 0;
-// not a typo; there is no constant for 1 << 1
+// Not a typo; there is no constant for 1 << 1.
 const ARMV8_AES: u32 = 1 << 2;
 const ARMV8_SHA1: u32 = 1 << 3;
 const ARMV8_SHA256: u32 = 1 << 4;
@@ -44,7 +44,7 @@ pub fn armcap_from_features<G: auxv::Provider> (getauxval: G) -> u32 {
         armcap |= armcap_for_hwcap2(hwcap2);
     }
 
-    return armcap;
+    armcap
 }
 
 fn armcap_for_hwcap2(hwcap2: auxv::Type) -> u32 {
@@ -62,7 +62,7 @@ fn armcap_for_hwcap2(hwcap2: auxv::Type) -> u32 {
         ret |= ARMV8_SHA256;
     }
 
-    return ret;
+    ret
 }
 
 mod auxv;
@@ -93,20 +93,22 @@ mod tests {
     }
 
     #[test]
-    fn armcap_bits_arm_8_with_neon_only_getauxv_hwcap_and_all_getauxv_hwcap2_yields_all_features_armcap() {
+    fn armcap_bits_arm_8_with_neon_only_hwcap_all_hwcap2_yields_all_features() {
         let mut auxv = HashMap::new();
         let _ = auxv.insert(auxv::AT_HWCAP, ARM_HWCAP_NEON);
-        let _ = auxv.insert(auxv::AT_HWCAP2, ARM_HWCAP2_AES | ARM_HWCAP2_PMULL | ARM_HWCAP2_SHA1 | ARM_HWCAP2_SHA2);
+        let _ = auxv.insert(auxv::AT_HWCAP2, ARM_HWCAP2_AES | ARM_HWCAP2_PMULL |
+            ARM_HWCAP2_SHA1 | ARM_HWCAP2_SHA2);
         let getauxv = StubGetauxval {
             auxv: auxv
         };
 
-        do_armcap_bits_test(getauxv, ARMV7_NEON | ARMV8_AES | ARMV8_SHA1 | ARMV8_SHA256 | ARMV8_PMULL);
+        do_armcap_bits_test(getauxv, ARMV7_NEON | ARMV8_AES | ARMV8_SHA1 |
+            ARMV8_SHA256 | ARMV8_PMULL);
     }
 
 
     #[test]
-    fn armcap_bits_arm_8_with_neon_only_getauxv_hwcap_and_aes_getauxv_hwcap2_yields_only_neon_aes_armcap() {
+    fn armcap_bits_arm_8_with_neon_only_hwcap_aes_hwcap2_yields_neon_aes() {
         let mut auxv = HashMap::new();
         let _ = auxv.insert(auxv::AT_HWCAP, ARM_HWCAP_NEON);
         let _ = auxv.insert(auxv::AT_HWCAP2, ARM_HWCAP2_AES);
@@ -120,10 +122,8 @@ mod tests {
     #[test]
     fn armcap_for_hwcap2_all_hwcap2_returns_all_armcap() {
         assert_eq!(ARMV8_AES | ARMV8_PMULL | ARMV8_SHA1 | ARMV8_SHA256,
-            super::armcap_for_hwcap2(ARM_HWCAP2_AES
-                                        | ARM_HWCAP2_PMULL
-                                        | ARM_HWCAP2_SHA1
-                                        | ARM_HWCAP2_SHA2));
+            super::armcap_for_hwcap2(ARM_HWCAP2_AES | ARM_HWCAP2_PMULL |
+                ARM_HWCAP2_SHA1 | ARM_HWCAP2_SHA2));
     }
 
     fn do_armcap_bits_test(getauxval: StubGetauxval,

--- a/src/cpu_feature/arm_linux/arm_linux.rs
+++ b/src/cpu_feature/arm_linux/arm_linux.rs
@@ -1,3 +1,18 @@
+// Copyright (c) 2016, Google Inc.
+// Copyright (c) 2016, Marshall Pierce.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
 // See /usr/include/asm/hwcap.h on an ARM installation for the source of these values
 const ARM_HWCAP2_AES: auxv::Type = 1 << 0;
 const ARM_HWCAP2_PMULL: auxv::Type = 1 << 1;

--- a/src/cpu_feature/arm_linux/arm_linux.rs
+++ b/src/cpu_feature/arm_linux/arm_linux.rs
@@ -1,15 +1,10 @@
-use self::auxv::Type;
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_os="linux"))]
-use self::auxv::NativeProvider;
-use self::auxv::{AT_HWCAP, AT_HWCAP2, Provider};
-
 // See /usr/include/asm/hwcap.h on an ARM installation for the source of these values
-const ARM_HWCAP2_AES: Type = 1 << 0;
-const ARM_HWCAP2_PMULL: Type = 1 << 1;
-const ARM_HWCAP2_SHA1: Type = 1 << 2;
-const ARM_HWCAP2_SHA2: Type = 1 << 3;
+const ARM_HWCAP2_AES: auxv::Type = 1 << 0;
+const ARM_HWCAP2_PMULL: auxv::Type = 1 << 1;
+const ARM_HWCAP2_SHA1: auxv::Type = 1 << 2;
+const ARM_HWCAP2_SHA2: auxv::Type = 1 << 3;
 
-const ARM_HWCAP_NEON: Type = 1 << 12;
+const ARM_HWCAP_NEON: auxv::Type = 1 << 12;
 
 // Constants used in GFp_armcap_P
 // Keep in sync with include/openssl/arm_arch.h
@@ -20,33 +15,16 @@ const ARMV8_SHA1: u32 = 1 << 3;
 const ARMV8_SHA256: u32 = 1 << 4;
 const ARMV8_PMULL: u32 = 1 << 5;
 
-extern "C" {
-    #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-        target_os="linux"))]
-    #[allow(non_upper_case_globals)]
-    pub static mut GFp_armcap_P: u32;
-}
-
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-    target_os="linux"))]
-pub fn arm_linux_set_cpu_features() {
-    let getauxval = NativeProvider {};
-
-    unsafe {
-        GFp_armcap_P |= armcap_from_features(getauxval);
-    }
-}
-
 /// returns a u32 with bits set for use in GFp_armcap_P
-fn armcap_from_features<G: Provider> (getauxval: G) -> u32 {
-    let hwcap = getauxval.getauxval(AT_HWCAP).unwrap_or(0);
+pub fn armcap_from_features<G: auxv::Provider> (getauxval: G) -> u32 {
+    let hwcap = getauxval.getauxval(auxv::AT_HWCAP);
     
     // Matching OpenSSL, only report other features if NEON is present.
     let mut armcap: u32 = 0;
     if hwcap & ARM_HWCAP_NEON != 0 {
         armcap |= ARMV7_NEON;
 
-        let hwcap2 = getauxval.getauxval(AT_HWCAP2).unwrap_or(0);
+        let hwcap2 = getauxval.getauxval(auxv::AT_HWCAP2);
 
         armcap |= armcap_for_hwcap2(hwcap2);
     }
@@ -54,7 +32,7 @@ fn armcap_from_features<G: Provider> (getauxval: G) -> u32 {
     return armcap;
 }
 
-fn armcap_for_hwcap2(hwcap2: Type) -> u32 {
+fn armcap_for_hwcap2(hwcap2: auxv::Type) -> u32 {
     let mut ret: u32 = 0;
     if hwcap2 & ARM_HWCAP2_AES != 0 {
         ret |= ARMV8_AES;
@@ -82,17 +60,15 @@ mod tests {
         ARMV8_AES, ARMV8_PMULL, ARMV8_SHA1, ARMV8_SHA256, ARM_HWCAP2_AES,
         ARM_HWCAP2_PMULL, ARM_HWCAP2_SHA1, ARM_HWCAP2_SHA2,
         ARM_HWCAP_NEON};
-    use super::auxv::{Type, GetauxvalError,
-        Provider, AT_HWCAP, AT_HWCAP2};
+    use super::auxv;
 
     struct StubGetauxval {
-        auxv: HashMap<Type, Type>
+        auxv: HashMap<auxv::Type, auxv::Type>
     }
 
-    impl Provider for StubGetauxval {
-        fn getauxval(&self, auxv_type: Type)
-                -> Result<Type, GetauxvalError> {
-            self.auxv.get(&auxv_type).map(|v| *v).ok_or(GetauxvalError::NotFound)
+    impl auxv::Provider for StubGetauxval {
+        fn getauxval(&self, auxv_type: auxv::Type) -> auxv::Type {
+            self.auxv.get(&auxv_type).map(|v| *v).unwrap_or(0)
         }
     }
 
@@ -104,8 +80,8 @@ mod tests {
     #[test]
     fn armcap_bits_arm_8_with_neon_only_getauxv_hwcap_and_all_getauxv_hwcap2_yields_all_features_armcap() {
         let mut auxv = HashMap::new();
-        let _ = auxv.insert(AT_HWCAP, ARM_HWCAP_NEON);
-        let _ = auxv.insert(AT_HWCAP2, ARM_HWCAP2_AES | ARM_HWCAP2_PMULL | ARM_HWCAP2_SHA1 | ARM_HWCAP2_SHA2);
+        let _ = auxv.insert(auxv::AT_HWCAP, ARM_HWCAP_NEON);
+        let _ = auxv.insert(auxv::AT_HWCAP2, ARM_HWCAP2_AES | ARM_HWCAP2_PMULL | ARM_HWCAP2_SHA1 | ARM_HWCAP2_SHA2);
         let getauxv = StubGetauxval {
             auxv: auxv
         };
@@ -117,8 +93,8 @@ mod tests {
     #[test]
     fn armcap_bits_arm_8_with_neon_only_getauxv_hwcap_and_aes_getauxv_hwcap2_yields_only_neon_aes_armcap() {
         let mut auxv = HashMap::new();
-        let _ = auxv.insert(AT_HWCAP, ARM_HWCAP_NEON);
-        let _ = auxv.insert(AT_HWCAP2, ARM_HWCAP2_AES);
+        let _ = auxv.insert(auxv::AT_HWCAP, ARM_HWCAP_NEON);
+        let _ = auxv.insert(auxv::AT_HWCAP2, ARM_HWCAP2_AES);
         let getauxv = StubGetauxval {
             auxv: auxv
         };
@@ -143,7 +119,7 @@ mod tests {
 
     fn hwcap_neon_getauxv() -> StubGetauxval {
         let mut auxv = HashMap::new();
-        let _ = auxv.insert(AT_HWCAP,
+        let _ = auxv.insert(auxv::AT_HWCAP,
                             ARM_HWCAP_NEON);
 
         StubGetauxval {

--- a/src/cpu_feature/arm_linux/auxv.rs
+++ b/src/cpu_feature/arm_linux/auxv.rs
@@ -7,50 +7,28 @@ pub type Type = u64;
 
 extern "C" {
     /// Invoke getauxval(3) if available. If it's not linked, or if invocation
-    /// fails or the type is not found, sets success to false and returns 0.
-    #[cfg(target_os="linux")]
-    pub fn getauxval_wrapper(auxv_type: Type, success: *mut Type) -> i32;
-}
-
-#[derive(Debug, PartialEq)]
-pub enum GetauxvalError {
-    /// getauxval() is not available at runtime
-    #[cfg(target_os="linux")]
-    FunctionNotAvailable,
-    /// getauxval() could not find the requested type
-    NotFound,
-    /// getauxval() encountered a different error
-    #[cfg(target_os="linux")]
-    UnknownError
+    /// fails or the type is not found, returns 0.
+    #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
+        target_os = "linux"))]
+    pub fn getauxval_wrapper(auxv_type: Type) -> Type;
 }
 
 pub trait Provider {
     /// Look up an entry in the auxiliary vector. See getauxval(3) in glibc.
-    /// Unfortunately, prior to glibc 2.19, getauxval() returns 0 without
-    /// setting `errno` if the type is not found, so on such old systems
-    /// this will return `Ok(0)` rather than `Err(GetauxvalError::NotFound)`.
-    fn getauxval(&self, auxv_type: Type) -> Result<Type, GetauxvalError>;
+    /// If the requested type is not found, 0 will be returned.
+    fn getauxval(&self, auxv_type: Type) -> Type;
 }
 
-#[cfg(target_os="linux")]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
+    target_os = "linux"))]
 pub struct NativeProvider {}
 
-#[cfg(target_os="linux")]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
+    target_os = "linux"))]
 impl Provider for NativeProvider {
-    /// Returns Some if the native invocation succeeds and the requested type was
-    /// found, otherwise None.
-    fn getauxval(&self, auxv_type: Type)
-            -> Result<Type, GetauxvalError> {
-
-        let mut result = 0;
+    fn getauxval(&self, auxv_type: Type) -> Type {
         unsafe {
-            return match getauxval_wrapper(auxv_type, &mut result) {
-                1 => Ok(result),
-                0 => Err(GetauxvalError::NotFound),
-                -1 => Err(GetauxvalError::FunctionNotAvailable),
-                -2 => Err(GetauxvalError::UnknownError),
-                x => panic!("getauxval_wrapper returned an unexpected value: {}", x)
-            }
+            return getauxval_wrapper(auxv_type);
         }
     }
 }

--- a/src/cpu_feature/arm_linux/auxv.rs
+++ b/src/cpu_feature/arm_linux/auxv.rs
@@ -1,0 +1,90 @@
+#[cfg(any(all(target_pointer_width = "32", test),
+    all(target_pointer_width = "32", target_os = "linux")))]
+pub type AuxvUnsignedLong = u32;
+#[cfg(any(all(target_pointer_width = "64", test),
+    all(target_pointer_width = "64", target_os = "linux")))]
+pub type AuxvUnsignedLong = u64;
+
+extern "C" {
+    /// Invoke getauxval(3) if available. If it's not linked, or if invocation
+    /// fails or the type is not found, sets success to false and returns 0.
+    #[cfg(target_os="linux")]
+    pub fn getauxval_wrapper(auxv_type: AuxvUnsignedLong,
+                             success: *mut AuxvUnsignedLong) -> i32;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum GetauxvalError {
+    /// getauxval() is not available at runtime
+    #[cfg(target_os="linux")]
+    FunctionNotAvailable,
+    /// getauxval() could not find the requested type
+    NotFound,
+    /// getauxval() encountered a different error
+    #[cfg(target_os="linux")]
+    UnknownError
+}
+
+pub trait GetauxvalProvider {
+    /// Look up an entry in the auxiliary vector. See getauxval(3) in glibc.
+    /// Unfortunately, prior to glibc 2.19, getauxval() returns 0 without
+    /// setting `errno` if the type is not found, so on such old systems
+    /// this will return `Ok(0)` rather than `Err(GetauxvalError::NotFound)`.
+    fn getauxval(&self, auxv_type: AuxvUnsignedLong)
+        -> Result<AuxvUnsignedLong, GetauxvalError>;
+}
+
+#[cfg(target_os="linux")]
+pub struct NativeGetauxvalProvider {}
+
+#[cfg(target_os="linux")]
+impl GetauxvalProvider for NativeGetauxvalProvider {
+    /// Returns Some if the native invocation succeeds and the requested type was
+    /// found, otherwise None.
+    fn getauxval(&self, auxv_type: AuxvUnsignedLong)
+            -> Result<AuxvUnsignedLong, GetauxvalError> {
+
+        let mut result = 0;
+        unsafe {
+            return match getauxval_wrapper(auxv_type, &mut result) {
+                1 => Ok(result),
+                0 => Err(GetauxvalError::NotFound),
+                -1 => Err(GetauxvalError::FunctionNotAvailable),
+                -2 => Err(GetauxvalError::UnknownError),
+                x => panic!("getauxval_wrapper returned an unexpected value: {}", x)
+            }
+        }
+    }
+}
+
+// from [linux]/include/uapi/linux/auxvec.h. First 32 bits of HWCAP
+// even on platforms where unsigned long is 64 bits.
+pub const AT_HWCAP: AuxvUnsignedLong = 16;
+// currently only used by powerpc and arm64 AFAICT
+pub const AT_HWCAP2: AuxvUnsignedLong = 26;
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os="linux")]
+    use super::{AT_HWCAP, GetauxvalError, GetauxvalProvider,
+        NativeGetauxvalProvider};
+
+    #[test]
+    #[cfg(target_os="linux")]
+    fn test_getauxv_hwcap_linux_finds_hwcap() {
+        let native_getauxval = NativeGetauxvalProvider{};
+        let result = native_getauxval.getauxval(AT_HWCAP);
+        // there should be SOMETHING in the value
+        assert!(result.unwrap() > 0);
+    }
+
+    #[test]
+    #[cfg(target_os="linux")]
+    fn test_getauxv_hwcap_linux_doesnt_find_bogus_type() {
+        let native_getauxval = NativeGetauxvalProvider{};
+
+        // AT_NULL aka 0 is effectively the EOF for auxv, so it's never a valid type
+        assert_eq!(GetauxvalError::NotFound, native_getauxval.getauxval(0).unwrap_err());
+    }
+
+}

--- a/src/cpu_feature/arm_linux/auxv.rs
+++ b/src/cpu_feature/arm_linux/auxv.rs
@@ -7,7 +7,7 @@ extern "C" {
     /// Invoke getauxval(3) if available. If it's not linked, or if invocation
     /// fails or the type is not found, returns 0.
     #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-        target_os = "linux"))]
+        any(target_os = "linux", target_os = "android")))]
     pub fn getauxval_wrapper(auxv_type: Type) -> Value;
 }
 
@@ -18,11 +18,11 @@ pub trait Provider {
 }
 
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-    target_os = "linux"))]
+    any(target_os = "linux", target_os = "android")))]
 pub struct NativeProvider;
 
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-    target_os = "linux"))]
+    any(target_os = "linux", target_os = "android")))]
 impl Provider for NativeProvider {
     fn getauxval(&self, auxv_type: Type) -> Value {
         unsafe { getauxval_wrapper(auxv_type) }

--- a/src/cpu_feature/arm_linux/auxv.rs
+++ b/src/cpu_feature/arm_linux/auxv.rs
@@ -1,16 +1,15 @@
 #[cfg(any(all(target_pointer_width = "32", test),
     all(target_pointer_width = "32", target_os = "linux")))]
-pub type AuxvUnsignedLong = u32;
+pub type Type = u32;
 #[cfg(any(all(target_pointer_width = "64", test),
     all(target_pointer_width = "64", target_os = "linux")))]
-pub type AuxvUnsignedLong = u64;
+pub type Type = u64;
 
 extern "C" {
     /// Invoke getauxval(3) if available. If it's not linked, or if invocation
     /// fails or the type is not found, sets success to false and returns 0.
     #[cfg(target_os="linux")]
-    pub fn getauxval_wrapper(auxv_type: AuxvUnsignedLong,
-                             success: *mut AuxvUnsignedLong) -> i32;
+    pub fn getauxval_wrapper(auxv_type: Type, success: *mut Type) -> i32;
 }
 
 #[derive(Debug, PartialEq)]
@@ -25,24 +24,23 @@ pub enum GetauxvalError {
     UnknownError
 }
 
-pub trait GetauxvalProvider {
+pub trait Provider {
     /// Look up an entry in the auxiliary vector. See getauxval(3) in glibc.
     /// Unfortunately, prior to glibc 2.19, getauxval() returns 0 without
     /// setting `errno` if the type is not found, so on such old systems
     /// this will return `Ok(0)` rather than `Err(GetauxvalError::NotFound)`.
-    fn getauxval(&self, auxv_type: AuxvUnsignedLong)
-        -> Result<AuxvUnsignedLong, GetauxvalError>;
+    fn getauxval(&self, auxv_type: Type) -> Result<Type, GetauxvalError>;
 }
 
 #[cfg(target_os="linux")]
-pub struct NativeGetauxvalProvider {}
+pub struct NativeProvider {}
 
 #[cfg(target_os="linux")]
-impl GetauxvalProvider for NativeGetauxvalProvider {
+impl Provider for NativeProvider {
     /// Returns Some if the native invocation succeeds and the requested type was
     /// found, otherwise None.
-    fn getauxval(&self, auxv_type: AuxvUnsignedLong)
-            -> Result<AuxvUnsignedLong, GetauxvalError> {
+    fn getauxval(&self, auxv_type: Type)
+            -> Result<Type, GetauxvalError> {
 
         let mut result = 0;
         unsafe {
@@ -59,32 +57,6 @@ impl GetauxvalProvider for NativeGetauxvalProvider {
 
 // from [linux]/include/uapi/linux/auxvec.h. First 32 bits of HWCAP
 // even on platforms where unsigned long is 64 bits.
-pub const AT_HWCAP: AuxvUnsignedLong = 16;
+pub const AT_HWCAP: Type = 16;
 // currently only used by powerpc and arm64 AFAICT
-pub const AT_HWCAP2: AuxvUnsignedLong = 26;
-
-#[cfg(test)]
-mod tests {
-    #[cfg(target_os="linux")]
-    use super::{AT_HWCAP, GetauxvalError, GetauxvalProvider,
-        NativeGetauxvalProvider};
-
-    #[test]
-    #[cfg(target_os="linux")]
-    fn test_getauxv_hwcap_linux_finds_hwcap() {
-        let native_getauxval = NativeGetauxvalProvider{};
-        let result = native_getauxval.getauxval(AT_HWCAP);
-        // there should be SOMETHING in the value
-        assert!(result.unwrap() > 0);
-    }
-
-    #[test]
-    #[cfg(target_os="linux")]
-    fn test_getauxv_hwcap_linux_doesnt_find_bogus_type() {
-        let native_getauxval = NativeGetauxvalProvider{};
-
-        // AT_NULL aka 0 is effectively the EOF for auxv, so it's never a valid type
-        assert_eq!(GetauxvalError::NotFound, native_getauxval.getauxval(0).unwrap_err());
-    }
-
-}
+pub const AT_HWCAP2: Type = 26;

--- a/src/cpu_feature/cpu_feature.rs
+++ b/src/cpu_feature/cpu_feature.rs
@@ -1,3 +1,4 @@
-#[cfg(any(test, all(any(target_arch = "arm", target_arch = "aarch64"), target_os="linux")))]
+#[cfg(any(test, all(any(target_arch = "arm", target_arch = "aarch64"),
+    any(target_os="linux", target_os="android"))))]
 #[path = "arm_linux/arm_linux.rs"]
 pub mod arm_linux;

--- a/src/cpu_feature/cpu_feature.rs
+++ b/src/cpu_feature/cpu_feature.rs
@@ -1,3 +1,3 @@
 #[cfg(any(test, all(any(target_arch = "arm", target_arch = "aarch64"), target_os="linux")))]
 #[path = "arm_linux/arm_linux.rs"]
-mod arm_linux;
+pub mod arm_linux;

--- a/src/cpu_feature/cpu_feature.rs
+++ b/src/cpu_feature/cpu_feature.rs
@@ -1,0 +1,3 @@
+#[cfg(any(test, all(any(target_arch = "arm", target_arch = "aarch64"), target_os="linux")))]
+#[path = "arm_linux/arm_linux.rs"]
+mod arm_linux;

--- a/src/init.rs
+++ b/src/init.rs
@@ -32,7 +32,7 @@ pub fn init_once() {
 // On ARM Linux, use pure Rust.
 
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-    target_os = "linux"))]
+    any(target_os = "linux", target_os = "android")))]
 fn set_cpu_features() {
     unsafe {
         GFp_armcap_P |= arm_linux::armcap_from_features(auxv::NativeProvider);
@@ -41,7 +41,7 @@ fn set_cpu_features() {
 
 extern {
     #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-        target_os="linux"))]
+        any(target_os = "linux", target_os = "android")))]
     #[allow(non_upper_case_globals)]
     pub static mut GFp_armcap_P: u32;
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -13,10 +13,10 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-    target_os = "linux"))]
+    any(target_os = "linux", target_os = "android")))]
 use cpu_feature::arm_linux::auxv;
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
-    target_os = "linux"))]
+    any(target_os = "linux", target_os = "android")))]
 use cpu_feature::arm_linux;
 
 #[inline(always)]

--- a/src/init.rs
+++ b/src/init.rs
@@ -15,6 +15,9 @@
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
     target_os = "linux"))]
 use cpu_feature::arm_linux::auxv;
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
+    target_os = "linux"))]
+use cpu_feature::arm_linux;
 
 #[inline(always)]
 pub fn init_once() {
@@ -34,7 +37,7 @@ fn set_cpu_features() {
     let getauxval = auxv::NativeProvider {};
 
     unsafe {
-        GFp_armcap_P |= armcap_from_features(getauxval);
+        GFp_armcap_P |= arm_linux::armcap_from_features(getauxval);
     }
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -49,13 +49,15 @@ extern {
 // On other platforms (excluding iOS aarch64), use C feature detection.
 
 #[cfg(all(not(all(target_arch = "aarch64", target_os = "ios")),
-    not(all(any(target_arch = "arm", target_arch = "aarch64"), target_os = "linux"))))]
+    not(all(any(target_arch = "arm", target_arch = "aarch64"),
+        any(target_os = "linux", target_os = "android")))))]
 extern {
     fn GFp_cpuid_setup();
 }
 
 #[cfg(all(not(all(target_arch = "aarch64", target_os = "ios")),
-    not(all(any(target_arch = "arm", target_arch = "aarch64"), target_os = "linux"))))]
+    not(all(any(target_arch = "arm", target_arch = "aarch64"),
+        any(target_os = "linux", target_os = "android")))))]
 fn set_cpu_features() {
     unsafe { GFp_cpuid_setup() }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -12,6 +12,10 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
+    target_os = "linux"))]
+use cpu_feature::arm_linux::auxv;
+
 #[inline(always)]
 pub fn init_once() {
     #[cfg(not(all(target_arch = "aarch64", target_os = "ios")))]
@@ -27,7 +31,18 @@ pub fn init_once() {
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
     target_os = "linux"))]
 fn set_cpu_features() {
-    cpu_feature::arm_linux::arm_linux_set_cpu_features();
+    let getauxval = auxv::NativeProvider {};
+
+    unsafe {
+        GFp_armcap_P |= armcap_from_features(getauxval);
+    }
+}
+
+extern "C" {
+    #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
+        target_os="linux"))]
+    #[allow(non_upper_case_globals)]
+    pub static mut GFp_armcap_P: u32;
 }
 
 // On other platforms (excluding iOS aarch64), use C feature detection

--- a/src/init.rs
+++ b/src/init.rs
@@ -29,26 +29,24 @@ pub fn init_once() {
     }
 }
 
-// On arm linux, use pure rust
+// On ARM Linux, use pure Rust.
 
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
     target_os = "linux"))]
 fn set_cpu_features() {
-    let getauxval = auxv::NativeProvider {};
-
     unsafe {
-        GFp_armcap_P |= arm_linux::armcap_from_features(getauxval);
+        GFp_armcap_P |= arm_linux::armcap_from_features(auxv::NativeProvider);
     }
 }
 
-extern "C" {
+extern {
     #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"),
         target_os="linux"))]
     #[allow(non_upper_case_globals)]
     pub static mut GFp_armcap_P: u32;
 }
 
-// On other platforms (excluding iOS aarch64), use C feature detection
+// On other platforms (excluding iOS aarch64), use C feature detection.
 
 #[cfg(all(not(all(target_arch = "aarch64", target_os = "ios")),
     not(all(any(target_arch = "arm", target_arch = "aarch64"), target_os = "linux"))))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,9 @@ pub mod signature;
 #[cfg(any(feature = "use_heap", test))]
 pub mod test;
 
+#[path = "cpu_feature/cpu_feature.rs"]
+mod cpu_feature;
+
 mod private {
     /// Traits that are designed to only be implemented internally in *ring*.
     //


### PR DESCRIPTION
This is 1 and 2 of your suggested PR disassembly in #392. I elected to do them together because otherwise this would have failed to build on arm because there wouldn't be a replacement for `GFp_cpuid_setup`.