### PR TITLE
Implement constant-time modular left shift by 1 bit.

### DIFF
--- a/crypto/bn/bn_test.cc
+++ b/crypto/bn/bn_test.cc
@@ -263,7 +263,7 @@ static bool TestLShift1(FileTest *t) {
       !GFp_BN_div(ret.get(), remainder.get(), lshift1.get(), two.get()) ||
       !ExpectBIGNUMsEqual(t, "LShift1 / 2", a.get(), ret.get()) ||
       !ExpectBIGNUMsEqual(t, "LShift1 % 2", zero.get(), remainder.get()) ||
-      !GFp_BN_lshift1(ret.get(), a.get()) ||
+      !GFp_BN_lshift(ret.get(), a.get(), 1) ||
       !ExpectBIGNUMsEqual(t, "A << 1", lshift1.get(), ret.get()) ||
       !GFp_BN_rshift1(ret.get(), lshift1.get()) ||
       !ExpectBIGNUMsEqual(t, "LShift >> 1", a.get(), ret.get()) ||

--- a/crypto/bn/shift.c
+++ b/crypto/bn/shift.c
@@ -101,37 +101,6 @@ int GFp_BN_lshift(BIGNUM *r, const BIGNUM *a, int n) {
   return 1;
 }
 
-int GFp_BN_lshift1(BIGNUM *r, const BIGNUM *a) {
-  BN_ULONG *ap, *rp, t, c;
-  int i;
-
-  if (r != a) {
-    r->neg = a->neg;
-    if (GFp_bn_wexpand(r, a->top + 1) == NULL) {
-      return 0;
-    }
-    r->top = a->top;
-  } else {
-    if (GFp_bn_wexpand(r, a->top + 1) == NULL) {
-      return 0;
-    }
-  }
-  ap = a->d;
-  rp = r->d;
-  c = 0;
-  for (i = 0; i < a->top; i++) {
-    t = *(ap++);
-    *(rp++) = ((t << 1) | c) & BN_MASK2;
-    c = (t & BN_TBIT) ? 1 : 0;
-  }
-  if (c) {
-    *rp = 1;
-    r->top++;
-  }
-
-  return 1;
-}
-
 int GFp_BN_rshift(BIGNUM *r, const BIGNUM *a, int n) {
   int i, j, nw, lb, rb;
   BN_ULONG *t, *f;

--- a/crypto/limbs/limbs.c
+++ b/crypto/limbs/limbs.c
@@ -114,3 +114,21 @@ void LIMBS_sub_mod(Limb r[], const Limb a[], const Limb b[], const Limb m[],
     carry = limb_adc(&r[i], r[i], m[i] & underflow, carry);
   }
 }
+
+void LIMBS_shl_mod(Limb r[], const Limb m[], size_t num_limbs) {
+  Limb overflow1 =
+      constant_time_is_nonzero_size_t(r[num_limbs - 1] & LIMB_HIGH_BIT);
+  Limb carry = 0;
+  for (size_t i = 0; i < num_limbs; ++i) {
+    Limb limb = r[i];
+    Limb new_carry = limb >> (LIMB_BITS - 1);
+    r[i] = (limb << 1) | carry;
+    carry = new_carry;
+  }
+  Limb overflow2 = ~LIMBS_less_than(r, m, num_limbs);
+  Limb overflow = overflow1 | overflow2;
+  Carry borrow = limb_sub(&r[0], r[0], m[0] & overflow);
+  for (size_t i = 1; i < num_limbs; ++i) {
+    borrow = limb_sbb(&r[i], r[i], m[i] & overflow, borrow);
+  }
+}

--- a/crypto/limbs/limbs.h
+++ b/crypto/limbs/limbs.h
@@ -24,6 +24,8 @@
 typedef BN_ULONG Limb;
 
 #define LIMB_BITS BN_BITS2
+#define LIMB_HIGH_BIT ((Limb)(1) << (LIMB_BITS - 1))
+
 
 Limb LIMBS_are_zero(const Limb a[], size_t num_limbs);
 Limb LIMBS_equal(const Limb a[], const Limb b[], size_t num_limbs);
@@ -32,6 +34,8 @@ void LIMBS_add_mod(Limb r[], const Limb a[], const Limb b[], const Limb m[],
                    size_t num_limbs);
 void LIMBS_sub_mod(Limb r[], const Limb a[], const Limb b[], const Limb m[],
                    size_t num_limbs);
+void LIMBS_shl_mod(Limb r[], const Limb m[], size_t num_limbs);
+
 
 
 #endif /* RING_LIMBS_H */

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -309,10 +309,6 @@ OPENSSL_EXPORT int GFp_BN_is_odd(const BIGNUM *bn);
  */
 OPENSSL_EXPORT int GFp_BN_lshift(BIGNUM *r, const BIGNUM *a, int n);
 
-/* GFp_BN_lshift1 sets |r| equal to |a| << 1, where |r| and |a| may be the same
- * pointer. It returns one on success and zero on allocation failure. */
-OPENSSL_EXPORT int GFp_BN_lshift1(BIGNUM *r, const BIGNUM *a);
-
 /* GFp_BN_rshift sets |r| equal to |a| >> n, where |r| and |a| may be the same
  * pointer. It returns one on success and zero on allocation failure. */
 OPENSSL_EXPORT int GFp_BN_rshift(BIGNUM *r, const BIGNUM *a, int n);


### PR DESCRIPTION
This is the (blueprint for the) constant-time modular left shift designed to complete the removal of the timing side channel (inherited from OpenSSL and then BoringSSL) from RSA signing setup.

I suspect the performance of this will be approximately the same as what's currently done in the master branch. It would be great to confirm that. This PR isn't intended to address the performance issue; it's just intended to (be a blueprint for the) fix for the timing side channel. Still, please let me know whether it helps at all, or hurts, the performance. I know of ways to optimize this if necessary.

/cc @ctz