### PR TITLE
Disable _FORTIFY_SOURCE for Musl on Linux

### DIFF
--- a/mk/top_of_makefile.mk
+++ b/mk/top_of_makefile.mk
@@ -68,6 +68,13 @@ ifeq ($(TARGET_ABI),eabi)
 MABI = aapcs
 endif
 
+# TODO: This is here until Musl finishes adding support for _FORTIFY_SOURCE
+ifeq ($(TARGET_ABI),musl)
+ifeq ($(TARGET_SYS),linux)
+CPPFLAGS += -U_FORTIFY_SOURCE
+endif
+endif
+
 # Cortex-M0, Cortex-M0+, Cortex-M1: armv6_m
 # Cortex-M3: armv7_m
 # Cortex-M4, Cortex-M7: armv7e_m


### PR DESCRIPTION
This _works_, but I don't really understand what I'm doing. I didn't manage to compile https://github.com/ctz/rustls with this change on top of ring's `master`. I could do a side-by-side comparison by basing by change on be1e17583af16f6261b336d4696dca88fbe792a0.

This is a workaround for #409.