### PR TITLE
allow implementing PBKDF2 for other digest algorithms

### DIFF
--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -254,7 +254,8 @@ pub fn verify(prf: &'static PRF, iterations: u32, salt: &[u8],
 
 /// A PRF algorithm for use with `derive` and `verify`.
 pub struct PRF {
-    digest_alg: &'static digest::Algorithm,
+    /// digest algorithm usable as a PBKDF2 PRF
+    pub digest_alg: &'static digest::Algorithm,
 }
 
 /// HMAC-SHA256.


### PR DESCRIPTION
To implement authentication in systems like [MongoDB](https://docs.mongodb.com/manual/core/security-scram-sha-1/), we need other variants of PBKDF2, like HMAC-SHA1.

Since you might not want to commit the API to provide weaker variants by default, I thought exposing the digest algorithm member of PRF would allow it discreetly if someone needs it.