### PR TITLE
Use travis_wait only on ARM release builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1683,4 +1683,4 @@ matrix:
 
     # END GENERATED
 
-script: if [[ "$TARGET_X" =~ ^a*.*linux-.*eabi ]]; then travis_wait 60 mk/travis.sh; else mk/travis.sh; fi
+script: if [[ "$TARGET_X" =~ ^a*.*linux-.*eabi && "$MODE_X" == "RELWITHDEBINFO" ]]; then travis_wait 60 mk/travis.sh; else mk/travis.sh; fi


### PR DESCRIPTION
The other builds don't seem to timeout. This way we have faster/better feedback for the arm builds.