### PR TITLE
Replace digest Algorithm attribute accesses with getter methods. #461

### DIFF
--- a/src/digest/digest.rs
+++ b/src/digest/digest.rs
@@ -274,7 +274,7 @@ impl core::fmt::Debug for Digest {
 /// C analog: `EVP_MD`
 pub struct Algorithm {
     /// C analog: `EVP_MD_size`
-    pub output_len: usize,
+    output_len: usize,
 
     /// The size of the chaining value of the digest function, in bytes. For
     /// non-truncated algorithms (SHA-1, SHA-256, SHA-512), this is equal to
@@ -282,10 +282,10 @@ pub struct Algorithm {
     /// this is equal to the length before truncation. This is mostly helpful
     /// for determining the size of an HMAC key that is appropriate for the
     /// digest algorithm.
-    pub chaining_len: usize,
+    chaining_len: usize,
 
     /// C analog: `EVP_MD_block_size`
-    pub block_len: usize,
+    block_len: usize,
 
     /// The length of the length in the padding.
     len_len: usize,
@@ -295,6 +295,28 @@ pub struct Algorithm {
     format_output: fn(input: &State) -> Output,
 
     initial_state: State,
+}
+
+impl Algorithm {
+    /// C analog: `EVP_MD_size`
+    pub fn output_len(&self) -> usize {
+        self.output_len
+    }
+
+    /// The size of the chaining value of the digest function, in bytes. For
+    /// non-truncated algorithms (SHA-1, SHA-256, SHA-512), this is equal to
+    /// `output_len`. For truncated algorithms (e.g. SHA-384, SHA-512/256),
+    /// this is equal to the length before truncation. This is mostly helpful
+    /// for determining the size of an HMAC key that is appropriate for the
+    /// digest algorithm.
+    pub fn chaining_len(&self) -> usize {
+        self.chaining_len
+    }
+
+    /// C analog: `EVP_MD_block_size`
+    pub fn block_len(&self) -> usize {
+        self.block_len
+    }
 }
 
 impl core::fmt::Debug for Algorithm {
@@ -771,6 +793,15 @@ mod tests {
                    &format!("{:?}",
                             digest::digest(&digest::SHA512, b"hello, world")));
 
+    }
+
+    #[test]
+    fn test_algorithm_accessors() {
+        for alg in &[&digest::SHA1, &digest::SHA256, &digest::SHA384, &digest::SHA512] {
+            assert_eq!(alg.output_len, alg.output_len());
+            assert_eq!(alg.chaining_len, alg.chaining_len());
+            assert_eq!(alg.block_len, alg.block_len());
+        }
     }
 
     mod max_input {

--- a/src/ec/suite_b/ecdsa.rs
+++ b/src/ec/suite_b/ecdsa.rs
@@ -291,7 +291,7 @@ mod tests {
                                                                  &digest_name);
 
             let num_limbs = ops.public_key_ops.common.num_limbs;
-            assert_eq!(input.len(), digest_alg.output_len);
+            assert_eq!(input.len(), digest_alg.output_len());
             assert_eq!(output.len(),
                        ops.public_key_ops.common.num_limbs * LIMB_BYTES);
 

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -96,8 +96,8 @@ pub fn extract(salt: &hmac::SigningKey, secret: &[u8]) -> hmac::SigningKey {
 /// the 8-bit iteration counter in the expansion step.
 pub fn expand(prk: &hmac::SigningKey, info: &[u8], out: &mut [u8]) {
     let digest_alg = prk.digest_algorithm();
-    assert!(out.len() <= 255 * digest_alg.output_len);
-    assert!(digest_alg.block_len >= digest_alg.output_len);
+    assert!(out.len() <= 255 * digest_alg.output_len());
+    assert!(digest_alg.block_len() >= digest_alg.output_len());
 
     let mut ctx = hmac::SigningContext::with_key(prk);
 
@@ -110,19 +110,19 @@ pub fn expand(prk: &hmac::SigningKey, info: &[u8], out: &mut [u8]) {
         let t = ctx.sign();
 
         // Append `t` to the output.
-        let to_copy = if out.len() - pos < digest_alg.output_len {
+        let to_copy = if out.len() - pos < digest_alg.output_len() {
             out.len() - pos
         } else {
-            digest_alg.output_len
+            digest_alg.output_len()
         };
         let t_bytes = t.as_ref();
         for i in 0..to_copy {
             out[pos + i] = t_bytes[i];
         }
-        if to_copy < digest_alg.output_len {
+        if to_copy < digest_alg.output_len() {
             break;
         }
-        pos += digest_alg.output_len;
+        pos += digest_alg.output_len();
 
         ctx = hmac::SigningContext::with_key(prk);
         ctx.update(t_bytes);

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -143,7 +143,7 @@ pub fn derive(prf: &'static PRF, iterations: u32, salt: &[u8],
               secret: &[u8], out: &mut [u8]) {
     assert!(iterations >= 1);
 
-    let output_len = prf.digest_alg.output_len;
+    let output_len = prf.digest_alg.output_len();
 
     // This implementation's performance is asymptotically optimal as described
     // in https://jbp.io/2015/08/11/pbkdf2-performance-matters/. However, it
@@ -219,7 +219,7 @@ pub fn verify(prf: &'static PRF, iterations: u32, salt: &[u8],
 
     let mut derived_buf = [0u8; digest::MAX_OUTPUT_LEN];
 
-    let output_len = prf.digest_alg.output_len;
+    let output_len = prf.digest_alg.output_len();
     let secret = hmac::SigningKey::new(prf.digest_alg, secret);
     let mut idx: u32 = 0;
 

--- a/src/rsa/padding.rs
+++ b/src/rsa/padding.rs
@@ -97,7 +97,7 @@ fn pkcs1_encode(pkcs1: &PKCS1, m_hash: &digest::Digest, m_out: &mut [u8]) {
     let em = m_out;
 
     let digest_len =
-        pkcs1.digestinfo_prefix.len() + pkcs1.digest_alg.output_len;
+        pkcs1.digestinfo_prefix.len() + pkcs1.digest_alg.output_len();
 
     // The specification requires at least 8 bytes of padding. Since we
     // disallow keys smaller than 2048 bits, this should always be true.
@@ -368,7 +368,7 @@ impl PSSMetrics {
         debug_assert!(leading_zero_bits < 8);
         let top_byte_mask = 0xffu8 >> leading_zero_bits;
 
-        let h_len = digest_alg.output_len;
+        let h_len = digest_alg.output_len();
 
         // We require the salt length to be equal to the digest length.
         let s_len = h_len;
@@ -402,7 +402,7 @@ impl PSSMetrics {
 // https://tools.ietf.org/html/rfc3447#appendix-B.2.1.
 fn mgf1(digest_alg: &'static digest::Algorithm, seed: &[u8], mask: &mut [u8])
         -> Result<(), error::Unspecified> {
-    let digest_len = digest_alg.output_len;
+    let digest_len = digest_alg.output_len();
 
     // Maximum counter value is the value of (mask_len / digest_len) rounded up.
     let ctr_max = (mask.len() - 1) / digest_len;


### PR DESCRIPTION
I've made the attributes private, added attribute getters for `output_len`, `chaining_len` and `block_len`, and updated all uses throughout the codebase. I've also implemented a test that the values are correct, and checked it works.

> The original motivation for doing things the current way might no longer be valid.

At present nothing in the codebase tries to set these parameters. Beyond that I don't have enough context to comment.