### PR TITLE
Faster montgomery setup

### DIFF
--- a/crypto/bn/internal.h
+++ b/crypto/bn/internal.h
@@ -201,7 +201,7 @@ void GFp_bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                      const BN_ULONG *np, const BN_ULONG *n0, int num);
 
 uint64_t GFp_bn_mont_n0(const BIGNUM *n);
-int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, unsigned p, const BIGNUM *n);
+int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, size_t p, const BIGNUM *n);
 
 static inline void bn_umult_lohi(BN_ULONG *low_out, BN_ULONG *high_out,
                                  BN_ULONG a, BN_ULONG b) {

--- a/crypto/bn/internal.h
+++ b/crypto/bn/internal.h
@@ -201,7 +201,8 @@ void GFp_bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                      const BN_ULONG *np, const BN_ULONG *n0, int num);
 
 uint64_t GFp_bn_mont_n0(const BIGNUM *n);
-int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, size_t p, const BIGNUM *n);
+int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, size_t p, const BIGNUM *n,
+                                  BN_ULONG n0[BN_MONT_CTX_N0_LIMBS]);
 
 static inline void bn_umult_lohi(BN_ULONG *low_out, BN_ULONG *high_out,
                                  BN_ULONG a, BN_ULONG b) {

--- a/crypto/bn/montgomery_inv.c
+++ b/crypto/bn/montgomery_inv.c
@@ -162,7 +162,7 @@ static uint64_t bn_neg_inv_mod_r_u64(uint64_t n) {
 /* bn_mod_exp_base_2_vartime calculates r = 2**p (mod n). |p| must be larger
  * than log_2(n); i.e. 2**p must be larger than |n|. |n| must be positive and
  * odd. */
-int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, unsigned p, const BIGNUM *n) {
+int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, size_t p, const BIGNUM *n) {
   assert(!GFp_BN_is_zero(n));
   assert(!GFp_BN_is_negative(n));
   assert(GFp_BN_is_odd(n));

--- a/crypto/bn/montgomery_inv.c
+++ b/crypto/bn/montgomery_inv.c
@@ -159,10 +159,10 @@ static uint64_t bn_neg_inv_mod_r_u64(uint64_t n) {
   return v;
 }
 
-/* bn_mod_exp_base_2_vartime calculates r = 2**p (mod n). |p| must be larger
- * than log_2(n); i.e. 2**p must be larger than |n|. |n| must be positive and
- * odd. */
-int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, size_t p, const BIGNUM *n) {
+/* bn_mod_exp_base_2_vartime calculates r = 2**(2*p) (mod n). 2**p must be
+ * larger than |n|. |n| must be positive and odd. */
+int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, size_t p, const BIGNUM *n,
+                                  BN_ULONG n0[BN_MONT_CTX_N0_LIMBS]) {
   assert(!GFp_BN_is_zero(n));
   assert(!GFp_BN_is_negative(n));
   assert(GFp_BN_is_odd(n));
@@ -179,7 +179,7 @@ int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, size_t p, const BIGNUM *n) {
   if (GFp_bn_wexpand(r, n->top) == NULL) {
     return 0;
   }
-  assert(p > n_bits);
+  assert(p >= n_bits);
   if (!GFp_BN_set_bit(r, n_bits - 1)) {
     return 0;
   }
@@ -188,9 +188,41 @@ int GFp_bn_mod_exp_base_2_vartime(BIGNUM *r, size_t p, const BIGNUM *n) {
   if (r->top < n->top) {
     r->d[n->top] = 0;
   }
+  size_t i = n_bits - 1;
 
-  for (unsigned i = n_bits - 1; i < p; ++i) {
+  /* The first iteration results in r == 2**p == R.
+   * The second iteration results in r == 2*R.
+   *
+   * Once we have 2*R, we can use either squaring or shifting depending on
+   * the relative performance between the two. We assume that
+   * Cshift < Csquare < 2*Cshift, where |CShift| is the cost of shifting and
+   * Csquare is the cost of squaring. Therefore, we shift once more to get
+   * r == 4*R, then we switch to squaring. */
+  while (i < p + 2 && i < 2 * p) {
     LIMBS_shl_mod(r->d, r->d, n->d, n->top);
+    ++i;
+  }
+
+  i = 2;
+  while (2 * i <= p) {
+    if (!GFp_BN_mod_mul_mont(r, r, r, n, n0)) {
+      return 0;
+    }
+    i *= 2;
+  }
+
+  // TODO: Make sure we're testing {1023, 2047, 3071, 4091, 8191, etc.}-bit
+  // moduli.
+
+  /* For |p| in {1024, 2048, 4096, 8192}, at least, we will be done at this
+   * point. Unfortunately for other cases we will need to do a bunch of
+   * shifting. This is especially unfortunate for p == 3072 since that is
+   * actually common for RSA verification. */
+  assert(i == p || (p != 1024 && p != 2048 && p != 4096 && p != 8192));
+
+  while (i < p) {
+    LIMBS_shl_mod(r->d, r->d, n->d, n->top);
+    ++i;
   }
 
   GFp_bn_correct_top(r);

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -115,7 +115,6 @@ extern "C" {
 #define OPENSSL_EXPORT
 
 typedef struct bignum_st BIGNUM;
-typedef struct bn_mont_ctx_st BN_MONT_CTX;
 
 typedef struct RAND RAND;
 

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -368,15 +368,6 @@ int GFp_BN_mod_inverse_odd(BIGNUM *out, int *out_no_inverse, const BIGNUM *a,
                            const BIGNUM *n);
 
 
-/* Montgomery arithmetic. */
-
-/* BN_MONT_CTX contains the precomputed values needed to work in a specific
- * Montgomery domain. */
-
-/* GFp_BN_MONT_CTX_set sets up a Montgomery context given the modulus, |mod|.
- * It returns one on success and zero on error. */
-OPENSSL_EXPORT int GFp_BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod);
-
 /* GFp_BN_from_mont sets |ret| equal to |a| * R^-1, i.e. translates values out
  * of the Montgomery domain. |a| is assumed to be in the range [0, n), where |n|
  * is the Montgomery modulus. It returns one on success or zero on error. */
@@ -417,19 +408,6 @@ struct bignum_st {
   int dmax;  /* Size of |d|, in words. */
   int neg;   /* one if the number is negative */
   int flags; /* bitmask of BN_FLG_* values */
-};
-
-/* Keep in sync with `BN_MONT_CTX` in `ring::rsa::bigint` */
-struct bn_mont_ctx_st {
-  BIGNUM RR; /* used to convert to montgomery form */
-  BIGNUM N;  /* The modulus */
-
-  /* Least significant word(s) of the "magic" Montgomery constant. When
-   * |BN_MONT_CTX_N0_LIMBS == 1|, n0[1] is probably unused, however it is safer
-   * to always use two elements just in case any code from another OpenSSL
-   * variant that assumes |n0| has two elements is imported. Keep in sync with
-   * |N0_LIMBS| in bigint.rs. */
-  BN_ULONG n0[2];
 };
 
 OPENSSL_EXPORT unsigned GFp_BN_num_bits_word(BN_ULONG l);

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -38,6 +38,10 @@
 //! [Static checking of units in Servo]:
 //!     https://blog.mozilla.org/research/2014/06/23/static-checking-of-units-in-servo/
 
+// There are two quantities relevant to this code, `r` and `R`, that have
+// different values. We avoid using `r` to refer to `R` so we have to disable
+// this lint.
+#![allow(non_snake_case)]
 
 // XXX TODO: Remove this once RSA verification has been done in Rust.
 #![cfg_attr(not(feature = "rsa_signing"), allow(dead_code))]
@@ -57,10 +61,6 @@ pub fn verify_less_than<A: core::convert::AsRef<BIGNUM>,
         return Err(error::Unspecified);
     }
     Ok(())
-}
-
-impl<M> AsRef<BIGNUM> for Modulus<M> {
-    fn as_ref<'a>(&'a self) -> &'a BIGNUM { self.ctx.n() }
 }
 
 impl AsRef<BIGNUM> for OddPositive {
@@ -127,10 +127,8 @@ impl Positive {
         self.0.into_odd_positive()
     }
 
-    pub fn bit_length(&self) -> bits::BitLength {
-        let bits = unsafe { GFp_BN_num_bits(self.as_ref()) };
-        bits::BitLength::from_usize_bits(bits)
-    }
+    #[inline]
+    pub fn bit_length(&self) -> bits::BitLength { self.0.bit_length() }
 }
 
 /// Odd positive integers.
@@ -147,22 +145,9 @@ impl OddPositive {
         self.0.into_elem(m)
     }
 
+    #[inline]
     pub fn into_modulus<M>(self) -> Result<Modulus<M>, error::Unspecified> {
-        // A `Modulus` must be larger than 1.
-        if self.bit_length() < bits::BitLength::from_usize_bits(2) {
-            return Err(error::Unspecified);
-        }
-
-        let mut r = Modulus {
-            ctx: BN_MONT_CTX::new(),
-            m: PhantomData,
-        };
-        // XXX: This makes a copy of `self`'s `BIGNUM`. TODO: change this to a
-        // move.
-        try!(bssl::map_result(unsafe {
-            GFp_BN_MONT_CTX_set(&mut r.ctx, self.as_ref())
-        }));
-        Ok(r)
+        Modulus::new(self)
     }
 
     pub fn into_public_exponent(self)
@@ -208,7 +193,15 @@ pub unsafe trait NotMuchSmallerModulus<L>: SmallerModulus<L> {}
 /// and larger than 2. The larger-than-1 requirement is imposed, at least, by
 /// the modular inversion code.
 pub struct Modulus<M> {
-    ctx: BN_MONT_CTX,
+    value: OddPositive, // Also `value >= 3`.
+
+    // n0 * N == -1 (mod r).
+    //
+    // TODO(perf): Not all 32-bit platforms actually make use of n0[1]. For the
+    // ones that don't, we could use a shorter `R` value and use faster `Limb`
+    // calculations instead of double-precision `u64` calculations.
+    n0: N0,
+
     m: PhantomData<M>,
 }
 
@@ -218,12 +211,55 @@ unsafe impl<M> Send for Modulus<M> {}
 // `Modulus` is immutable.
 unsafe impl<M> Sync for Modulus<M> {}
 
+#[allow(trivial_numeric_casts)] // XXX
+impl<M> Modulus<M> {
+    fn new(value: OddPositive) -> Result<Self, error::Unspecified> {
+        // A `Modulus` must be larger than 1.
+        if value.bit_length() < bits::BitLength::from_usize_bits(2) {
+            return Err(error::Unspecified);
+        }
+        let n0 = unsafe { GFp_bn_mont_n0(value.as_ref()) };
+        Ok(Modulus {
+            value: value,
+            n0: n0_from_u64(n0),
+            m: PhantomData,
+        })
+    }
+
+    // RR = R**2 (mod N). R is the smallest power of 2**LIMB_BITS such that
+    // R > mod. Even though the assembly on some 32-bit platforms works with
+    // 64-bit values, using `LIMB_BITS` here, rather than
+    // `N0_LIMBS_USED * LIMB_BITS`, is correct because R**2 will still be a
+    // multiple of the latter as `N0_LIMBS_USED` is either one or two.
+    pub fn compute_oneRR(&self) -> Result<Elem<M, RR>, error::Unspecified> {
+        use limb::LIMB_BITS;
+        let lg_R =
+            (self.value.bit_length().as_usize_bits() + (LIMB_BITS - 1))
+                / LIMB_BITS * LIMB_BITS;
+
+        let mut RR = try!(Elem::zero());
+        try!(bssl::map_result(unsafe {
+            GFp_bn_mod_exp_base_2_vartime(RR.value.as_mut_ref(), 2 * lg_R,
+                                          self.value.as_ref())
+        }));
+        Ok(RR)
+    }
+}
+
 // Not Montgomery encoded; there is no *R* factor that need to be canceled out.
 pub enum Unencoded {}
 
 // Montgomery encoded; the value has one *R* factor that needs to be canceled
 // out.
 pub enum R {}
+
+// Montgomery encoded twice; the value has two *R* factors that need to be
+// canceled out.
+pub enum RR {}
+
+// Inversely Montgomery encoded; the value has one 1/*R* factor that needs to
+// be canceled out.
+pub enum RInverse {}
 
 pub trait MontgomeryEncodingProduct {
     type Output;
@@ -243,6 +279,21 @@ impl MontgomeryEncodingProduct for (R, Unencoded) {
 impl MontgomeryEncodingProduct for (R, R) {
     type Output = R;
 }
+
+impl MontgomeryEncodingProduct for (RR, Unencoded) {
+    type Output = R;
+}
+impl MontgomeryEncodingProduct for (Unencoded, RR) {
+    type Output = R;
+}
+
+impl MontgomeryEncodingProduct for (RInverse, RR) {
+    type Output = Unencoded;
+}
+impl MontgomeryEncodingProduct for (RR, RInverse) {
+    type Output = Unencoded;
+}
+
 
 /// Montgomery-encoded elements of a field.
 //
@@ -298,7 +349,7 @@ impl<M> Elem<M, R> {
                           -> Result<Elem<M, Unencoded>, error::Unspecified> {
         let mut r = self.value;
         try!(bssl::map_result(unsafe {
-            GFp_BN_from_mont(&mut r.0, &r.0, m.as_ref(), m.ctx.n0())
+            GFp_BN_from_mont(&mut r.0, &r.0, &m.value.as_ref(), &m.n0)
         }));
         Ok(Elem {
             value: r,
@@ -329,16 +380,8 @@ impl<M> Elem<M, Unencoded> {
 
     pub fn into_encoded(self, m: &Modulus<M>)
                         -> Result<Elem<M, R>, error::Unspecified> {
-        let mut value = self.value;
-        try!(bssl::map_result(unsafe {
-            GFp_BN_mod_mul_mont(value.as_mut_ref(), value.as_ref(), m.ctx.RR(),
-                                m.as_ref(), m.ctx.n0())
-        }));
-        Ok(Elem {
-            value: value,
-            m: PhantomData,
-            encoding: PhantomData,
-        })
+        let RR = try!(m.compute_oneRR());
+        elem_mul(&RR, self, &m)
     }
 
     pub fn into_odd_positive(self) -> Result<OddPositive, error::Unspecified> {
@@ -353,8 +396,8 @@ pub fn elem_mul<M, AF, BF>(a: &Elem<M, AF>, b: Elem<M, BF>, m: &Modulus<M>)
         where (AF, BF): MontgomeryEncodingProduct {
     let mut r = b.value;
     try!(bssl::map_result(unsafe {
-        GFp_BN_mod_mul_mont(&mut r.0, a.value.as_ref(), &r.0, m.as_ref(),
-                            m.ctx.n0())
+        GFp_BN_mod_mul_mont(&mut r.0, a.value.as_ref(), &r.0, &m.value.as_ref(),
+                            &m.n0)
     }));
     Ok(Elem {
         value: r,
@@ -371,7 +414,7 @@ pub fn elem_set_to_product<M, AF, BF>(
         where (AF, BF): MontgomeryEncodingProduct {
     bssl::map_result(unsafe {
         GFp_BN_mod_mul_mont(r.value.as_mut_ref(), a.value.as_ref(),
-                            b.value.as_ref(), m.as_ref(), m.ctx.n0())
+                            b.value.as_ref(), &m.value.as_ref(), &m.n0)
     })
 }
 
@@ -380,8 +423,8 @@ pub fn elem_reduced_once<Larger, Smaller: SlightlySmallerModulus<Larger>>(
         -> Result<Elem<Smaller, Unencoded>, error::Unspecified> {
     let mut r = try!(Elem::zero());
     try!(bssl::map_result(unsafe {
-        GFp_BN_mod_sub_quick(r.value.as_mut_ref(), a.value.as_ref(), m.as_ref(),
-                             m.as_ref())
+        GFp_BN_mod_sub_quick(r.value.as_mut_ref(), a.value.as_ref(),
+                             m.value.as_ref(), m.value.as_ref())
     }));
     Ok(r)
 }
@@ -390,18 +433,15 @@ pub fn elem_reduced<Larger, Smaller: NotMuchSmallerModulus<Larger>>(
         a: &Elem<Larger, Unencoded>, m: &Modulus<Smaller>)
         -> Result<Elem<Smaller, R>, error::Unspecified> {
     let mut tmp = try!(a.try_clone());
-    let mut r = try!(Elem::zero());
+    let mut r = try!(Elem::<Smaller, RInverse>::zero());
     try!(bssl::map_result(unsafe {
         GFp_BN_from_montgomery_word(r.value.as_mut_ref(),
-                                    tmp.value.as_mut_ref(), m.as_ref(),
-                                    m.ctx.n0())
+                                    tmp.value.as_mut_ref(), &m.value.as_ref(),
+                                    &m.n0)
     }));
-    try!(bssl::map_result(unsafe {
-        GFp_BN_mod_mul_mont(r.value.as_mut_ref(), r.value.as_ref(), m.ctx.RR(),
-                            m.as_ref(), m.ctx.n0())
-    }));
-    let r = try!(r.into_encoded(m));
-    Ok(r)
+    let RR = try!(m.compute_oneRR()); // XXX
+    let r = try!(elem_mul(&RR, r, &m));
+    elem_mul(&RR, r, &m)
 }
 
 pub fn elem_squared<M, E>(a: Elem<M, E>, m: &Modulus<M>)
@@ -411,7 +451,7 @@ pub fn elem_squared<M, E>(a: Elem<M, E>, m: &Modulus<M>)
     let mut value = a.value;
     try!(bssl::map_result(unsafe {
         GFp_BN_mod_mul_mont(value.as_mut_ref(), value.as_ref(), value.as_ref(),
-                            m.as_ref(), m.ctx.n0())
+                            &m.value.as_ref(), &m.n0)
     }));
     Ok(Elem {
         value: value,
@@ -435,8 +475,8 @@ pub fn elem_add<M, E>(a: &Elem<M, E>, b: Elem<M, E>, m: &Modulus<M>)
                       -> Result<Elem<M, E>, error::Unspecified> {
     let mut value = b.value;
     try!(bssl::map_result(unsafe {
-        GFp_BN_mod_add_quick(&mut value.0, a.value.as_ref(), &value.0,
-                             m.as_ref())
+        GFp_BN_mod_add_quick(&mut value.0, a.value.as_ref(), value.as_ref(),
+                             m.value.as_ref())
     }));
     Ok(Elem {
         value: value,
@@ -451,7 +491,7 @@ pub fn elem_sub<M, E>(a: Elem<M, E>, b: &Elem<M, E>, m: &Modulus<M>)
     let mut value = a.value;
     try!(bssl::map_result(unsafe {
         GFp_BN_mod_sub_quick(&mut value.0, &value.0, b.value.as_ref(),
-                             m.as_ref())
+                             m.value.as_ref())
     }));
     Ok(Elem {
         value: value,
@@ -525,8 +565,8 @@ pub fn elem_exp_consttime<M>(
     let mut r = base.value;
     try!(bssl::map_result(unsafe {
         GFp_BN_mod_exp_mont_consttime(&mut r.0, &r.0, exponent.as_ref(),
-                                      one.value.as_ref(), m.as_ref(),
-                                      m.ctx.n0())
+                                      one.value.as_ref(), &m.value.as_ref(),
+                                      &m.n0)
     }));
     Ok(Elem {
         value: r,
@@ -538,7 +578,7 @@ pub fn elem_exp_consttime<M>(
 pub fn elem_randomize<M, E>(a: &mut Elem<M, E>, m: &Modulus<M>,
                             rng: &rand::SecureRandom)
                             -> Result<(), error::Unspecified> {
-    a.value.randomize(m.as_ref(), rng)
+    a.value.randomize(m.value.as_ref(), rng)
 }
 
 // r = 1/a (mod m), blinded with a random element.
@@ -548,8 +588,8 @@ pub fn elem_randomize<M, E>(a: &mut Elem<M, E>, m: &Modulus<M>,
 pub fn elem_set_to_inverse_blinded<M>(
             r: &mut Elem<M, Unencoded>, a: &Elem<M, Unencoded>, m: &Modulus<M>,
             rng: &rand::SecureRandom) -> Result<(), InversionError> {
-    let mut blinding_factor = try!(Elem::zero());
-    try!(blinding_factor.value.randomize(m.as_ref(), rng));
+    let mut blinding_factor = try!(Elem::<M, R>::zero());
+    try!(blinding_factor.value.randomize(m.value.as_ref(), rng));
     let to_blind = try!(a.try_clone());
     let blinded = try!(elem_mul(&blinding_factor, to_blind, m));
     let blinded_inverse = try!(elem_inverse(blinded, m));
@@ -567,7 +607,7 @@ fn elem_inverse<M>(a: Elem<M, Unencoded>, m: &Modulus<M>)
     let mut no_inverse = 0;
     try!(bssl::map_result(unsafe {
         GFp_BN_mod_inverse_odd(value.as_mut_ref(), &mut no_inverse,
-                               value.as_ref(), m.as_ref())
+                               value.as_ref(), m.value.as_ref())
     }).map_err(|_| {
         if no_inverse != 0 {
             InversionError::NoInverse
@@ -612,6 +652,11 @@ impl Nonnegative {
         Ok(r)
     }
 
+    fn bit_length(&self) -> bits::BitLength {
+        let bits = unsafe { GFp_BN_num_bits(self.as_ref()) };
+        bits::BitLength::from_usize_bits(bits)
+    }
+
     fn is_zero(&self) -> bool {
         let is_zero = unsafe { GFp_BN_is_zero(self.as_ref()) };
         is_zero != 0
@@ -636,7 +681,7 @@ impl Nonnegative {
 
     fn into_elem<M>(self, m: &Modulus<M>)
                     -> Result<Elem<M, Unencoded>, error::Unspecified> {
-        try!(verify_less_than(&self, &m));
+        try!(verify_less_than(&self, &m.value));
         Ok(Elem {
             value: self,
             m: PhantomData,
@@ -661,21 +706,29 @@ impl Nonnegative {
     }
 }
 
-// These types are defined in their own submodule so that their private
-// components are not accessible.
-
-// Keep in sync with the length of `bn_mont_ctx_st::n0`, which is actually
-// different than value of `BN_MONT_CTX_N0_LIMBS`.
+type N0 = [limb::Limb; N0_LIMBS];
 const N0_LIMBS: usize = 2;
 
-type N0 = [limb::Limb; N0_LIMBS];
+// const N0_LIMBS_USED: usize = 1;
+#[cfg(target_pointer_width = "64")]
+#[inline]
+fn n0_from_u64(n0: u64) -> N0 {
+    [n0, 0]
+}
 
-#[allow(non_snake_case)]
+// const N0_LIMBS_USED: usize = 2;
+#[cfg(target_pointer_width = "32")]
+#[inline]
+fn n0_from_u64(n0: u64) -> N0 {
+    [n0 as limb::Limb, (n0 >> limb::LIMB_BITS) as limb::Limb]
+}
+
+// `BIGNUM` is defined in its own submodule so that its private components are
+// not accessible.
 mod repr_c {
     use core;
     use {c, limb};
     use libc;
-    use super::N0;
 
     /* Keep in sync with `bignum_st` in openss/bn.h. */
     #[repr(C)]
@@ -711,31 +764,9 @@ mod repr_c {
             }
         }
     }
-
-    /* Keep in sync with `bn_mont_ctx_st` in openss/bn.h. */
-    #[repr(C)]
-    pub struct BN_MONT_CTX {
-        RR: BIGNUM,
-        N: BIGNUM,
-        n0: N0,
-    }
-
-    impl BN_MONT_CTX {
-        pub fn new() -> Self {
-            BN_MONT_CTX {
-                RR: BIGNUM::zero(),
-                N: BIGNUM::zero(),
-                n0: [0, 0],
-            }
-        }
-
-        pub fn n(&self) -> &BIGNUM { &self.N }
-        pub fn n0(&self) -> &N0 { &self.n0 }
-        pub fn RR(&self) -> &BIGNUM { &self.RR }
-    }
 }
 
-pub use self::repr_c::{BIGNUM, BN_MONT_CTX};
+pub use self::repr_c::BIGNUM;
 
 extern {
     fn GFp_BN_one(r: &mut BIGNUM) -> c::int;
@@ -750,6 +781,9 @@ extern {
     fn GFp_BN_is_zero(a: &BIGNUM) -> c::int;
     fn GFp_BN_is_one(a: &BIGNUM) -> c::int;
     fn GFp_BN_num_bits(bn: *const BIGNUM) -> c::size_t;
+    fn GFp_bn_mont_n0(n: &BIGNUM) -> u64;
+    fn GFp_bn_mod_exp_base_2_vartime(r: &mut BIGNUM, p: c::size_t,
+                                     n: &BIGNUM) -> c::int;
 
     // `r` and `a` may alias.
     fn GFp_BN_from_mont(r: *mut BIGNUM, a: *const BIGNUM, n: &BIGNUM, n0: &N0)
@@ -774,7 +808,6 @@ extern {
     fn GFp_BN_copy(a: &mut BIGNUM, b: &BIGNUM) -> c::int;
     fn GFp_BN_from_montgomery_word(r: &mut BIGNUM, a: &mut BIGNUM, n: &BIGNUM,
                                    n0: &N0) -> c::int;
-    fn GFp_BN_MONT_CTX_set(ctx: &mut BN_MONT_CTX, modulus: &BIGNUM) -> c::int;
 }
 
 #[allow(improper_ctypes)]

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -257,6 +257,11 @@ pub enum R {}
 // canceled out.
 pub enum RR {}
 
+
+// Montgomery encoded three times; the value has three *R* factors that need to
+// be canceled out.
+pub enum RRR {}
+
 // Inversely Montgomery encoded; the value has one 1/*R* factor that needs to
 // be canceled out.
 pub enum RInverse {}
@@ -292,6 +297,17 @@ impl MontgomeryEncodingProduct for (RInverse, RR) {
 }
 impl MontgomeryEncodingProduct for (RR, RInverse) {
     type Output = Unencoded;
+}
+
+impl MontgomeryEncodingProduct for (RR, RR) {
+    type Output = RRR;
+}
+
+impl MontgomeryEncodingProduct for (RRR, RInverse) {
+    type Output = R;
+}
+impl MontgomeryEncodingProduct for (RInverse, RRR) {
+    type Output = R;
 }
 
 

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -239,8 +239,8 @@ impl<M> Modulus<M> {
 
         let mut RR = try!(Elem::zero());
         try!(bssl::map_result(unsafe {
-            GFp_bn_mod_exp_base_2_vartime(RR.value.as_mut_ref(), 2 * lg_R,
-                                          self.value.as_ref())
+            GFp_bn_mod_exp_base_2_vartime(RR.value.as_mut_ref(), lg_R,
+                                          self.value.as_ref(), &self.n0)
         }));
         Ok(RR)
     }
@@ -791,7 +791,7 @@ extern {
     fn GFp_BN_num_bits(bn: *const BIGNUM) -> c::size_t;
     fn GFp_bn_mont_n0(n: &BIGNUM) -> u64;
     fn GFp_bn_mod_exp_base_2_vartime(r: &mut BIGNUM, p: c::size_t,
-                                     n: &BIGNUM) -> c::int;
+                                     n: &BIGNUM, n0: &N0) -> c::int;
 
     // `r` and `a` may alias.
     fn GFp_BN_from_mont(r: *mut BIGNUM, a: *const BIGNUM, n: &BIGNUM, n0: &N0)

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -431,7 +431,7 @@ pub fn elem_reduced_once<Larger, Smaller: SlightlySmallerModulus<Larger>>(
 
 pub fn elem_reduced<Larger, Smaller: NotMuchSmallerModulus<Larger>>(
         a: &Elem<Larger, Unencoded>, m: &Modulus<Smaller>)
-        -> Result<Elem<Smaller, R>, error::Unspecified> {
+        -> Result<Elem<Smaller, RInverse>, error::Unspecified> {
     let mut tmp = try!(a.try_clone());
     let mut r = try!(Elem::<Smaller, RInverse>::zero());
     try!(bssl::map_result(unsafe {
@@ -439,9 +439,7 @@ pub fn elem_reduced<Larger, Smaller: NotMuchSmallerModulus<Larger>>(
                                     tmp.value.as_mut_ref(), &m.value.as_ref(),
                                     &m.n0)
     }));
-    let RR = try!(m.compute_oneRR()); // XXX
-    let r = try!(elem_mul(&RR, r, &m));
-    elem_mul(&RR, r, &m)
+    Ok(r)
 }
 
 pub fn elem_squared<M, E>(a: Elem<M, E>, m: &Modulus<M>)
@@ -958,7 +956,8 @@ mod tests {
 
             //let a = a.into_encoded(&m).unwrap();
             let actual_result = elem_reduced(&a, &m).unwrap();
-            let actual_result = actual_result.into_unencoded(&m).unwrap();
+            let oneRR = m.compute_oneRR().unwrap();
+            let actual_result = elem_mul(&oneRR, actual_result, &m).unwrap();
             assert_elem_eq(&actual_result, &expected_result);
 
             Ok(())

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -31,18 +31,11 @@ use untrusted;
 pub struct RSAKeyPair {
     n: bigint::Modulus<N>,
     e: bigint::PublicExponent,
-    p: bigint::Modulus<P>,
-    q: bigint::Modulus<Q>,
-    dP: bigint::OddPositive,
-    dQ: bigint::OddPositive,
+    p: PrivatePrime<P>,
+    q: PrivatePrime<Q>,
     qInv: bigint::Elem<P, R>,
-
     qq: bigint::Modulus<QQ>,
     q_mod_n: bigint::Elem<N, R>,
-
-    one_mod_p: bigint::Elem<P, R>, // 1 (mod p), Montgomery encoded.
-    one_mod_q: bigint::Elem<Q, R>, // 1 (mod q), Montgomery encoded.
-
     n_bits: bits::BitLength,
 }
 
@@ -148,7 +141,6 @@ impl RSAKeyPair {
                     let clone = try!(q_mod_n_decoded.try_clone());
                     try!(clone.into_encoded(&n))
                 };
-
                 let p_mod_n = {
                     let p = try!(p.try_clone());
                     try!(p.into_elem(&n))
@@ -159,38 +151,16 @@ impl RSAKeyPair {
                     return Err(error::Unspecified);
                 }
 
-                // XXX: We don't check that `dP == d % (p - 1)` or that
-                // `dQ == d % (q - 1)` because we don't (in the long term)
-                // have a good way to do modulo with an even modulus. Instead
-                // we just check that `1 <= dP < p - 1` and `1 <= dQ < q - 1`.
-                // We'll check them, to some unknown extent, when we do the
-                // private key operation, since we verify that the result of
-                // the private key operation using the CRT parameters is
-                // consistent with `n` and `e`. TODO: Either prove that what we
-                // do is sufficient, or make it so.
-                //
-                // We need to prove that `dP < p - 1`. If we verify
-                // `dP < p` then we'll know that either `dP == p - 1` or
-                // `dP < p - 1`. Since `p` is odd, `p - 1` is even. `d` is odd,
-                // and an odd number modulo an even number is odd.
-                // Therefore `dP` must be odd. But then it cannot be `p - 1`
-                // and so we know `dP < p - 1`.
-                let dP = try!(dP.into_odd_positive());
-                try!(bigint::verify_less_than(&dP, &p));
-                // The same argument can be used to prove `dQ < q - 1`.
-                let dQ = try!(dQ.into_odd_positive());
-                try!(bigint::verify_less_than(&dQ, &q));
+                let p = try!(PrivatePrime::new(p, dP));
 
-                let p = try!(p.into_modulus::<P>());
-
-                let qInv = try!(qInv.into_elem(&p));
-                let qInv = try!(qInv.into_encoded(&p));
+                let qInv = try!(qInv.into_elem(&p.modulus));
+                let qInv = try!(qInv.into_encoded(&p.modulus));
                 let q_mod_p = {
                     let q = try!(q.try_clone());
-                    try!(q.into_elem(&p))
+                    try!(q.into_elem(&p.modulus))
                 };
                 let qInv_times_q_mod_p =
-                    try!(bigint::elem_mul(&qInv, q_mod_p, &p));
+                    try!(bigint::elem_mul(&qInv, q_mod_p, &p.modulus));
                 if !qInv_times_q_mod_p.is_one() {
                     return Err(error::Unspecified);
                 }
@@ -200,26 +170,15 @@ impl RSAKeyPair {
                 let qq = try!(qq.into_odd_positive());
                 let qq = try!(qq.into_modulus::<QQ>());
 
-                let q = try!(q.into_modulus::<Q>());
-
-                let one_mod_p = try!(bigint::Elem::one());
-                let one_mod_p = try!(one_mod_p.into_encoded(&p));
-
-                let one_mod_q = try!(bigint::Elem::one());
-                let one_mod_q = try!(one_mod_q.into_encoded(&q));
-
+                let q = try!(PrivatePrime::new(q, dQ));
                 Ok(RSAKeyPair {
                     n: n,
                     e: e,
                     p: p,
                     q: q,
-                    dP: dP,
-                    dQ: dQ,
                     qInv: qInv,
                     q_mod_n: q_mod_n,
                     qq: qq,
-                    one_mod_p: one_mod_p,
-                    one_mod_q: one_mod_q,
                     n_bits: n_bits,
                 })
             })
@@ -234,10 +193,65 @@ impl RSAKeyPair {
     }
 }
 
+#[allow(non_snake_case)] // `r` and `R` denote different values.
+struct PrivatePrime<M: Prime> {
+    modulus: bigint::Modulus<M>,
+    exponent: bigint::OddPositive,
+    oneR: bigint::Elem<M, R>, // 1 (mod p), Montgomery encoded.
+}
+
+#[allow(non_snake_case)] // Use Standard names.
+impl<M: Prime> PrivatePrime<M> {
+    /// Constructs a `PrivatePrime` from the private prime `p` and `dP` where
+    /// dP == d % (p - 1).
+    fn new(p: bigint::OddPositive, dP: bigint::Positive)
+           -> Result<Self, error::Unspecified> {
+        // XXX: We don't check that `dP == d % (p - 1)` because we don't (in
+        // the long term) have a good way to do modulo with an even modulus.
+        // Instead we just check that `1 <= dP < p - 1`. We'll check it, to
+        // some unknown extent, when we do the private key operation, since we
+        // verify that the result of the private key operation using the CRT
+        // parameters is consistent with `n` and `e`. TODO: Either prove that
+        // what we do is sufficient, or make it so.
+        //
+        // Proof that `dP < p - 1`:
+        //
+        // If `dP < p` then either `dP == p - 1` or `dP < p - 1`. Since `p` is
+        // odd, `p - 1` is even. `d` is odd, and an odd number modulo an even
+        // number is odd. Therefore `dP` must be odd. But then it cannot be
+        // `p - 1` and so we know `dP < p - 1`.
+        let dP = try!(dP.into_odd_positive());
+        try!(bigint::verify_less_than(&dP, &p));
+
+        let p = try!(p.into_modulus());
+
+        let one = try!(bigint::Elem::one());
+        let oneR = try!(one.into_encoded(&p));
+
+        Ok(PrivatePrime {
+            modulus: p,
+            exponent: dP,
+            oneR: oneR,
+        })
+    }
+}
+
+fn elem_exp_consttime<M, MM>(c: &bigint::Elem<MM>, p: &PrivatePrime<M>)
+                             -> Result<bigint::Elem<M>, error::Unspecified>
+                             where M: bigint::NotMuchSmallerModulus<MM>,
+                                   M: Prime {
+    let c_mod_m = try!(bigint::elem_reduced(c, &p.modulus));
+    bigint::elem_exp_consttime(c_mod_m, &p.exponent, &p.oneR, &p.modulus)
+}
+
+
 // Type-level representations of the different moduli used in RSA signing, in
 // addition to `super::N`. See `super::bigint`'s modulue-level documentation.
 
+unsafe trait Prime {}
+
 enum P {}
+unsafe impl Prime for P {}
 unsafe impl bigint::SmallerModulus<N> for P {}
 unsafe impl bigint::NotMuchSmallerModulus<N> for P {}
 
@@ -253,6 +267,7 @@ unsafe impl bigint::NotMuchSmallerModulus<N> for QQ {}
 unsafe impl bigint::SlightlySmallerModulus<N> for QQ {}
 
 enum Q {}
+unsafe impl Prime for Q {}
 unsafe impl bigint::SmallerModulus<N> for Q {}
 unsafe impl bigint::SmallerModulus<P> for Q {}
 
@@ -356,27 +371,18 @@ impl RSASigningState {
 
         // Step 2.
         let result = try!(blinding.blind(base, key.e, &key.n, rng, |c| {
-            // Step 2.b.
-
             // Step 2.b.i.
-
-            let c_mod_p = try!(bigint::elem_reduced(&c, &key.p));
-            let m_1 =
-                try!(bigint::elem_exp_consttime(c_mod_p, &key.dP,
-                                                &key.one_mod_p, &key.p));
-
+            let m_1 = try!(elem_exp_consttime(&c, &key.p));
             let c_mod_qq = try!(bigint::elem_reduced_once(&c, &key.qq));
-            let c_mod_q = try!(bigint::elem_reduced(&c_mod_qq, &key.q));
-            let m_2 =
-                try!(bigint::elem_exp_consttime(c_mod_q, &key.dQ,
-                                                &key.one_mod_q, &key.q));
+            let m_2 = try!(elem_exp_consttime(&c_mod_qq, &key.q));
 
             // Step 2.b.ii isn't needed since there are only two primes.
 
             // Step 2.b.iii.
+            let p = &key.p.modulus;
             let m_2 = bigint::elem_widen(m_2);
-            let m_1_minus_m_2 = try!(bigint::elem_sub(m_1, &m_2, &key.p));
-            let h = try!(bigint::elem_mul(&key.qInv, m_1_minus_m_2, &key.p));
+            let m_1_minus_m_2 = try!(bigint::elem_sub(m_1, &m_2, p));
+            let h = try!(bigint::elem_mul(&key.qInv, m_1_minus_m_2, p));
 
             // Step 2.b.iv. The reduction in the modular multiplication isn't
             // necessary because `h < p` and `p * q == n` implies `h * q < n`.

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -236,11 +236,15 @@ impl<M: Prime> PrivatePrime<M> {
     }
 }
 
+#[allow(non_snake_case)] // `R` and `r` mean different things.
 fn elem_exp_consttime<M, MM>(c: &bigint::Elem<MM>, p: &PrivatePrime<M>)
                              -> Result<bigint::Elem<M>, error::Unspecified>
                              where M: bigint::NotMuchSmallerModulus<MM>,
                                    M: Prime {
     let c_mod_m = try!(bigint::elem_reduced(c, &p.modulus));
+    let oneRR = try!(p.modulus.compute_oneRR()); // XXX
+    let c_mod_m = try!(bigint::elem_mul(&oneRR, c_mod_m, &p.modulus));
+    let c_mod_m = try!(bigint::elem_mul(&oneRR, c_mod_m, &p.modulus));
     bigint::elem_exp_consttime(c_mod_m, &p.exponent, &p.oneR, &p.modulus)
 }
 

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -12,6 +12,9 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+// TODO: `R` vs `r` comment.
+#![allow(non_snake_case)]
+
 /// RSA PKCS#1 1.5 signatures.
 
 use {bits, digest, error, private, signature};
@@ -133,7 +136,11 @@ pub fn verify_rsa(params: &RSAParameters,
     let s = try!(s.into_elem::<N>(&n));
 
     // Step 2.
-    let s = try!(s.into_encoded(&n));
+    let s = {
+        // Montgomery encode `s`.
+        let oneRR = try!(n.compute_oneRR());
+        try!(bigint::elem_mul(&oneRR, s, &n))
+    };
     let m = try!(bigint::elem_exp_vartime(s, e, &n));
     let m = try!(m.into_unencoded(&n));
 


### PR DESCRIPTION
This is a sketch of a possible fix for #431. See the last commit in this series. Unfortunately, it gets messier moduli with lengths that aren't of the form 2<sup>2<sup>n</sup></sup>. Fortunately, most common moduli lengths (1024, 2048, 4096, and 8192) are of that form, but 3072 isn't. We may add a special case for 3072.

@ctz @DemiMarie Can you run your benchmarks against this and let me know the results?