### PR TITLE
Fix windows gnu build.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -580,7 +580,7 @@ fn compile(p: &Path, target: &Target, out_dir: &Path,
         let mut out_path = out_dir.clone().join(p.file_name().unwrap());
         out_path.set_extension(target.obj_ext);
         if need_run(&p, &out_path, includes_modified) {
-            let cmd = if target.env() != "msvc" || ext != "asm" {
+            let cmd = if target.os() != WINDOWS || ext != "asm" {
                 cc(p, ext, target, &out_path)
             } else {
                 yasm(p, target.arch(), &out_path)
@@ -624,7 +624,7 @@ fn cc(file: &Path, ext: &str, target: &Target, out_dir: &Path) -> Command {
     }
     if target.os() != "none" &&
         target.os() != "redox" &&
-        target.env() != "msvc" {
+        target.os() != "windows" {
         let _ = c.flag("-fstack-protector");
     }
 

--- a/crypto/cpu-intel.c
+++ b/crypto/cpu-intel.c
@@ -62,10 +62,14 @@
 #include <inttypes.h>
 
 #if defined(OPENSSL_WINDOWS)
+#ifdef _MSC_VER
 #pragma warning(push, 3)
+#endif
 #include <immintrin.h>
 #include <intrin.h>
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 #endif
 
 #include "internal.h"

--- a/crypto/curve25519/asm/x25519-asm-x86_64.S
+++ b/crypto/curve25519/asm/x25519-asm-x86_64.S
@@ -27,6 +27,10 @@
 /* OS X's C ABI prefixes functions with underscore. */
 #define C_ABI(x) _ ## x
 #define HIDDEN .private_extern
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+/* MinGW build support */
+#define C_ABI(x) x
+#define HIDDEN .globl
 #else
 #define C_ABI(x) x
 #define HIDDEN .hidden

--- a/crypto/rand/sysrand.c
+++ b/crypto/rand/sysrand.c
@@ -45,8 +45,9 @@ long GFp_sysrand_chunk(void *buf, size_t len);
 
 #include <limits.h>
 
+#ifdef _MSC_VER
 #pragma warning(push, 3)
-
+#endif
 #include <windows.h>
 
 /* #define needed to link in RtlGenRandom(), a.k.a. SystemFunction036.  See the
@@ -56,7 +57,9 @@ long GFp_sysrand_chunk(void *buf, size_t len);
 #include <ntsecapi.h>
 #undef SystemFunction036
 
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 long GFp_sysrand_chunk(void *out, size_t requested) {
   if (requested > ULONG_MAX) {


### PR DESCRIPTION
Hi, i'm using windows gnu x64 rust build. I'm trying to build Rocket.rs but found that `ring` does not compile. So i downloaded it and fixed it. Now all the `ring` tests pass (one ignored?) with `cargo test`. I think this might be useful to others.

I haven't investigated on the "precompiled" conditional branch though. I'm not really sure it's working. Will take another PR if i found another problem.