### PR TITLE
Create Android AVD after test build and use more RAM on the emulator.

### DIFF
--- a/mk/travis-install-android.sh
+++ b/mk/travis-install-android.sh
@@ -48,10 +48,6 @@ expect {
   popd
 fi
 
-echo no | $ANDROID_SDK_INSTALL_DIR/tools/android create avd --name arm-18 --target android-18 --abi armeabi-v7a
-
-$ANDROID_SDK_INSTALL_DIR/tools/android list avd
-
 if [[ ! -d $ANDROID_NDK_INSTALL_DIR/sysroot/usr/include/arm-linux-androideabi ]];then
   mkdir -p "${ANDROID_INSTALL_PREFIX}/downloads"
   pushd "${ANDROID_INSTALL_PREFIX}/downloads"

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -88,7 +88,9 @@ fi
 case $TARGET_X in
 armv7-linux-androideabi)
   cargo test -vv -j2 --no-run ${mode-} ${FEATURES_X-} --target=$TARGET_X
-  emulator @arm-18 -no-skin -no-boot-anim -no-window &
+  echo no | android create avd --name arm-18 --target android-18 --abi armeabi-v7a
+  android list avd
+  emulator @arm-18 -memory 2048 -no-skin -no-boot-anim -no-window &
   adb wait-for-device
   adb push $target_dir/ring-* /data/ring-test
   for testfile in `find src crypto -name "*_test*.txt"`; do


### PR DESCRIPTION
This way we'll get to build issues faster.