### PR TITLE
Update Android NDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ the table below. The C compilers listed are used for compiling the C portions.
 </tr>
 <tr><td>Android</td>
     <td>32&#8209;bit&nbsp;ARM</td>
-    <td>Built using the Android SDK 24.4.1 and Android NDK 10e, tested using
+    <td>Built using the Android SDK 24.4.1 and Android NDK 14, tested using
         the Android emulator. (Aarch64 builds are blocked on the Rust team
         producing AAarch64 builds of Rust's libstd.)</td>
 </tr>

--- a/mk/travis-install-android.sh
+++ b/mk/travis-install-android.sh
@@ -24,7 +24,7 @@ set -ex
 ANDROID_SDK_VERSION=${ANDROID_SDK_VERSION:-24.4.1}
 ANDROID_SDK_URL=https://dl.google.com/android/android-sdk_r${ANDROID_SDK_VERSION}-linux.tgz
 
-ANDROID_NDK_VERSION=${ANDROID_NDK_VERSION:-10e}
+ANDROID_NDK_VERSION=${ANDROID_NDK_VERSION:-14}
 ANDROID_NDK_URL=https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip
 
 ANDROID_INSTALL_PREFIX="${HOME}/android"


### PR DESCRIPTION
Part of #474. The android install script doesn't handle upgrades and the travis cache so you might need to go to travis and delete all your caches. I this works I'll work on using the unified headers and switching to clang.