### PR TITLE
Fixing a compilation problem in current nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -220,11 +220,11 @@ fn build_msvc(target_triple: &[&str], disable_opt: bool, num_jobs: &str,
     run_command_with_args(&msbuild, &test_args);
 }
 
-fn run_command_with_args<S>(command_name: S, args: &Vec<String>)
+fn run_command_with_args<S>(command_name: S, args: &[String])
     where S: AsRef<std::ffi::OsStr> + Copy
 {
     let status = std::process::Command::new(command_name)
-        .args(args.iter())
+        .args(args)
         .status()
         .unwrap_or_else(|e| {
             panic!("failed to execute {}: {}",

--- a/build.rs
+++ b/build.rs
@@ -224,7 +224,7 @@ fn run_command_with_args<S>(command_name: S, args: &Vec<String>)
     where S: AsRef<std::ffi::OsStr> + Copy
 {
     let status = std::process::Command::new(command_name)
-        .args(&args)
+        .args(args.iter())
         .status()
         .unwrap_or_else(|e| {
             panic!("failed to execute {}: {}",


### PR DESCRIPTION
This problem completely forbids the use of ring in nightly.
It would be really awesome if this were updated soon on crates.io, because:

- I'm using ring + rustls + thrussh to write a webserver (soon to be merged with the new hyper).
- `impl trait` is kind of mandatory to write anything efficient with tokio+futures, and is available only on nightly.

I couldn't find the commit in the rust repository that introduced it.