### PR TITLE
Use armv7 for android build on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       os: osx
       osx_image: xcode8.2
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -50,7 +50,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -63,7 +63,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -76,7 +76,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
@@ -585,7 +585,7 @@ matrix:
       os: osx
       osx_image: xcode8.2
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -598,7 +598,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -611,7 +611,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -624,7 +624,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
@@ -1153,7 +1153,7 @@ matrix:
       os: osx
       osx_image: xcode8.2
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1166,7 +1166,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1179,7 +1179,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty
@@ -1192,7 +1192,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: TARGET_X=arm-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -26,7 +26,7 @@ aarch64-unknown-linux-gnu)
 arm-unknown-linux-gnueabihf)
   export QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf
   ;;
-arm-linux-androideabi)
+armv7-linux-androideabi)
   # install the android sdk/ndk
   mk/travis-install-android.sh
 
@@ -86,7 +86,7 @@ else
 fi
 
 case $TARGET_X in
-arm-linux-androideabi)
+armv7-linux-androideabi)
   cargo test -vv -j2 --no-run ${mode-} ${FEATURES_X-} --target=$TARGET_X
   emulator @arm-18 -no-skin -no-boot-anim -no-window &
   adb wait-for-device

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -53,7 +53,7 @@ osx_compilers = [
 
 compilers = {
     "aarch64-unknown-linux-gnu" : [ "aarch64-linux-gnu-gcc" ],
-    "arm-linux-androideabi" : [ "arm-linux-androideabi-gcc" ],
+    "armv7-linux-androideabi" : [ "arm-linux-androideabi-gcc" ],
     "arm-unknown-linux-gnueabihf" : [ "arm-linux-gnueabihf-gcc" ],
     "i686-unknown-linux-gnu" : linux_compilers,
     "x86_64-unknown-linux-gnu" : linux_compilers,
@@ -82,7 +82,7 @@ targets = {
         "x86_64-apple-darwin",
     ],
     "linux" : [
-        "arm-linux-androideabi",
+        "armv7-linux-androideabi",
         "x86_64-unknown-linux-gnu",
         "aarch64-unknown-linux-gnu",
         "i686-unknown-linux-gnu",
@@ -162,7 +162,7 @@ def format_entry(os, target, compiler, rust, mode, features):
         sources = sorted(list(set(sources_with_dups)))
 
     # TODO: Use trusty for everything?
-    if arch in ["aarch64", "arm"] and sys != "androideabi":
+    if arch in ["aarch64", "arm", "armv7"]:
         template += """
       dist: trusty
       sudo: required"""
@@ -219,7 +219,7 @@ def get_linux_packages_to_install(target, compiler, arch, kcov):
         packages += ["gcc-arm-linux-gnueabihf",
                      "g++-arm-linux-gnueabihf",
                      "libc6-dev-armhf-cross"]
-    if target == "arm-linux-androideabi":
+    if target == "armv7-linux-androideabi":
         packages += ["expect",
                      "openjdk-6-jre-headless"]
 
@@ -248,7 +248,7 @@ def get_linux_packages_to_install(target, compiler, arch, kcov):
                          "libelf-dev",
                          "libdw-dev",
                          "binutils-dev"]
-    elif arch not in ["aarch64", "arm"]:
+    elif arch not in ["aarch64", "arm", "armv7"]:
         raise ValueError("unexpected arch: %s" % arch)
 
     return packages


### PR DESCRIPTION
I noticed that just by changing the target these flags, `-march=armv7-a` and `mfpu=vfpv3-d16`, get passed to gcc. According to [this](https://developer.android.com/ndk/guides/standalone_toolchain.html#abi_compatibility) we should also pass `-mfloat-abi=softfp`. We may also want to pass `-thumb` and `-mfpu=neon` and lean on on the runtime detection for arm cpu features. There's also the recommended flags to the linker that we may want to pass to both gcc and rustc.