### PR TITLE
Remove option that breaks newer android emulators.

### DIFF
--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -88,7 +88,7 @@ fi
 case $TARGET_X in
 arm-linux-androideabi)
   cargo test -vv -j2 --no-run ${mode-} ${FEATURES_X-} --target=$TARGET_X
-  emulator @arm-18 -no-skin -no-boot-anim -no-audio -no-window &
+  emulator @arm-18 -no-skin -no-boot-anim -no-window &
   adb wait-for-device
   adb push $target_dir/ring-* /data/ring-test
   for testfile in `find src crypto -name "*_test*.txt"`; do


### PR DESCRIPTION
This gets the android builds running on the emulator and shows that the switch to clang unfortunately broke ring on android. I won't have time until later in the week to try to find the cause. I tried passing a lot of different flags to clang to try to fix this but I've had no luck so far.