### PR TITLE
Use `#[repr(c)]` for `BIGNUM` & `BN_MONT_CTX` and allocate them in Rust by value.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,7 @@ include = [
     "crypto/test/bn_test_convert.c",
     "crypto/test/bn_test_lib.c",
     "crypto/test/bn_test_lib.h",
+    "crypto/test/bn_test_new.c",
     "crypto/test/bn_test_util.h",
     "crypto/test/file_test.cc",
     "crypto/test/file_test.h",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,7 @@ include = [
 name = "ring"
 
 [dependencies]
+libc = "0.2.20"
 untrusted = "0.3.2"
 
 [target.'cfg(any(target_os = "redox", unix))'.dependencies]

--- a/crypto/bn/bn.c
+++ b/crypto/bn/bn.c
@@ -70,20 +70,6 @@
 uint64_t GFp_BN_get_positive_u64(const BIGNUM *bn);
 
 
-BIGNUM *GFp_BN_new(void) {
-  BIGNUM *bn = OPENSSL_malloc(sizeof(BIGNUM));
-
-  if (bn == NULL) {
-    OPENSSL_PUT_ERROR(BN, ERR_R_MALLOC_FAILURE);
-    return NULL;
-  }
-
-  memset(bn, 0, sizeof(BIGNUM));
-  bn->flags = BN_FLG_MALLOCED;
-
-  return bn;
-}
-
 void GFp_BN_init(BIGNUM *bn) {
   memset(bn, 0, sizeof(BIGNUM));
 }

--- a/crypto/bn/bn.c
+++ b/crypto/bn/bn.c
@@ -75,6 +75,9 @@ void GFp_BN_init(BIGNUM *bn) {
 }
 
 void GFp_BN_free(BIGNUM *bn) {
+  /* Keep this in sync with the |Drop| impl for |BIGNUM| in
+   * |ring::rsa::bigint|. */
+
   if (bn == NULL) {
     return;
   }

--- a/crypto/bn/convert.c
+++ b/crypto/bn/convert.c
@@ -62,32 +62,22 @@
 #include "internal.h"
 
 
-BIGNUM *GFp_BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
+int GFp_BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
+  assert(ret != NULL); /* Stronger requirement than BoringSSL. */
+
   size_t num_words;
   unsigned m;
   BN_ULONG word = 0;
-  BIGNUM *bn = NULL;
-
-  if (ret == NULL) {
-    ret = bn = GFp_BN_new();
-  }
-
-  if (ret == NULL) {
-    return NULL;
-  }
 
   if (len == 0) {
     ret->top = 0;
-    return ret;
+    return 1;
   }
 
   num_words = ((len - 1) / BN_BYTES) + 1;
   m = (len - 1) % BN_BYTES;
   if (GFp_bn_wexpand(ret, num_words) == NULL) {
-    if (bn) {
-      GFp_BN_free(bn);
-    }
-    return NULL;
+    return 0;
   }
 
   /* |GFp_bn_wexpand| must check bounds on |num_words| to write it into
@@ -108,7 +98,7 @@ BIGNUM *GFp_BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
   /* need to call this due to clear byte at top if avoiding having the top bit
    * set (-ve number) */
   GFp_bn_correct_top(ret);
-  return ret;
+  return 1;
 }
 
 /* constant_time_select_ulong returns |x| if |v| is 1 and |y| if |v| is 0. Its

--- a/crypto/bn/montgomery.c
+++ b/crypto/bn/montgomery.c
@@ -119,10 +119,6 @@
 #include "../internal.h"
 
 
-/* Avoid -Wmissing-prototypes warnings. */
-const BIGNUM *GFp_BN_MONT_CTX_get0_n(const BN_MONT_CTX *mont);
-
-
 OPENSSL_COMPILE_ASSERT(BN_MONT_CTX_N0_LIMBS == 1 || BN_MONT_CTX_N0_LIMBS == 2,
                        BN_MONT_CTX_N0_LIMBS_VALUE_INVALID);
 OPENSSL_COMPILE_ASSERT(sizeof(BN_ULONG) * BN_MONT_CTX_N0_LIMBS ==
@@ -177,10 +173,6 @@ int GFp_BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod) {
   }
 
   return 1;
-}
-
-const BIGNUM *GFp_BN_MONT_CTX_get0_n(const BN_MONT_CTX *mont) {
-  return &mont->N;
 }
 
 int GFp_BN_to_mont(BIGNUM *ret, const BIGNUM *a, const BN_MONT_CTX *mont) {

--- a/crypto/bn/montgomery.c
+++ b/crypto/bn/montgomery.c
@@ -123,30 +123,6 @@
 const BIGNUM *GFp_BN_MONT_CTX_get0_n(const BN_MONT_CTX *mont);
 
 
-BN_MONT_CTX *GFp_BN_MONT_CTX_new(void) {
-  BN_MONT_CTX *ret = OPENSSL_malloc(sizeof(BN_MONT_CTX));
-
-  if (ret == NULL) {
-    return NULL;
-  }
-
-  memset(ret, 0, sizeof(BN_MONT_CTX));
-  GFp_BN_init(&ret->RR);
-  GFp_BN_init(&ret->N);
-
-  return ret;
-}
-
-void GFp_BN_MONT_CTX_free(BN_MONT_CTX *mont) {
-  if (mont == NULL) {
-    return;
-  }
-
-  GFp_BN_free(&mont->RR);
-  GFp_BN_free(&mont->N);
-  OPENSSL_free(mont);
-}
-
 OPENSSL_COMPILE_ASSERT(BN_MONT_CTX_N0_LIMBS == 1 || BN_MONT_CTX_N0_LIMBS == 2,
                        BN_MONT_CTX_N0_LIMBS_VALUE_INVALID);
 OPENSSL_COMPILE_ASSERT(sizeof(BN_ULONG) * BN_MONT_CTX_N0_LIMBS ==

--- a/crypto/libring-test.Windows.vcxproj
+++ b/crypto/libring-test.Windows.vcxproj
@@ -24,6 +24,7 @@
 
     <ClCompile Include="test/bn_test_convert.c" />
     <ClCompile Include="test/bn_test_lib.c" />
+    <ClCompile Include="test/bn_test_new.c" />
     <ClCompile Include="test/file_test.cc" />
   </ItemGroup>
   <ItemGroup>

--- a/crypto/test/bn_test_lib.c
+++ b/crypto/test/bn_test_lib.c
@@ -55,7 +55,7 @@
  * [including the GNU Public Licence.]
  */
 /* ====================================================================
- * Copyright (c) 1998-2001 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1998-2006 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -157,4 +157,28 @@ int GFp_BN_rand(BIGNUM *rnd, int bits, RAND *rng) {
 err:
   OPENSSL_free(buf);
   return (ret);
+}
+
+BN_MONT_CTX *GFp_BN_MONT_CTX_new(void) {
+  BN_MONT_CTX *ret = OPENSSL_malloc(sizeof(BN_MONT_CTX));
+
+  if (ret == NULL) {
+    return NULL;
+  }
+
+  memset(ret, 0, sizeof(BN_MONT_CTX));
+  GFp_BN_init(&ret->RR);
+  GFp_BN_init(&ret->N);
+
+  return ret;
+}
+
+void GFp_BN_MONT_CTX_free(BN_MONT_CTX *mont) {
+  if (mont == NULL) {
+    return;
+  }
+
+  GFp_BN_free(&mont->RR);
+  GFp_BN_free(&mont->N);
+  OPENSSL_free(mont);
 }

--- a/crypto/test/bn_test_lib.h
+++ b/crypto/test/bn_test_lib.h
@@ -136,6 +136,9 @@ extern "C" {
 
 /* Basic functions. */
 
+/* GFp_BN_new creates a new, allocated BIGNUM and initialises it. */
+BIGNUM *GFp_BN_new(void);
+
 void GFp_BN_set_negative(BIGNUM *bn, int sign);
 
 /* Conversion functions. */

--- a/crypto/test/bn_test_new.c
+++ b/crypto/test/bn_test_new.c
@@ -1,0 +1,78 @@
+/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+ * All rights reserved.
+ *
+ * This package is an SSL implementation written
+ * by Eric Young (eay@cryptsoft.com).
+ * The implementation was written so as to conform with Netscapes SSL.
+ *
+ * This library is free for commercial and non-commercial use as long as
+ * the following conditions are aheared to.  The following conditions
+ * apply to all code found in this distribution, be it the RC4, RSA,
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ * included with this distribution is covered by the same copyright terms
+ * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+ *
+ * Copyright remains Eric Young's, and as such any Copyright notices in
+ * the code are not to be removed.
+ * If this package is used in a product, Eric Young should be given attribution
+ * as the author of the parts of the library used.
+ * This can be in the form of a textual message at program startup or
+ * in documentation (online or textual) provided with the package.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *    "This product includes cryptographic software written by
+ *     Eric Young (eay@cryptsoft.com)"
+ *    The word 'cryptographic' can be left out if the rouines from the library
+ *    being used are not cryptographic related :-).
+ * 4. If you include any Windows specific code (or a derivative thereof) from
+ *    the apps directory (application code) you must include an acknowledgement:
+ *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * The licence and distribution terms for any publically available version or
+ * derivative of this code cannot be changed.  i.e. this code cannot simply be
+ * copied and put under another distribution licence
+ * [including the GNU Public Licence.] */
+
+#include <openssl/bn.h>
+
+#include <string.h>
+
+#include <openssl/err.h>
+#include <openssl/mem.h>
+
+#include "../test/bn_test_lib.h"
+
+BIGNUM *GFp_BN_new(void) {
+  BIGNUM *bn = OPENSSL_malloc(sizeof(BIGNUM));
+
+  if (bn == NULL) {
+    OPENSSL_PUT_ERROR(BN, ERR_R_MALLOC_FAILURE);
+    return NULL;
+  }
+
+  memset(bn, 0, sizeof(BIGNUM));
+  bn->flags = BN_FLG_MALLOCED;
+
+  return bn;
+}

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -211,11 +211,8 @@ OPENSSL_EXPORT void GFp_BN_set_flags(BIGNUM *bn, int flags);
 /* Conversion functions. */
 
 /* GFp_BN_bin2bn sets |*ret| to the value of |len| bytes from |in|, interpreted
- * as a big-endian number, and returns |ret|. If |ret| is NULL then a fresh
- * |BIGNUM| is allocated and returned. It returns NULL on allocation
- * failure. */
-OPENSSL_EXPORT BIGNUM *GFp_BN_bin2bn(const uint8_t *in, size_t len,
-                                     BIGNUM *ret);
+ * as a big-endian number. It returns one on success and zero otherwise. */
+OPENSSL_EXPORT int GFp_BN_bin2bn(const uint8_t *in, size_t len, BIGNUM *ret);
 
 /* GFp_BN_bn2bin_padded serialises the absolute value of |in| to |out| as a
  * big-endian integer. The integer is padded with leading zeros up to size

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -162,9 +162,6 @@ extern "C" {
 
 /* Allocation and freeing. */
 
-/* GFp_BN_new creates a new, allocated BIGNUM and initialises it. */
-OPENSSL_EXPORT BIGNUM *GFp_BN_new(void);
-
 /* GFp_BN_init initialises a stack allocated |BIGNUM|. */
 OPENSSL_EXPORT void GFp_BN_init(BIGNUM *bn);
 

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -450,6 +450,7 @@ OPENSSL_EXPORT int GFp_BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a,
 
 /* Private functions */
 
+/* Keep in sync with `BIGNUM` in `ring::rsa::bigint`. */
 struct bignum_st {
   BN_ULONG *d; /* Pointer to an array of 'BN_BITS2' bit chunks in little-endian
                   order. */
@@ -459,6 +460,7 @@ struct bignum_st {
   int flags; /* bitmask of BN_FLG_* values */
 };
 
+/* Keep in sync with `BN_MONT_CTX` in `ring::rsa::bigint` */
 struct bn_mont_ctx_st {
   BIGNUM RR; /* used to convert to montgomery form */
   BIGNUM N;  /* The modulus */

--- a/mk/ring.mk
+++ b/mk/ring.mk
@@ -127,6 +127,7 @@ RING_TEST_SRCS = $(addprefix $(RING_PREFIX), \
   crypto/constant_time_test.c \
   crypto/test/bn_test_convert.c \
   crypto/test/bn_test_lib.c \
+  crypto/test/bn_test_new.c \
   crypto/test/file_test.cc \
   $(NULL))
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,8 @@
 #![cfg_attr(feature = "internal_benches", allow(unstable_features))]
 #![cfg_attr(feature = "internal_benches", feature(test))]
 
+extern crate libc;
+
 #[cfg(feature = "internal_benches")]
 extern crate test as bench;
 

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -581,10 +581,33 @@ impl Nonnegative {
     }
 }
 
-#[allow(non_camel_case_types)]
-pub enum BN_MONT_CTX {}
+// These types are defined in their own submodule so that their private
+// components are not accessible.
 
-pub enum BIGNUM {}
+#[allow(non_snake_case)]
+mod repr_c {
+    use {c, limb};
+
+    /* Keep in sync with `bignum_st` in openss/bn.h. */
+    #[repr(C)]
+    pub struct BIGNUM {
+        d: *mut limb::Limb,
+        top: c::int,
+        dmax: c::int,
+        neg: c::int,
+        flags: c::int,
+    }
+
+    /* Keep in sync with `bn_mont_ctx_st` in openss/bn.h. */
+    #[repr(C)]
+    pub struct BN_MONT_CTX {
+        RR: BIGNUM,
+        N: BIGNUM,
+        n0: [limb::Limb; 2],
+    }
+}
+
+pub use self::repr_c::{BIGNUM, BN_MONT_CTX};
 
 extern {
     fn GFp_BN_new() -> *mut BIGNUM;

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -61,9 +61,7 @@ impl<M> AsRef<BN_MONT_CTX> for Modulus<M> {
 }
 
 impl<M> AsRef<BIGNUM> for Modulus<M> {
-    fn as_ref<'a>(&'a self) -> &'a BIGNUM {
-        unsafe { GFp_BN_MONT_CTX_get0_n(self.as_ref()) }
-    }
+    fn as_ref<'a>(&'a self) -> &'a BIGNUM { self.ctx.n() }
 }
 
 impl AsRef<BIGNUM> for OddPositive {
@@ -627,6 +625,8 @@ mod repr_c {
                 n0: [0, 0],
             }
         }
+
+        pub fn n(&self) -> &BIGNUM { &self.N }
     }
 }
 
@@ -669,7 +669,6 @@ extern {
     fn GFp_BN_copy(a: &mut BIGNUM, b: &BIGNUM) -> c::int;
 
     fn GFp_BN_MONT_CTX_set(ctx: &mut BN_MONT_CTX, modulus: &BIGNUM) -> c::int;
-    fn GFp_BN_MONT_CTX_get0_n<'a>(ctx: &'a BN_MONT_CTX) -> &'a BIGNUM;
 }
 
 #[allow(improper_ctypes)]

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -110,14 +110,11 @@ impl Positive {
         if input.is_empty() {
             return Err(error::Unspecified);
         }
-        let value = unsafe {
+        let mut r = try!(Nonnegative::zero());
+        try!(bssl::map_result(unsafe {
             GFp_BN_bin2bn(input.as_slice_less_safe().as_ptr(), input.len(),
-                          core::ptr::null_mut())
-        };
-        if value.is_null() {
-            return Err(error::Unspecified);
-        }
-        let r = Nonnegative(value);
+                          r.as_mut_ref())
+        }));
         if r.is_zero() {
             return Err(error::Unspecified);
         }
@@ -611,8 +608,8 @@ pub use self::repr_c::{BIGNUM, BN_MONT_CTX};
 
 extern {
     fn GFp_BN_new() -> *mut BIGNUM;
-    fn GFp_BN_bin2bn(in_: *const u8, len: c::size_t, ret: *mut BIGNUM)
-                     -> *mut BIGNUM;
+    fn GFp_BN_bin2bn(in_: *const u8, len: c::size_t, ret: &mut BIGNUM)
+                     -> c::int;
     fn GFp_BN_bn2bin_padded(out_: *mut u8, len: c::size_t, in_: &BIGNUM)
                             -> c::int;
     fn GFp_BN_ucmp(a: &BIGNUM, b: &BIGNUM) -> c::int;


### PR DESCRIPTION
This is part of the fix for #416.