### PR TITLE
Allow Ring to be built by emscripten

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -93,6 +93,8 @@ extern "C" {
 #define OPENSSL_PNACL
 #elif defined(__myriad2__)
 #define OPENSSL_32_BIT
+#elif defined(__EMSCRIPTEN__)
+#define OPENSSL_32_BIT
 #else
 #error "Unknown target CPU"
 #endif


### PR DESCRIPTION
Rust now supports WA and asm.js but it was impossible to build ring since the CPU architecture wasn't defined in the OpenSSL headers. This defines emscripten to be a 32-bit CPU.