### PR TITLE
Use clang on android.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       os: osx
       osx_image: xcode8.2
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -50,7 +50,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -63,7 +63,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -76,7 +76,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -585,7 +585,7 @@ matrix:
       os: osx
       osx_image: xcode8.2
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -598,7 +598,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -611,7 +611,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -624,7 +624,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -1153,7 +1153,7 @@ matrix:
       os: osx
       osx_image: xcode8.2
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1166,7 +1166,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1179,7 +1179,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1192,7 +1192,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-clang CXX_X=arm-linux-androideabi-clang++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ the table below. The C compilers listed are used for compiling the C portions.
 </tr>
 <tr><td>Android</td>
     <td>32&#8209;bit&nbsp;ARM</td>
-    <td>Built using the Android SDK 24.4.1 and Android NDK 10e, tested using
-        the Android emulator. (Aarch64 builds are blocked on the Rust team
+    <td>Built using the Android SDK 24.4.1 and Android NDK 14 (Android clang version 3.8.275480),
+        tested using the Android emulator.(Aarch64 builds are blocked on the Rust team
         producing AAarch64 builds of Rust's libstd.)</td>
 </tr>
 <tr><td>Mac&nbsp;OS&nbsp;X</td>

--- a/build.rs
+++ b/build.rs
@@ -547,11 +547,8 @@ fn cc(file: &str, ext: &str, target: &Target, out_dir: &Path) -> Command {
         // http://www.openwall.com/lists/musl/2015/06/17/1
         let _ = c.flag("-U_FORTIFY_SOURCE");
     }
-    if target.os() == "android" {
-        // Define __ANDROID_API__ to the Android API level we want.
-        // Needed for Android NDK Unified Headers, see:
-        // https://android.googlesource.com/platform/ndk/+/master/docs/UnifiedHeaders.md#Supporting-Unified-Headers-in-Your-Build-System
-        let _ = c.define("__ANDROID_API__", Some("18"));
+    if target.os() == "android" && target.arch() == "arm" {
+            let _ = c.flag("-march=armv7-a");
     }
 
     let mut c = c.get_compiler().to_command();

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -53,7 +53,7 @@ osx_compilers = [
 
 compilers = {
     "aarch64-unknown-linux-gnu" : [ "aarch64-linux-gnu-gcc" ],
-    "arm-linux-androideabi" : [ "arm-linux-androideabi-gcc" ],
+    "arm-linux-androideabi" : [ "arm-linux-androideabi-clang" ],
     "arm-unknown-linux-gnueabihf" : [ "arm-linux-gnueabihf-gcc" ],
     "i686-unknown-linux-gnu" : linux_compilers,
     "x86_64-unknown-linux-gnu" : linux_compilers,


### PR DESCRIPTION
I stopped defining `__ANDROID_API__` which means we drop support for gcc on android. This is a PR for issue #473.