### PR TITLE
Allow exporting public components of `RSAKeyPair`.

### DIFF
--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -63,6 +63,19 @@ pub mod slice {
          (value & 0xff) as u8]
     }
 
+    #[inline(always)]
+    #[allow(dead_code)] // Only used for RSA currently
+    pub fn be_u8_from_u64(value: u64) -> [u8; 8] {
+        [((value >> 56) & 0xff) as u8,
+         ((value >> 48) & 0xff) as u8,
+         ((value >> 40) & 0xff) as u8,
+         ((value >> 32) & 0xff) as u8,
+         ((value >> 24) & 0xff) as u8,
+         ((value >> 16) & 0xff) as u8,
+         ((value >> 8) & 0xff) as u8,
+         (value & 0xff) as u8]
+    }
+
     // https://github.com/rust-lang/rust/issues/27750
     // https://internals.rust-lang.org/t/stabilizing-basic-functions-on-arrays-and-slices/2868
     #[inline(always)]

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -139,8 +139,7 @@ impl Positive {
     }
 
     pub fn bit_length(&self) -> bits::BitLength {
-        let bits = unsafe { GFp_BN_num_bits(self.as_ref()) };
-        bits::BitLength::from_usize_bits(bits)
+        self.0.bit_length()
     }
 }
 
@@ -216,6 +215,12 @@ pub struct Modulus<M> {
 
     /// The ring ℤ/mℤ for which this is the modulus.
     ring: PhantomData<M>,
+}
+
+impl<M> Modulus<M> {
+    pub fn bit_length(&self) -> bits::BitLength {
+        self.ctx.n().bit_length()
+    }
 }
 
 // `Modulus` uniquely owns and references its contents.
@@ -556,6 +561,10 @@ impl Nonnegative {
         Ok(OddPositive(Positive(self)))
     }
 
+    pub fn bit_length(&self) -> bits::BitLength {
+        self.0.bit_length()
+    }
+
     pub fn try_clone(&self) -> Result<Nonnegative, error::Unspecified> {
         let mut r = try!(Nonnegative::zero());
         try!(bssl::map_result(unsafe {
@@ -571,7 +580,7 @@ impl Nonnegative {
 #[allow(non_snake_case)]
 mod repr_c {
     use core;
-    use {c, limb};
+    use {bits, c, limb};
     use libc;
 
     /* Keep in sync with `bignum_st` in openss/bn.h. */
@@ -606,6 +615,11 @@ mod repr_c {
                 neg: 0,
                 flags: 0,
             }
+        }
+
+        pub fn bit_length(&self) -> bits::BitLength {
+            let bits = unsafe { super::GFp_BN_num_bits(self) };
+            bits::BitLength::from_usize_bits(bits)
         }
     }
 

--- a/src/rsa/rsa.rs
+++ b/src/rsa/rsa.rs
@@ -67,7 +67,7 @@ fn parse_public_key(input: untrusted::Input)
 fn check_public_modulus_and_exponent(
         n: bigint::Positive, e: bigint::Positive, n_min_bits: bits::BitLength,
         n_max_bits: bits::BitLength)
-        -> Result<(bigint::OddPositive, bigint::PublicExponent),
+        -> Result<(bigint::Modulus<N>, bigint::PublicExponent),
                   error::Unspecified> {
     // This is an incomplete implementation of NIST SP800-56Br1 Section
     // 6.4.2.2, "Partial Public-Key Validation for RSA." That spec defers to
@@ -111,6 +111,8 @@ fn check_public_modulus_and_exponent(
     if e_bits < bits::BitLength::from_usize_bits(2) {
         return Err(error::Unspecified);
     }
+
+    let n = try!(n.into_modulus::<N>());
 
     // Only small public exponents are supported.
     let e = try!(e.into_public_exponent());

--- a/src/rsa/rsa.rs
+++ b/src/rsa/rsa.rs
@@ -52,80 +52,143 @@ pub struct RSAParameters {
     min_bits: bits::BitLength,
 }
 
-fn parse_public_key(input: untrusted::Input)
-                    -> Result<(untrusted::Input, untrusted::Input),
-                              error::Unspecified> {
-    input.read_all(error::Unspecified, |input| {
-        der::nested(input, der::Tag::Sequence, error::Unspecified, |input| {
-            let n = try!(der::positive_integer(input));
-            let e = try!(der::positive_integer(input));
-            Ok((n, e))
-        })
-    })
+/// An RSA public key, used for signature verification. Feature: `rsa_signing`.
+pub struct RSAPublicKey {
+    n: bigint::Modulus<N>,
+    e: bigint::PublicExponent,
 }
 
-fn check_public_modulus_and_exponent(
-        n: bigint::Positive, e: bigint::Positive, n_min_bits: bits::BitLength,
-        n_max_bits: bits::BitLength)
-        -> Result<(bigint::Modulus<N>, bigint::PublicExponent),
-                  error::Unspecified> {
-    // This is an incomplete implementation of NIST SP800-56Br1 Section
-    // 6.4.2.2, "Partial Public-Key Validation for RSA." That spec defers to
-    // NIST SP800-89 Section 5.3.3, "(Explicit) Partial Public Key Validation
-    // for RSA," "with the caveat that the length of the modulus shall be a
-    // length that is specified in this Recommendation." In SP800-89, two
-    // different sets of steps are given, one set numbered, and one set
-    // lettered. TODO: Document this in the end-user documentation for RSA
-    // keys.
-
-    // Step 3 / Step c (out of order).
-    let n = try!(n.into_odd_positive());
-    let e = try!(e.into_odd_positive());
-
-    // `pkcs1_encode` depends on this not being small. Otherwise,
-    // `pkcs1_encode` would generate padding that is invalid (too few 0xFF
-    // bytes) for very small keys.
-    const N_MIN_BITS: bits::BitLength = bits::BitLength(2048);
-
-    // Step 1 / Step a. XXX: SP800-56Br1 and SP800-89 require the length of
-    // the public modulus to be exactly 2048 or 3072 bits, but we are more
-    // flexible to be compatible with other commonly-used crypto libraries.
-    assert!(n_min_bits >= N_MIN_BITS);
-    let n_bits = n.bit_length();
-    let n_bits_rounded_up =
-        try!(bits::BitLength::from_usize_bytes(
-            n_bits.as_usize_bytes_rounded_up()));
-    if n_bits_rounded_up < n_min_bits {
-        return Err(error::Unspecified);
-    }
-    if n_bits > n_max_bits {
-        return Err(error::Unspecified);
+impl RSAPublicKey {
+    /// Parse a public key in DER-encoded ASN.1 `RSAPublicKey` form (see
+    /// [RFC 3447 Appendix A.1.1]).
+    pub fn from_der(input: untrusted::Input)
+                    -> Result<RSAPublicKey, error::Unspecified> {
+        input.read_all(error::Unspecified, |input| {
+            der::nested(input, der::Tag::Sequence, error::Unspecified, |input| {
+                let n = try!(der::positive_integer(input));
+                let e = try!(der::positive_integer(input));
+                Self::from_be_bytes(n, e)
+            })
+        })
     }
 
-    // Step 2 / Step b. XXX: FIPS 186-4 seems to indicate that the minimum
-    // exponent value is 2**16 + 1, but it isn't clear if this is just for
-    // signing or also for verification. We support exponents of 3 and larger
-    // for compatibility with other commonly-used crypto libraries.
-    //
-    let e_bits = e.bit_length();
-    if e_bits < bits::BitLength::from_usize_bits(2) {
-        return Err(error::Unspecified);
+    /// Parse a public key from byte arrays containing the public modulus and
+    /// exponent in big endian order.
+    pub fn from_be_bytes(n: untrusted::Input, e: untrusted::Input)
+                         -> Result<RSAPublicKey, error::Unspecified> {
+        let n = try!(bigint::Positive::from_be_bytes(n));
+        let e = try!(bigint::Positive::from_be_bytes(e));
+        Self::from_bn(n, e)
     }
 
-    let n = try!(n.into_modulus::<N>());
+    fn from_bn(n: bigint::Positive, e: bigint::Positive)
+               -> Result<RSAPublicKey, error::Unspecified> {
+        let n = try!(n.into_odd_positive());
+        let e = try!(e.into_odd_positive());
 
-    // Only small public exponents are supported.
-    let e = try!(e.into_public_exponent());
+        let n = try!(n.into_modulus::<N>());
+        let e = try!(e.into_public_exponent());
 
-    // If `n` is less than `e` then somebody has probably accidentally swapped
-    // them. The largest acceptable `e` is smaller than the smallest acceptable
-    // `n`, so no additional checks need to be done.
-    debug_assert!(bigint::PUBLIC_EXPONENT_MAX_BITS < N_MIN_BITS);
+        Ok(RSAPublicKey { n: n, e: e })
+    }
 
-    // XXX: Steps 4 & 5 / Steps d, e, & f are not implemented. This is also the
-    // case in most other commonly-used crypto libraries.
+    fn check_modulus(&self, n_min_bits: bits::BitLength,
+                     n_max_bits: bits::BitLength)
+                     -> Result<(), error::Unspecified> {
+        // This is an incomplete implementation of NIST SP800-56Br1 Section
+        // 6.4.2.2, "Partial Public-Key Validation for RSA." That spec defers to
+        // NIST SP800-89 Section 5.3.3, "(Explicit) Partial Public Key Validation
+        // for RSA," "with the caveat that the length of the modulus shall be a
+        // length that is specified in this Recommendation." In SP800-89, two
+        // different sets of steps are given, one set numbered, and one set
+        // lettered. TODO: Document this in the end-user documentation for RSA
+        // keys.
 
-    Ok((n, e))
+        // `pkcs1_encode` depends on this not being small. Otherwise,
+        // `pkcs1_encode` would generate padding that is invalid (too few 0xFF
+        // bytes) for very small keys.
+        const N_MIN_BITS: bits::BitLength = bits::BitLength(2048);
+
+        // Step 1 / Step a. XXX: SP800-56Br1 and SP800-89 require the length of
+        // the public modulus to be exactly 2048 or 3072 bits, but we are more
+        // flexible to be compatible with other commonly-used crypto libraries.
+        assert!(n_min_bits >= N_MIN_BITS);
+        let n_bits = self.n.bit_length();
+        let n_bits_rounded_up =
+            try!(bits::BitLength::from_usize_bytes(
+                n_bits.as_usize_bytes_rounded_up()));
+        if n_bits_rounded_up < n_min_bits {
+            return Err(error::Unspecified);
+        }
+        if n_bits > n_max_bits {
+            return Err(error::Unspecified);
+        }
+
+        // Step 2 / Step b. XXX: FIPS 186-4 seems to indicate that the minimum
+        // exponent value is 2**16 + 1, but it isn't clear if this is just for
+        // signing or also for verification. We support exponents of 3 and larger
+        // for compatibility with other commonly-used crypto libraries.
+        //
+        let e_bits = self.e.bit_length();
+        if e_bits < bits::BitLength::from_usize_bits(2) {
+            return Err(error::Unspecified);
+        }
+
+        // If `n` is less than `e` then somebody has probably accidentally swapped
+        // them. The largest acceptable `e` is smaller than the smallest acceptable
+        // `n`, so no additional checks need to be done.
+        debug_assert!(bigint::PUBLIC_EXPONENT_MAX_BITS < N_MIN_BITS);
+
+        // XXX: Steps 4 & 5 / Steps d, e, & f are not implemented. This is also the
+        // case in most other commonly-used crypto libraries.
+
+        Ok(())
+    }
+
+    /// Verify a message signature using this public key.
+    pub fn verify(&self, params: &RSAParameters, msg: untrusted::Input,
+                  signature: untrusted::Input)
+                  -> Result<(), error::Unspecified> {
+        verification::verify_rsa(params, self, msg, signature)
+    }
+
+    /// Returns the length in bytes of the public modulus.
+    ///
+    /// A signature has the same length as the public modulus.
+    pub fn modulus_len(&self) -> usize {
+        self.n.bit_length().as_usize_bytes_rounded_up()
+    }
+
+    /// Extracts the public modulus.
+    ///
+    /// `out` must be exactly `modulus_len()` bytes long. It will be filled
+    /// with the big-endian-encoded bytes, without any padding.
+    pub fn export_modulus(&self, out: &mut [u8])
+                    -> Result<(), error::Unspecified> {
+        if out.len() == self.modulus_len() {
+            self.n.fill_be_bytes(out)
+        } else {
+            Err(error::Unspecified)
+        }
+    }
+
+    /// Returns the length in bytes of the public exponent.
+    pub fn exponent_len(&self) -> usize {
+        self.e.bit_length().as_usize_bytes_rounded_up()
+    }
+
+    /// Extracts the public exponent.
+    ///
+    /// `out` must be exactly `exponent_len()` bytes long. It will be filled
+    /// with the big-endian-encoded bytes, without any padding.
+    pub fn export_exponent(&self, out: &mut [u8])
+                    -> Result<(), error::Unspecified> {
+        if out.len() == self.exponent_len() {
+            self.e.fill_be_bytes(out)
+        } else {
+            Err(error::Unspecified)
+        }
+    }
 }
 
 // Type-level representation of an RSA public modulus *n*. See
@@ -148,3 +211,29 @@ mod random;
 // can see it.
 #[doc(hidden)]
 pub use rsa::random::GFp_rand_mod;
+
+
+#[cfg(test)]
+mod tests {
+    use {signature, std, untrusted};
+
+    #[test]
+    fn test_export() {
+        const PUBLIC_KEY_DER: &'static [u8] =
+            include_bytes!("signature_rsa_example_public_key.der");
+        let key_bytes_der = untrusted::Input::from(PUBLIC_KEY_DER);
+        let public_key = signature::RSAPublicKey::from_der(key_bytes_der).unwrap();
+
+        let len = public_key.modulus_len();
+        let mut buf: std::vec::Vec<u8> = vec![0; len+1];
+        assert!(public_key.export_modulus(&mut buf).is_err());
+        assert!(public_key.export_modulus(&mut buf[..len]).is_ok());
+        assert!(public_key.export_modulus(&mut buf[..len-1]).is_err());
+
+        let len = public_key.exponent_len();
+        let mut buf: std::vec::Vec<u8> = vec![0; len+1];
+        assert!(public_key.export_exponent(&mut buf).is_err());
+        assert!(public_key.export_exponent(&mut buf[..len]).is_ok());
+        assert!(public_key.export_exponent(&mut buf[..len-1]).is_err());
+    }
+}

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -17,7 +17,7 @@
 use {bits, der, digest, error};
 use rand;
 use std;
-use super::{blinding, bigint, N};
+use super::{blinding, bigint, N, RSAPublicKey};
 use untrusted;
 
 /// An RSA key pair, used for signing. Feature: `rsa_signing`.
@@ -28,8 +28,7 @@ use untrusted;
 /// module-level documentation for an example.
 #[allow(non_snake_case)] // Use the standard names.
 pub struct RSAKeyPair {
-    n: bigint::Modulus<N>,
-    e: bigint::PublicExponent,
+    public_key: RSAPublicKey,
     p: bigint::Modulus<P>,
     q: bigint::Modulus<Q>,
     dP: bigint::OddPositive,
@@ -106,12 +105,13 @@ impl RSAKeyPair {
                 // https://www.mail-archive.com/openssl-dev@openssl.org/msg44759.html.
                 // Also, this limit might help with memory management decisions
                 // later.
-                let (n, e) = try!(super::check_public_modulus_and_exponent(
-                    n, e, bits::BitLength::from_usize_bits(2048),
+                let public_key = try!(RSAPublicKey::from_bn(n, e));
+                try!(public_key.check_modulus(
+                    bits::BitLength::from_usize_bits(2048),
                     super::PRIVATE_KEY_PUBLIC_MODULUS_MAX_BITS));
 
                 let d = try!(d.into_odd_positive());
-                try!(bigint::verify_less_than(&d, &n));
+                try!(bigint::verify_less_than(&d, &public_key.n));
 
                 let half_n_bits = n_bits.half_rounded_up();
                 if p.bit_length() != half_n_bits {
@@ -136,14 +136,14 @@ impl RSAKeyPair {
                 // to checking p * q == n.
                  let q_mod_n = {
                     let q = try!(q.try_clone());
-                    try!(q.into_elem(&n))
+                    try!(q.into_elem(&public_key.n))
                 };
                 let p_mod_n = {
                     let p = try!(p.try_clone());
-                    try!(p.into_elem_decoded(&n))
+                    try!(p.into_elem_decoded(&public_key.n))
                 };
-                let pq_mod_n =
-                    try!(bigint::elem_mul_mixed(&q_mod_n, p_mod_n, &n));
+                let pq_mod_n = try!(bigint::elem_mul_mixed(
+                    &q_mod_n, p_mod_n, &public_key.n));
                 if !pq_mod_n.is_zero() {
                     return Err(error::Unspecified);
                 }
@@ -185,19 +185,18 @@ impl RSAKeyPair {
 
                 let q_mod_n_decoded = {
                     let q = try!(q.try_clone());
-                    try!(q.into_elem_decoded(&n))
+                    try!(q.into_elem_decoded(&public_key.n))
                 };
                 let qq =
                     try!(bigint::elem_mul_mixed(&q_mod_n, q_mod_n_decoded,
-                                                &n));
+                                                &public_key.n));
                 let qq = try!(qq.into_odd_positive());
                 let qq = try!(qq.into_modulus::<QQ>());
 
                 let q = try!(q.into_modulus::<Q>());
 
                 Ok(RSAKeyPair {
-                    n: n,
-                    e: e,
+                    public_key: public_key,
                     p: p,
                     q: q,
                     dP: dP,
@@ -211,42 +210,9 @@ impl RSAKeyPair {
         })
     }
 
-    /// Returns the length in bytes of the key pair's public modulus.
-    ///
-    /// A signature has the same length as the public modulus.
-    pub fn public_modulus_len(&self) -> usize {
-        self.n_bits.as_usize_bytes_rounded_up()
-    }
-
-    /// Extracts the public modulus.
-    ///
-    /// `out` must be exactly `modulus_len()` bytes long. It will be filled
-    /// with the big-endian-encoded bytes, without any padding.
-    pub fn export_public_modulus(&self, out: &mut [u8])
-                    -> Result<(), error::Unspecified> {
-        if out.len() == self.public_modulus_len() {
-            self.n.fill_be_bytes(out)
-        } else {
-            Err(error::Unspecified)
-        }
-    }
-
-    /// Returns the length in bytes of the key pair's public exponent.
-    pub fn public_exponent_len(&self) -> usize {
-        self.e.bit_length().as_usize_bytes_rounded_up()
-    }
-
-    /// Extracts the public exponent.
-    ///
-    /// `out` must be exactly `exponent_len()` bytes long. It will be filled
-    /// with the big-endian-encoded bytes, without any padding.
-    pub fn export_public_exponent(&self, out: &mut [u8])
-                    -> Result<(), error::Unspecified> {
-        if out.len() == self.public_exponent_len() {
-            self.e.fill_be_bytes(out)
-        } else {
-            Err(error::Unspecified)
-        }
+    /// Return a reference to the `RSAPublicKey` part of this key pair.
+    pub fn public_key(&self) -> &RSAPublicKey {
+        &self.public_key
     }
 }
 
@@ -317,8 +283,8 @@ impl RSASigningState {
     /// `padding_alg` and the digest is then padded using the padding algorithm
     /// from `padding_alg`. The signature it written into `signature`;
     /// `signature`'s length must be exactly the length returned by
-    /// `public_modulus_len()`. `rng` is used for blinding the message during
-    /// signing, to mitigate some side-channel (e.g. timing) attacks.
+    /// `public_key.modulus_len()`. `rng` is used for blinding the message
+    /// during signing, to mitigate some side-channel (e.g. timing) attacks.
     ///
     /// Many other crypto libraries have signing functions that takes a
     /// precomputed digest as input, instead of the message to digest. This
@@ -357,10 +323,11 @@ impl RSASigningState {
         // `Positive::from_be_bytes_padded()`.
         let base = try!(bigint::Positive::from_be_bytes_padded(
             untrusted::Input::from(signature)));
-        let base = try!(base.into_elem_decoded(&key.n));
+        let base = try!(base.into_elem_decoded(&key.public_key.n));
 
         // Step 2.
-        let result = try!(blinding.blind(base, key.e, &key.n, rng, |c| {
+        let result = try!(blinding.blind(base, key.public_key.e,
+                                         &key.public_key.n, rng, |c| {
             // Step 2.b.
 
             // Step 2.b.i.
@@ -387,10 +354,10 @@ impl RSASigningState {
             // Modular arithmetic is used simply to avoid implementing
             // non-modular arithmetic.
             let h = bigint::elem_widen(h);
-            let q_times_h =
-                try!(bigint::elem_mul_mixed(&key.q_mod_n, h, &key.n));
+            let q_times_h = try!(bigint::elem_mul_mixed(&key.q_mod_n, h,
+                                                        &key.public_key.n));
             let m_2 = bigint::elem_widen(m_2);
-            let m = try!(bigint::elem_add(&m_2, q_times_h, &key.n));
+            let m = try!(bigint::elem_add(&m_2, q_times_h, &key.public_key.n));
 
             // Step 2.b.v isn't needed since there are only two primes.
 
@@ -404,8 +371,8 @@ impl RSASigningState {
             // to `d`, `p`, and `q` is not verified during `RSAKeyPair`
             // construction.
             let computed = try!(m.try_clone());
-            let verify =
-                try!(bigint::elem_exp_vartime(computed, key.e, &key.n));
+            let verify = try!(bigint::elem_exp_vartime(computed,
+                                        key.public_key.e, &key.public_key.n));
             try!(bigint::elem_verify_equal_consttime(&verify, &c));
 
             // Step 3.
@@ -460,7 +427,7 @@ mod tests {
             let mut signing_state =
                 signature::RSASigningState::new(key_pair).unwrap();
             let mut actual: std::vec::Vec<u8> =
-                vec![0; signing_state.key_pair().public_modulus_len()];
+                vec![0; signing_state.key_pair().public_key().modulus_len()];
             signing_state.sign(alg, &rng, &msg, actual.as_mut_slice()).unwrap();
             assert_eq!(actual.as_slice() == &expected[..], result == "Pass");
             Ok(())
@@ -488,7 +455,7 @@ mod tests {
 
         // The output buffer is one byte too short.
         let mut signature =
-            vec![0; signing_state.key_pair().public_modulus_len() - 1];
+            vec![0; signing_state.key_pair().public_key().modulus_len() - 1];
 
         assert!(signing_state.sign(&signature::RSA_PKCS1_SHA256, &rng, MESSAGE,
                                    &mut signature).is_err());
@@ -519,7 +486,7 @@ mod tests {
         let key_bytes_der = untrusted::Input::from(PRIVATE_KEY_DER);
         let key_pair = signature::RSAKeyPair::from_der(key_bytes_der).unwrap();
         let key_pair = std::sync::Arc::new(key_pair);
-        let mut signature = vec![0; key_pair.public_modulus_len()];
+        let mut signature = vec![0; key_pair.public_key().modulus_len()];
 
         let mut signing_state =
             signature::RSASigningState::new(key_pair).unwrap();
@@ -549,10 +516,10 @@ mod tests {
         // The inversion itself is blinded. This blinding factor must be
         // non-zero.
         let mut inverse_blinding_factor =
-            vec![0u8; key_pair.public_modulus_len()];
+            vec![0u8; key_pair.public_key().modulus_len()];
         inverse_blinding_factor[0] = 1;
 
-        let zero = vec![0u8; key_pair.public_modulus_len()];
+        let zero = vec![0u8; key_pair.public_key().modulus_len()];
 
         let mut bytes = std::vec::Vec::new();
         bytes.push(&inverse_blinding_factor[..]);
@@ -569,7 +536,7 @@ mod tests {
         let mut signing_state =
             signature::RSASigningState::new(key_pair).unwrap();
         let mut signature =
-            vec![0; signing_state.key_pair().public_modulus_len()];
+            vec![0; signing_state.key_pair().public_key().modulus_len()];
         let result = signing_state.sign(&signature::RSA_PKCS1_SHA256, &rng,
                                         MESSAGE, &mut signature);
 
@@ -627,7 +594,7 @@ mod tests {
             let mut signing_state =
                 signature::RSASigningState::new(key_pair).unwrap();
             let mut actual: std::vec::Vec<u8> =
-                vec![0; signing_state.key_pair().public_modulus_len()];
+                vec![0; signing_state.key_pair().public_key().modulus_len()];
             try!(signing_state.sign(alg, &new_rng, &msg, actual.as_mut_slice()));
             assert_eq!(actual.as_slice() == &expected[..], result == "Pass");
             Ok(())
@@ -650,26 +617,5 @@ mod tests {
         let _: &Send = &signing_state;
         // TODO: Test that signing_state is NOT Sync; i.e.
         // `let _: &Sync = &signing_state;` must fail
-    }
-
-
-    #[test]
-    fn test_export() {
-        const PRIVATE_KEY_DER: &'static [u8] =
-            include_bytes!("signature_rsa_example_private_key.der");
-        let key_bytes_der = untrusted::Input::from(PRIVATE_KEY_DER);
-        let key_pair = signature::RSAKeyPair::from_der(key_bytes_der).unwrap();
-
-        let len = key_pair.public_modulus_len();
-        let mut buf: std::vec::Vec<u8> = vec![0; len+1];
-        assert!(key_pair.export_public_modulus(&mut buf).is_err());
-        assert!(key_pair.export_public_modulus(&mut buf[..len]).is_ok());
-        assert!(key_pair.export_public_modulus(&mut buf[..len-1]).is_err());
-
-        let len = key_pair.public_exponent_len();
-        let mut buf: std::vec::Vec<u8> = vec![0; len+1];
-        assert!(key_pair.export_public_exponent(&mut buf).is_err());
-        assert!(key_pair.export_public_exponent(&mut buf[..len]).is_ok());
-        assert!(key_pair.export_public_exponent(&mut buf[..len-1]).is_err());
     }
 }

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -128,8 +128,6 @@ impl RSAKeyPair {
                 let q = try!(q.into_odd_positive());
                 try!(bigint::verify_less_than(&q, &p));
 
-                let n = try!(n.into_modulus::<N>());
-
                 // Verify that p * q == n. We restrict ourselves to modular
                 // multiplication. We rely on the fact that we've verified
                 // 0 < q < p < n. We check that q and p are close to sqrt(n)

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -119,7 +119,6 @@ pub fn verify_rsa(params: &RSAParameters,
         try!(super::check_public_modulus_and_exponent(n, e, params.min_bits,
                                                       max_bits));
     let n_bits = n.bit_length();
-    let n = try!(n.into_modulus::<N>());
 
     // The signature must be the same length as the modulus, in bytes.
     if signature.len() != n_bits.as_usize_bytes_rounded_up() {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -186,7 +186,8 @@
 //! // SHA256 digest algorithm.
 //! const MESSAGE: &'static [u8] = b"hello, world";
 //! let rng = rand::SystemRandom::new();
-//! let mut signature = vec![0; signing_state.key_pair().public_modulus_len()];
+//! let signature_len = signing_state.key_pair().public_key().modulus_len();
+//! let mut signature = vec![0; signature_len];
 //! try!(signing_state.sign(&signature::RSA_PKCS1_SHA256, &rng, MESSAGE,
 //!                         &mut signature));
 //!
@@ -253,7 +254,7 @@ pub use rsa::{
 };
 
 #[cfg(feature = "use_heap")]
-pub use rsa::RSAParameters;
+pub use rsa::{RSAPublicKey, RSAParameters};
 
 #[cfg(feature = "use_heap")]
 pub use rsa::verification::{


### PR DESCRIPTION
In [Portier], we load RSA private keys once, leveraging the DER parsing in Ring. However, we need to then serve the public keys as JWK to clients. These additions allow us to grab the public components of an `RSAKeyPair` to build the JWK.

I agree to license my contributions to each file under the terms given at the top of each file I changed.

 [Portier]: https://portier.github.io/