### PR TITLE
Improve the usability of `ring::aead`.

### DIFF
--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -35,8 +35,7 @@ use {constant_time, error, init, poly1305, polyfill};
 pub use self::chacha20_poly1305::CHACHA20_POLY1305;
 pub use self::aes_gcm::{AES_128_GCM, AES_256_GCM};
 
-/// A key for authenticating and decrypting (&ldquo;opening&rdquo;)
-/// AEAD-protected data.
+/// A key for authenticating and decrypting (“opening”) AEAD-protected data.
 ///
 /// C analog: `EVP_AEAD_CTX` with direction `evp_aead_open`
 ///
@@ -76,7 +75,7 @@ impl OpeningKey {
     pub fn algorithm(&self) -> &'static Algorithm { self.key.algorithm() }
 }
 
-/// Authenticates and decrypts (&ldquo;opens&rdquo;) data in place.
+/// Authenticates and decrypts (“opens”) data in place. When
 ///
 /// The input is `in_out[in_prefix_len..]`; i.e. the input is the part of
 /// `in_out` after the prefix. When `open_in_place` returns `Ok(out_len)`, the
@@ -121,7 +120,7 @@ pub fn open_in_place(key: &OpeningKey, nonce: &[u8], in_prefix_len: usize,
     Ok(ciphertext_len) // `ciphertext_len` is also the plaintext length.
 }
 
-/// A key for encrypting and signing (&ldquo;sealing&rdquo;) data.
+/// A key for encrypting and signing (“sealing”) data.
 ///
 /// C analog: `EVP_AEAD_CTX` with direction `evp_aead_seal`.
 ///
@@ -157,7 +156,7 @@ impl SealingKey {
     pub fn algorithm(&self) -> &'static Algorithm { self.key.algorithm() }
 }
 
-/// Encrypts and signs (&ldquo;seals&rdquo;) data in place.
+/// Encrypts and signs (“seals”) data in place.
 ///
 /// `nonce` must be unique for every use of the key to seal data.
 ///

--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -192,7 +192,7 @@ impl SealingKey {
 ///
 /// The input is `in_out[..(in_out.len() - out_suffix_capacity)]`; i.e. the
 /// input is the part of `in_out` that precedes the suffix. When
-/// `seal_in_place` returns `Ok(out_len)`, the encrypted and signed output is
+/// `seal_in_place()` returns `Ok(out_len)`, the encrypted and signed output is
 /// `in_out[..out_len]`; i.e.  the output has been written over input and at
 /// least part of the data reserved for the suffix. (The input/output buffer
 /// is expressed this way because Rust's type system does not allow us to have

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -47,8 +47,8 @@ fn aes_gcm_init(ctx_buf: &mut [u8], key: &[u8])
 }
 
 fn aes_gcm_seal(ctx: &[u64; aead::KEY_CTX_BUF_ELEMS],
-                nonce: &[u8; aead::NONCE_LEN], in_out: &mut [u8],
-                tag: &mut [u8; aead::TAG_LEN], ad: &[u8])
+                nonce: &[u8; aead::NONCE_LEN], ad: &[u8], in_out: &mut [u8],
+                tag: &mut [u8; aead::TAG_LEN])
                 -> Result<(), error::Unspecified> {
     let ctx = polyfill::slice::u64_as_u8(ctx);
     bssl::map_result(unsafe {
@@ -58,9 +58,9 @@ fn aes_gcm_seal(ctx: &[u64; aead::KEY_CTX_BUF_ELEMS],
 }
 
 fn aes_gcm_open(ctx: &[u64; aead::KEY_CTX_BUF_ELEMS],
-                nonce: &[u8; aead::NONCE_LEN], in_out: &mut [u8],
-                in_prefix_len: usize, tag_out: &mut [u8; aead::TAG_LEN],
-                ad: &[u8]) -> Result<(), error::Unspecified> {
+                nonce: &[u8; aead::NONCE_LEN], ad: &[u8], in_prefix_len: usize,
+                in_out: &mut [u8], tag_out: &mut [u8; aead::TAG_LEN])
+                -> Result<(), error::Unspecified> {
     let ctx = polyfill::slice::u64_as_u8(ctx);
     bssl::map_result(unsafe {
         GFp_aes_gcm_open(ctx.as_ptr(), in_out.as_mut_ptr(),

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -34,8 +34,8 @@ pub fn chacha20_poly1305_init(ctx_buf: &mut [u8], key: &[u8])
 }
 
 fn chacha20_poly1305_seal(ctx: &[u64; aead::KEY_CTX_BUF_ELEMS],
-                          nonce: &[u8; aead::NONCE_LEN], in_out: &mut [u8],
-                          tag_out: &mut [u8; aead::TAG_LEN], ad: &[u8])
+                          nonce: &[u8; aead::NONCE_LEN], ad: &[u8],
+                          in_out: &mut [u8], tag_out: &mut [u8; aead::TAG_LEN])
                           -> Result<(), error::Unspecified> {
     let chacha20_key = try!(ctx_as_key(ctx));
     let mut counter = chacha::make_counter(nonce, 1);
@@ -46,9 +46,9 @@ fn chacha20_poly1305_seal(ctx: &[u64; aead::KEY_CTX_BUF_ELEMS],
 }
 
 fn chacha20_poly1305_open(ctx: &[u64; aead::KEY_CTX_BUF_ELEMS],
-                          nonce: &[u8; aead::NONCE_LEN], in_out: &mut [u8],
-                          in_prefix_len: usize,
-                          tag_out: &mut [u8; aead::TAG_LEN], ad: &[u8])
+                          nonce: &[u8; aead::NONCE_LEN], ad: &[u8],
+                          in_prefix_len: usize, in_out: &mut [u8],
+                          tag_out: &mut [u8; aead::TAG_LEN])
                           -> Result<(), error::Unspecified> {
     let chacha20_key = try!(ctx_as_key(ctx));
     let mut counter = chacha::make_counter(nonce, 0);


### PR DESCRIPTION
This attempts to improve the API of `ring::aead` by at least a marginal amount by fixing #371 (Removing the `in_prefix_len` parameter from `open_in_place()`) and #291 (fixing the processing of `out_suffix_capacity` in seal_in_place()`), and by returning slices instead of lengths from these functions.

Feedback is much appreciated. I'd like to improve this API more, but we're constrained because these APIs must (IMO): 1. be in-place, 2. be non-allocating, and 3. enforce that the tag is serialized immediately after the ciphertext.

Note that I plan to offer a not-in-place API in addition to this API, which maybe will use `std::io::Write` or similar, which I suspect will be less error-prone.

/cc @Philipp91 @mcginty @frewsxcv