### PR TITLE
Add utility to map boolean checks to `Result<(), error::Unspecified>`

### DIFF
--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -216,7 +216,7 @@ impl SealingKey {
 pub fn seal_in_place(key: &SealingKey, nonce: &[u8], ad: &[u8],
                      in_out: &mut [u8], out_suffix_capacity: usize)
                      -> Result<usize, error::Unspecified> {
-    try!(error::check(out_suffix_capacity >= key.key.algorithm.tag_len()));
+    check!(out_suffix_capacity >= key.key.algorithm.tag_len());
     let nonce = try!(slice_as_array_ref!(nonce, NONCE_LEN));
     let in_out_len =
         try!(in_out.len().checked_sub(out_suffix_capacity)
@@ -251,7 +251,7 @@ impl Key {
     fn init(&mut self, key_bytes: &[u8]) -> Result<(), error::Unspecified> {
         init::init_once();
 
-        try!(error::check(key_bytes.len() == self.algorithm.key_len()));
+        check!(key_bytes.len() == self.algorithm.key_len());
 
         let ctx_buf_bytes = polyfill::slice::u64_as_u8_mut(&mut self.ctx_buf);
         (self.algorithm.init)(ctx_buf_bytes, key_bytes)
@@ -324,7 +324,8 @@ const NONCE_LEN: usize = 96 / 8;
 /// operations that work on more than 256GB at a time, for all AEADs.
 fn check_per_nonce_max_bytes(in_out_len: usize)
                              -> Result<(), error::Unspecified> {
-    error::check(polyfill::u64_from_usize(in_out_len) < (1u64 << 32) * 64 - 64)
+    check!(polyfill::u64_from_usize(in_out_len) < (1u64 << 32) * 64 - 64);
+    Ok(())
 }
 
 

--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -216,9 +216,7 @@ impl SealingKey {
 pub fn seal_in_place(key: &SealingKey, nonce: &[u8], ad: &[u8],
                      in_out: &mut [u8], out_suffix_capacity: usize)
                      -> Result<usize, error::Unspecified> {
-    if out_suffix_capacity < key.key.algorithm.tag_len() {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(out_suffix_capacity >= key.key.algorithm.tag_len()));
     let nonce = try!(slice_as_array_ref!(nonce, NONCE_LEN));
     let in_out_len =
         try!(in_out.len().checked_sub(out_suffix_capacity)
@@ -253,9 +251,7 @@ impl Key {
     fn init(&mut self, key_bytes: &[u8]) -> Result<(), error::Unspecified> {
         init::init_once();
 
-        if key_bytes.len() != self.algorithm.key_len() {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(key_bytes.len() == self.algorithm.key_len()));
 
         let ctx_buf_bytes = polyfill::slice::u64_as_u8_mut(&mut self.ctx_buf);
         (self.algorithm.init)(ctx_buf_bytes, key_bytes)
@@ -328,10 +324,7 @@ const NONCE_LEN: usize = 96 / 8;
 /// operations that work on more than 256GB at a time, for all AEADs.
 fn check_per_nonce_max_bytes(in_out_len: usize)
                              -> Result<(), error::Unspecified> {
-    if polyfill::u64_from_usize(in_out_len) >= (1u64 << 32) * 64 - 64 {
-        return Err(error::Unspecified);
-    }
-    Ok(())
+    error::check(polyfill::u64_from_usize(in_out_len) < (1u64 << 32) * 64 - 64)
 }
 
 
@@ -638,7 +631,7 @@ mod tests {
         }
         {
             let mut in_out = Vec::from(to_open);
-            assert!(aead::open_in_place(&o_key, &nonce[..1], &ad, prefix_len, 
+            assert!(aead::open_in_place(&o_key, &nonce[..1], &ad, prefix_len,
                                         &mut in_out).is_err());
         }
 

--- a/src/constant_time.rs
+++ b/src/constant_time.rs
@@ -22,9 +22,7 @@ use {c, error};
 /// `a` and `b`.
 pub fn verify_slices_are_equal(a: &[u8], b: &[u8])
                                -> Result<(), error::Unspecified> {
-    if a.len() != b.len() {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(a.len() == b.len()));
     let result = unsafe { GFp_memcmp(a.as_ptr(), b.as_ptr(), a.len()) };
     match result {
         0 => Ok(()),

--- a/src/constant_time.rs
+++ b/src/constant_time.rs
@@ -22,7 +22,7 @@ use {c, error};
 /// `a` and `b`.
 pub fn verify_slices_are_equal(a: &[u8], b: &[u8])
                                -> Result<(), error::Unspecified> {
-    try!(error::check(a.len() == b.len()));
+    check!(a.len() == b.len());
     let result = unsafe { GFp_memcmp(a.as_ptr(), b.as_ptr(), a.len()) };
     match result {
         0 => Ok(()),

--- a/src/ec/ec.rs
+++ b/src/ec/ec.rs
@@ -70,9 +70,7 @@ impl<'a> PrivateKey {
     #[inline(always)]
     pub fn compute_public_key(&self, curve: &Curve, out: &mut [u8])
                               -> Result<(), error::Unspecified> {
-        if out.len() != curve.public_key_len {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(out.len() == curve.public_key_len));
         (curve.public_from_private)(out, self)
     }
 }

--- a/src/ec/ec.rs
+++ b/src/ec/ec.rs
@@ -70,7 +70,7 @@ impl<'a> PrivateKey {
     #[inline(always)]
     pub fn compute_public_key(&self, curve: &Curve, out: &mut [u8])
                               -> Result<(), error::Unspecified> {
-        try!(error::check(out.len() == curve.public_key_len));
+        check!(out.len() == curve.public_key_len);
         (curve.public_from_private)(out, self)
     }
 }

--- a/src/ec/eddsa.rs
+++ b/src/ec/eddsa.rs
@@ -84,15 +84,15 @@ impl<'a> Ed25519KeyPair {
                 slice_as_array_ref!(private_key, SEED_LEN).unwrap();
             let mut public_key_check = [0; PUBLIC_KEY_LEN];
             public_from_private(private_key, &mut public_key_check);
-            try!(error::check(public_key == public_key_check));
+            check!(public_key == public_key_check);
         }
         Ok(pair)
     }
 
     fn from_bytes_unchecked(private_key: &[u8], public_key: &[u8])
                             -> Result<Ed25519KeyPair, error::Unspecified> {
-        try!(error::check(private_key.len() == SEED_LEN));
-        try!(error::check(public_key.len() == PUBLIC_KEY_LEN));
+        check!(private_key.len() == SEED_LEN);
+        check!(public_key.len() == PUBLIC_KEY_LEN);
         let mut pair = Ed25519KeyPair { private_public: [0; KEY_PAIR_LEN] };
         {
             let (pair_private_key, pair_public_key) =
@@ -167,7 +167,7 @@ pub static ED25519: EdDSAParameters = EdDSAParameters {};
 impl signature::VerificationAlgorithm for EdDSAParameters {
     fn verify(&self, public_key: untrusted::Input, msg: untrusted::Input,
               signature: untrusted::Input) -> Result<(), error::Unspecified> {
-        try!(error::check(public_key.len() == PUBLIC_KEY_LEN));
+        check!(public_key.len() == PUBLIC_KEY_LEN);
         let public_key = public_key.as_slice_less_safe();
         let public_key = slice_as_array_ref!(public_key, ELEM_LEN).unwrap();
 
@@ -185,7 +185,7 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
         }));
 
         // Ensure `s` is not too large.
-        try!(error::check((signature_s[SCALAR_LEN - 1] & 0b11100000) == 0));
+        check!((signature_s[SCALAR_LEN - 1] & 0b11100000) == 0);
 
         let mut a = ExtPoint::new_at_infinity();
         try!(bssl::map_result(unsafe {
@@ -203,7 +203,8 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
         };
         let mut r_check = [0u8; ELEM_LEN];
         unsafe { GFp_x25519_ge_tobytes(&mut r_check, &r) };
-        error::check(signature_r == r_check)
+        check!(signature_r == r_check);
+        Ok(())
     }
 }
 

--- a/src/ec/eddsa.rs
+++ b/src/ec/eddsa.rs
@@ -84,21 +84,15 @@ impl<'a> Ed25519KeyPair {
                 slice_as_array_ref!(private_key, SEED_LEN).unwrap();
             let mut public_key_check = [0; PUBLIC_KEY_LEN];
             public_from_private(private_key, &mut public_key_check);
-            if public_key != public_key_check {
-                return Err(error::Unspecified);
-            }
+            try!(error::check(public_key == public_key_check));
         }
         Ok(pair)
     }
 
     fn from_bytes_unchecked(private_key: &[u8], public_key: &[u8])
                             -> Result<Ed25519KeyPair, error::Unspecified> {
-        if private_key.len() != SEED_LEN {
-            return Err(error::Unspecified);
-        }
-        if public_key.len() != PUBLIC_KEY_LEN {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(private_key.len() == SEED_LEN));
+        try!(error::check(public_key.len() == PUBLIC_KEY_LEN));
         let mut pair = Ed25519KeyPair { private_public: [0; KEY_PAIR_LEN] };
         {
             let (pair_private_key, pair_public_key) =
@@ -173,9 +167,7 @@ pub static ED25519: EdDSAParameters = EdDSAParameters {};
 impl signature::VerificationAlgorithm for EdDSAParameters {
     fn verify(&self, public_key: untrusted::Input, msg: untrusted::Input,
               signature: untrusted::Input) -> Result<(), error::Unspecified> {
-        if public_key.len() != PUBLIC_KEY_LEN {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(public_key.len() == PUBLIC_KEY_LEN));
         let public_key = public_key.as_slice_less_safe();
         let public_key = slice_as_array_ref!(public_key, ELEM_LEN).unwrap();
 
@@ -193,9 +185,7 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
         }));
 
         // Ensure `s` is not too large.
-        if (signature_s[SCALAR_LEN - 1] & 0b11100000) != 0 {
-            return Err(error::Unspecified);
-        }
+        try!(error::check((signature_s[SCALAR_LEN - 1] & 0b11100000) == 0));
 
         let mut a = ExtPoint::new_at_infinity();
         try!(bssl::map_result(unsafe {
@@ -213,10 +203,7 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
         };
         let mut r_check = [0u8; ELEM_LEN];
         unsafe { GFp_x25519_ge_tobytes(&mut r_check, &r) };
-        if signature_r != r_check {
-            return Err(error::Unspecified);
-        }
-        Ok(())
+        error::check(signature_r == r_check)
     }
 }
 

--- a/src/ec/suite_b/ops/ops.rs
+++ b/src/ec/suite_b/ops/ops.rs
@@ -413,9 +413,7 @@ fn parse_big_endian_fixed_consttime<M>(
         ops: &CommonOps, bytes: untrusted::Input, allow_zero: AllowZero,
         max_exclusive: &[Limb])
         -> Result<elem::Elem<M, Unencoded>, error::Unspecified> {
-    if bytes.len() != ops.num_limbs * LIMB_BYTES {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(bytes.len() == ops.num_limbs * LIMB_BYTES));
     let mut r = elem::Elem::zero();
     try!(parse_big_endian_in_range_and_pad_consttime(
             bytes, allow_zero, max_exclusive, &mut r.limbs[..ops.num_limbs]));

--- a/src/ec/suite_b/ops/ops.rs
+++ b/src/ec/suite_b/ops/ops.rs
@@ -413,7 +413,7 @@ fn parse_big_endian_fixed_consttime<M>(
         ops: &CommonOps, bytes: untrusted::Input, allow_zero: AllowZero,
         max_exclusive: &[Limb])
         -> Result<elem::Elem<M, Unencoded>, error::Unspecified> {
-    try!(error::check(bytes.len() == ops.num_limbs * LIMB_BYTES));
+    check!(bytes.len() == ops.num_limbs * LIMB_BYTES);
     let mut r = elem::Elem::zero();
     try!(parse_big_endian_in_range_and_pad_consttime(
             bytes, allow_zero, max_exclusive, &mut r.limbs[..ops.num_limbs]));

--- a/src/ec/suite_b/public_key.rs
+++ b/src/ec/suite_b/public_key.rs
@@ -38,9 +38,7 @@ pub fn parse_uncompressed_point(ops: &PublicKeyOps, input: untrusted::Input)
     let (x, y) = try!(input.read_all(error::Unspecified, |input| {
         // The encoding must be 4, which is the encoding for "uncompressed".
         let encoding = try!(input.read_byte());
-        if encoding != 4 {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(encoding == 4));
 
         // NIST SP 800-56A Step 2: "Verify that xQ and yQ are integers in the
         // interval [0, p-1] in the case that q is an odd prime p[.]"

--- a/src/ec/suite_b/public_key.rs
+++ b/src/ec/suite_b/public_key.rs
@@ -38,7 +38,7 @@ pub fn parse_uncompressed_point(ops: &PublicKeyOps, input: untrusted::Input)
     let (x, y) = try!(input.read_all(error::Unspecified, |input| {
         // The encoding must be 4, which is the encoding for "uncompressed".
         let encoding = try!(input.read_byte());
-        try!(error::check(encoding == 4));
+        check!(encoding == 4);
 
         // NIST SP 800-56A Step 2: "Verify that xQ and yQ are integers in the
         // interval [0, p-1] in the case that q is an odd prime p[.]"

--- a/src/ec/suite_b/suite_b.rs
+++ b/src/ec/suite_b/suite_b.rs
@@ -145,11 +145,7 @@ fn verify_affine_point_is_on_the_curve_scaled(
     ops.elem_mul(&mut rhs, x);
     ops.elem_add(&mut rhs, b_scaled);
 
-    if !ops.elems_are_equal(&lhs, &rhs) {
-        return Err(error::Unspecified);
-    }
-
-    Ok(())
+    error::check(ops.elems_are_equal(&lhs, &rhs))
 }
 
 

--- a/src/ec/suite_b/suite_b.rs
+++ b/src/ec/suite_b/suite_b.rs
@@ -145,7 +145,9 @@ fn verify_affine_point_is_on_the_curve_scaled(
     ops.elem_mul(&mut rhs, x);
     ops.elem_add(&mut rhs, b_scaled);
 
-    error::check(ops.elems_are_equal(&lhs, &rhs))
+    check!(ops.elems_are_equal(&lhs, &rhs));
+
+    Ok(())
 }
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -102,20 +102,23 @@ impl From<untrusted::EndOfInput> for Unspecified {
     fn from(_: untrusted::EndOfInput) -> Self { Unspecified }
 }
 
-/// Map a boolean condition to a `Result<(), ring::error::Unspecified>`.
+/// Map a boolean condition to a `Result<(), ring::error::Unspecified>`,
+/// returning early if it is false.
 ///
-/// The `check` function is meant for use in functions with return type
+/// The `check` macro is meant for use in functions with return type
 /// `Result<T, ring::error::Unspecified>`. The two motivating use cases are (a)
 /// such functions whose purpose is to check a boolean condition (e.g.
 /// `ring::signature::VerificationAlgorithm::verify()`) and (b) those which
 /// must return early with `Err(ring::error::Unspecified)` if certain
-/// intermediate conditions fail to hold. By composing with the standard `try!`
-/// macro, we can compactly represent such early returns.
-#[inline(always)]
-pub fn check(cond: bool) -> Result<(), Unspecified> {
-    if cond {
-        Ok(())
-    } else {
-        Err(Unspecified)
+/// intermediate conditions fail to hold.
+macro_rules! check {
+    ($cond:expr) => {
+        {
+            use error;
+
+            if !$cond {
+                return Err(error::Unspecified);
+            }
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,3 +101,21 @@ impl std::error::Error for Unspecified {
 impl From<untrusted::EndOfInput> for Unspecified {
     fn from(_: untrusted::EndOfInput) -> Self { Unspecified }
 }
+
+/// Map a boolean condition to a `Result<(), ring::error::Unspecified>`.
+///
+/// The `check` function is meant for use in functions with return type
+/// `Result<T, ring::error::Unspecified>`. The two motivating use cases are (a)
+/// such functions whose purpose is to check a boolean condition (e.g.
+/// `ring::signature::VerificationAlgorithm::verify()`) and (b) those which
+/// must return early with `Err(ring::error::Unspecified)` if certain
+/// intermediate conditions fail to hold. By composing with the standard `try!`
+/// macro, we can compactly represent such early returns.
+#[inline(always)]
+pub fn check(cond: bool) -> Result<(), Unspecified> {
+    if cond {
+        Ok(())
+    } else {
+        Err(Unspecified)
+    }
+}

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -187,7 +187,7 @@ impl SigningKey {
     pub fn generate_serializable(digest_alg: &'static digest::Algorithm,
                                  rng: &rand::SecureRandom, key_bytes: &mut [u8])
                     -> Result<SigningKey, error::Unspecified> {
-        try!(error::check(key_bytes.len() == recommended_key_len(digest_alg)));
+        check!(key_bytes.len() == recommended_key_len(digest_alg));
         try!(rng.fill(key_bytes));
         Ok(SigningKey::new(digest_alg, key_bytes))
     }

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -187,9 +187,7 @@ impl SigningKey {
     pub fn generate_serializable(digest_alg: &'static digest::Algorithm,
                                  rng: &rand::SecureRandom, key_bytes: &mut [u8])
                     -> Result<SigningKey, error::Unspecified> {
-        if key_bytes.len() != recommended_key_len(digest_alg) {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(key_bytes.len() == recommended_key_len(digest_alg)));
         try!(rng.fill(key_bytes));
         Ok(SigningKey::new(digest_alg, key_bytes))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,11 @@ mod arithmetic;
 mod bssl;
 
 #[macro_use]
+pub mod error;
+
+#[macro_use]
 mod polyfill;
+
 
 #[path = "aead/aead.rs"]
 pub mod aead;
@@ -146,7 +150,6 @@ pub mod digest;
 #[path = "ec/ec.rs"]
 mod ec;
 
-pub mod error;
 pub mod hkdf;
 pub mod hmac;
 mod init;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -113,8 +113,7 @@ pub fn parse_big_endian_in_range_partially_reduced_and_pad_consttime(
     try!(parse_big_endian_and_pad_consttime(input, result));
     limbs_reduce_once_constant_time(result, m);
     if allow_zero != AllowZero::Yes {
-        try!(error::check(limbs_are_zero_constant_time(&result) ==
-                          LimbMask::False));
+        check!(limbs_are_zero_constant_time(&result) == LimbMask::False);
     }
     Ok(())
 }
@@ -131,12 +130,11 @@ pub fn parse_big_endian_in_range_and_pad_consttime(
         input: untrusted::Input, allow_zero: AllowZero, max_exclusive: &[Limb],
         result: &mut [Limb]) -> Result<(), error::Unspecified> {
     try!(parse_big_endian_and_pad_consttime(input, result));
-    try!(error::check(limbs_less_than_limbs_consttime(&result, max_exclusive) ==
-                      LimbMask::True));
+    check!(limbs_less_than_limbs_consttime(&result, max_exclusive) ==
+           LimbMask::True);
 
     if allow_zero != AllowZero::Yes {
-        try!(error::check(limbs_are_zero_constant_time(&result) ==
-                          LimbMask::False));
+        check!(limbs_are_zero_constant_time(&result) == LimbMask::False);
     }
     Ok(())
 }
@@ -147,7 +145,7 @@ pub fn parse_big_endian_in_range_and_pad_consttime(
 pub fn parse_big_endian_and_pad_consttime(
         input: untrusted::Input, result: &mut [Limb])
         -> Result<(), error::Unspecified> {
-    try!(error::check(!input.is_empty()));
+    check!(!input.is_empty());
 
     // `bytes_in_current_limb` is the number of bytes in the current limb.
     // It will be `LIMB_BYTES` for all limbs except maybe the highest-order
@@ -160,7 +158,7 @@ pub fn parse_big_endian_and_pad_consttime(
     let num_encoded_limbs =
         (input.len() / LIMB_BYTES) +
         (if bytes_in_current_limb == LIMB_BYTES { 0 } else { 1 });
-    try!(error::check(num_encoded_limbs <= result.len()));
+    check!(num_encoded_limbs <= result.len());
 
     for r in &mut result[..] {
         *r = 0;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -113,9 +113,8 @@ pub fn parse_big_endian_in_range_partially_reduced_and_pad_consttime(
     try!(parse_big_endian_and_pad_consttime(input, result));
     limbs_reduce_once_constant_time(result, m);
     if allow_zero != AllowZero::Yes {
-        if limbs_are_zero_constant_time(&result) != LimbMask::False {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(limbs_are_zero_constant_time(&result) ==
+                          LimbMask::False));
     }
     Ok(())
 }
@@ -132,14 +131,12 @@ pub fn parse_big_endian_in_range_and_pad_consttime(
         input: untrusted::Input, allow_zero: AllowZero, max_exclusive: &[Limb],
         result: &mut [Limb]) -> Result<(), error::Unspecified> {
     try!(parse_big_endian_and_pad_consttime(input, result));
-    if limbs_less_than_limbs_consttime(&result, max_exclusive) !=
-            LimbMask::True {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(limbs_less_than_limbs_consttime(&result, max_exclusive) ==
+                      LimbMask::True));
+
     if allow_zero != AllowZero::Yes {
-        if limbs_are_zero_constant_time(&result) != LimbMask::False {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(limbs_are_zero_constant_time(&result) ==
+                          LimbMask::False));
     }
     Ok(())
 }
@@ -150,9 +147,7 @@ pub fn parse_big_endian_in_range_and_pad_consttime(
 pub fn parse_big_endian_and_pad_consttime(
         input: untrusted::Input, result: &mut [Limb])
         -> Result<(), error::Unspecified> {
-    if input.is_empty() {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(!input.is_empty()));
 
     // `bytes_in_current_limb` is the number of bytes in the current limb.
     // It will be `LIMB_BYTES` for all limbs except maybe the highest-order
@@ -165,9 +160,7 @@ pub fn parse_big_endian_and_pad_consttime(
     let num_encoded_limbs =
         (input.len() / LIMB_BYTES) +
         (if bytes_in_current_limb == LIMB_BYTES { 0 } else { 1 });
-    if num_encoded_limbs > result.len() {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(num_encoded_limbs <= result.len()));
 
     for r in &mut result[..] {
         *r = 0;

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -213,9 +213,7 @@ fn derive_block(secret: &hmac::SigningKey, iterations: u32, salt: &[u8],
 pub fn verify(prf: &'static PRF, iterations: u32, salt: &[u8],
               secret: &[u8], previously_derived: &[u8])
               -> Result<(), error::Unspecified> {
-    if previously_derived.is_empty() {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(!previously_derived.is_empty()));
 
     let mut derived_buf = [0u8; digest::MAX_OUTPUT_LEN];
 
@@ -245,11 +243,7 @@ pub fn verify(prf: &'static PRF, iterations: u32, salt: &[u8],
         matches &= current_block_matches;
     }
 
-    if matches == 0 {
-        return Err(error::Unspecified);
-    }
-
-    Ok(())
+    error::check(matches != 0)
 }
 
 /// A PRF algorithm for use with `derive` and `verify`.

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -213,7 +213,7 @@ fn derive_block(secret: &hmac::SigningKey, iterations: u32, salt: &[u8],
 pub fn verify(prf: &'static PRF, iterations: u32, salt: &[u8],
               secret: &[u8], previously_derived: &[u8])
               -> Result<(), error::Unspecified> {
-    try!(error::check(!previously_derived.is_empty()));
+    check!(!previously_derived.is_empty());
 
     let mut derived_buf = [0u8; digest::MAX_OUTPUT_LEN];
 
@@ -243,7 +243,9 @@ pub fn verify(prf: &'static PRF, iterations: u32, salt: &[u8],
         matches &= current_block_matches;
     }
 
-    error::check(matches != 0)
+    check!(matches != 0);
+
+    Ok(())
 }
 
 /// A PRF algorithm for use with `derive` and `verify`.

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -145,7 +145,7 @@ macro_rules! slice_as_array_ref {
 
             fn slice_as_array_ref<T>(slice: &[T])
                                      -> Result<&[T; $len], error::Unspecified> {
-                try!(error::check(slice.len() == $len));
+                check!(slice.len() == $len);
                 Ok(unsafe {
                     &*(slice.as_ptr() as *const [T; $len])
                 })
@@ -165,7 +165,8 @@ macro_rules! slice_as_array_ref_mut {
             fn slice_as_array_ref<T>(slice: &mut [T])
                                      -> Result<&mut [T; $len],
                                                error::Unspecified> {
-                try!(error::check(slice.len() == $len));                                                        Ok(unsafe {
+                check!(slice.len() == $len);
+                Ok(unsafe {
                     &mut *(slice.as_mut_ptr() as *mut [T; $len])
                 })
             }

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -145,9 +145,7 @@ macro_rules! slice_as_array_ref {
 
             fn slice_as_array_ref<T>(slice: &[T])
                                      -> Result<&[T; $len], error::Unspecified> {
-                if slice.len() != $len {
-                    return Err(error::Unspecified);
-                }
+                try!(error::check(slice.len() == $len));
                 Ok(unsafe {
                     &*(slice.as_ptr() as *const [T; $len])
                 })
@@ -167,10 +165,7 @@ macro_rules! slice_as_array_ref_mut {
             fn slice_as_array_ref<T>(slice: &mut [T])
                                      -> Result<&mut [T; $len],
                                                error::Unspecified> {
-                if slice.len() != $len {
-                    return Err(error::Unspecified);
-                }
-                Ok(unsafe {
+                try!(error::check(slice.len() == $len));                                                        Ok(unsafe {
                     &mut *(slice.as_mut_ptr() as *mut [T; $len])
                 })
             }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -134,9 +134,7 @@ mod sysrand {
                 super::GFp_sysrand_chunk(dest[read_len..].as_mut_ptr(),
                                          dest.len() - read_len)
             };
-            if r < 0 {
-                return Err(error::Unspecified);
-            }
+            try!(error::check(r >= 0));
             // XXX: If r == 0 then this is a busy wait loop waiting for the
             // kernel entropy pool to be initialized.
             read_len += r as usize;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -134,7 +134,7 @@ mod sysrand {
                 super::GFp_sysrand_chunk(dest[read_len..].as_mut_ptr(),
                                          dest.len() - read_len)
             };
-            try!(error::check(r >= 0));
+            check!(r >= 0);
             // XXX: If r == 0 then this is a busy wait loop waiting for the
             // kernel entropy pool to be initialized.
             read_len += r as usize;

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -75,26 +75,20 @@ impl Positive {
                          -> Result<Positive, error::Unspecified> {
         // Reject leading zeros. Also reject the value zero ([0]) because zero
         // isn't positive.
-        if untrusted::Reader::new(input).peek(0) {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(!untrusted::Reader::new(input).peek(0)));
         Self::from_be_bytes_padded(input)
     }
 
     pub fn from_be_bytes_padded(input: untrusted::Input)
                                 -> Result<Positive, error::Unspecified> {
         // Reject empty inputs.
-        if input.is_empty() {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(!input.is_empty()));
         let mut r = try!(Nonnegative::zero());
         try!(bssl::map_result(unsafe {
             GFp_BN_bin2bn(input.as_slice_less_safe().as_ptr(), input.len(),
                           r.as_mut_ref())
         }));
-        if r.is_zero() {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(!r.is_zero()));
         Ok(Positive(r))
     }
 
@@ -139,16 +133,10 @@ impl OddPositive {
     pub fn into_public_exponent(self)
                                 -> Result<PublicExponent, error::Unspecified> {
         let bits = self.bit_length();
-        if bits < bits::BitLength::from_usize_bits(2) {
-            return Err(error::Unspecified);
-        }
-        if bits > PUBLIC_EXPONENT_MAX_BITS {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(bits >= bits::BitLength::from_usize_bits(2)));
+        try!(error::check(bits <= PUBLIC_EXPONENT_MAX_BITS));
         let value = unsafe { GFp_BN_get_positive_u64(self.as_ref()) };
-        if value == 0 {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(value != 0));
         Ok(PublicExponent(value))
     }
 }
@@ -200,9 +188,8 @@ unsafe impl<M> Sync for Modulus<M> {}
 impl<M> Modulus<M> {
     fn new(value: OddPositive) -> Result<Self, error::Unspecified> {
         // A `Modulus` must be larger than 1.
-        if value.bit_length() < bits::BitLength::from_usize_bits(2) {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(value.bit_length() >=
+                          bits::BitLength::from_usize_bits(2)));
         let n0 = unsafe { GFp_bn_mont_n0(value.as_ref()) };
         Ok(Modulus {
             value: value,
@@ -654,10 +641,7 @@ impl Nonnegative {
     fn verify_less_than(&self, other: &Self)
                         -> Result<(), error::Unspecified> {
         let r = unsafe { GFp_BN_ucmp(self.as_ref(), other.as_ref()) };
-        if !(r < 0) {
-            return Err(error::Unspecified);
-        }
-        Ok(())
+        error::check(r < 0)
     }
 
     fn randomize(&mut self, m: &BIGNUM, rng: &rand::SecureRandom)
@@ -684,9 +668,7 @@ impl Nonnegative {
 
     fn into_odd_positive(self) -> Result<OddPositive, error::Unspecified> {
         let is_odd = unsafe { GFp_BN_is_odd(self.as_ref()) };
-        if is_odd == 0 {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(is_odd != 0));
         Ok(OddPositive(Positive(self)))
     }
 

--- a/src/rsa/padding.rs
+++ b/src/rsa/padding.rs
@@ -82,7 +82,8 @@ impl RSAVerification for PKCS1 {
         let calculated =
             &mut calculated[..mod_bits.as_usize_bytes_rounded_up()];
         pkcs1_encode(&self, m_hash, calculated);
-        error::check(m.skip_to_end() == polyfill::ref_from_mut_ref(calculated))
+        check!(m.skip_to_end() == polyfill::ref_from_mut_ref(calculated));
+        Ok(())
     }
 }
 
@@ -275,7 +276,7 @@ impl RSAVerification for PSS {
         // strip before we start the PSS decoding steps which is an artifact of
         // the `Verification` interface.
         if metrics.top_byte_mask == 0xff {
-            try!(error::check(try!(m.read_byte()) == 0));
+            check!(try!(m.read_byte()) == 0);
         };
         let em = m;
 
@@ -291,7 +292,7 @@ impl RSAVerification for PSS {
         let h_hash = try!(em.skip_and_get_input(metrics.h_len));
 
         // Step 4.
-        try!(error::check(try!(em.read_byte()) == 0xbc));
+        check!(try!(em.read_byte()) == 0xbc);
 
         // Step 7.
         let mut db = [0u8; PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN];
@@ -302,7 +303,7 @@ impl RSAVerification for PSS {
         try!(masked_db.read_all(error::Unspecified, |masked_bytes| {
             // Step 6. Check the top bits of first byte are zero.
             let b = try!(masked_bytes.read_byte());
-            try!(error::check(b & !metrics.top_byte_mask == 0));
+            check!(b & !metrics.top_byte_mask == 0);
             db[0] ^= b;
 
             // Step 8.
@@ -318,9 +319,9 @@ impl RSAVerification for PSS {
         // Step 10.
         let ps_len = metrics.ps_len;
         for i in 0..ps_len {
-            try!(error::check(db[i] == 0));
+            check!(db[i] == 0);
         }
-        try!(error::check(db[metrics.ps_len] == 1));
+        check!(db[metrics.ps_len] == 1);
 
         // Step 11.
         let salt = &db[(db.len() - metrics.s_len)..];
@@ -329,7 +330,9 @@ impl RSAVerification for PSS {
         let h_prime = pss_digest(self.digest_alg, m_hash, salt);
 
         // Step 14.
-        error::check(h_hash == h_prime.as_ref())
+        check!(h_hash == h_prime.as_ref());
+
+        Ok(())
     }
 }
 

--- a/src/rsa/padding.rs
+++ b/src/rsa/padding.rs
@@ -82,10 +82,7 @@ impl RSAVerification for PKCS1 {
         let calculated =
             &mut calculated[..mod_bits.as_usize_bytes_rounded_up()];
         pkcs1_encode(&self, m_hash, calculated);
-        if m.skip_to_end() != polyfill::ref_from_mut_ref(calculated) {
-            return Err(error::Unspecified);
-        }
-        Ok(())
+        error::check(m.skip_to_end() == polyfill::ref_from_mut_ref(calculated))
     }
 }
 
@@ -278,9 +275,7 @@ impl RSAVerification for PSS {
         // strip before we start the PSS decoding steps which is an artifact of
         // the `Verification` interface.
         if metrics.top_byte_mask == 0xff {
-            if try!(m.read_byte()) != 0 {
-                return Err(error::Unspecified);
-            }
+            try!(error::check(try!(m.read_byte()) == 0));
         };
         let em = m;
 
@@ -296,9 +291,7 @@ impl RSAVerification for PSS {
         let h_hash = try!(em.skip_and_get_input(metrics.h_len));
 
         // Step 4.
-        if try!(em.read_byte()) != 0xbc {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(try!(em.read_byte()) == 0xbc));
 
         // Step 7.
         let mut db = [0u8; PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN];
@@ -309,9 +302,7 @@ impl RSAVerification for PSS {
         try!(masked_db.read_all(error::Unspecified, |masked_bytes| {
             // Step 6. Check the top bits of first byte are zero.
             let b = try!(masked_bytes.read_byte());
-            if b & !metrics.top_byte_mask != 0 {
-                return Err(error::Unspecified);
-            }
+            try!(error::check(b & !metrics.top_byte_mask == 0));
             db[0] ^= b;
 
             // Step 8.
@@ -327,13 +318,9 @@ impl RSAVerification for PSS {
         // Step 10.
         let ps_len = metrics.ps_len;
         for i in 0..ps_len {
-            if db[i] != 0 {
-                return Err(error::Unspecified);
-            }
+            try!(error::check(db[i] == 0));
         }
-        if db[metrics.ps_len] != 1 {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(db[metrics.ps_len] == 1));
 
         // Step 11.
         let salt = &db[(db.len() - metrics.s_len)..];
@@ -342,11 +329,7 @@ impl RSAVerification for PSS {
         let h_prime = pss_digest(self.digest_alg, m_hash, salt);
 
         // Step 14.
-        if h_hash != h_prime.as_ref() {
-            return Err(error::Unspecified);
-        }
-
-        Ok(())
+        error::check(h_hash == h_prime.as_ref())
     }
 }
 

--- a/src/rsa/rsa.rs
+++ b/src/rsa/rsa.rs
@@ -101,8 +101,8 @@ fn check_public_modulus_and_exponent(
     let n_bits_rounded_up =
         try!(bits::BitLength::from_usize_bytes(
             n_bits.as_usize_bytes_rounded_up()));
-    try!(error::check(n_bits_rounded_up >= n_min_bits));
-    try!(error::check(n_bits <= n_max_bits));
+    check!(n_bits_rounded_up >= n_min_bits);
+    check!(n_bits <= n_max_bits);
 
     // Step 2 / Step b. NIST SP800-89 defers to FIPS 186-3, which requires
     // `e > 2**16`, so the requirement is met if and only if `e_min_bits >= 17`.
@@ -110,7 +110,7 @@ fn check_public_modulus_and_exponent(
     // compatibility.
     debug_assert!(e_min_bits >= bits::BitLength::from_usize_bits(2));
     let e_bits = e.bit_length();
-    try!(error::check(e_bits >= e_min_bits));
+    check!(e_bits >= e_min_bits);
 
     // Only small public exponents are supported.
     let e = try!(e.into_public_exponent());

--- a/src/rsa/rsa.rs
+++ b/src/rsa/rsa.rs
@@ -101,12 +101,8 @@ fn check_public_modulus_and_exponent(
     let n_bits_rounded_up =
         try!(bits::BitLength::from_usize_bytes(
             n_bits.as_usize_bytes_rounded_up()));
-    if n_bits_rounded_up < n_min_bits {
-        return Err(error::Unspecified);
-    }
-    if n_bits > n_max_bits {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(n_bits_rounded_up >= n_min_bits));
+    try!(error::check(n_bits <= n_max_bits));
 
     // Step 2 / Step b. NIST SP800-89 defers to FIPS 186-3, which requires
     // `e > 2**16`, so the requirement is met if and only if `e_min_bits >= 17`.
@@ -114,9 +110,7 @@ fn check_public_modulus_and_exponent(
     // compatibility.
     debug_assert!(e_min_bits >= bits::BitLength::from_usize_bits(2));
     let e_bits = e.bit_length();
-    if e_bits < e_min_bits {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(e_bits >= e_min_bits));
 
     // Only small public exponents are supported.
     let e = try!(e.into_public_exponent());

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -122,7 +122,7 @@ impl RSAKeyPair {
         input.read_all(error::Unspecified, |input| {
             der::nested(input, der::Tag::Sequence, error::Unspecified, |input| {
                 let version = try!(der::small_nonnegative_integer(input));
-                try!(error::check(version == 0));
+                check!(version == 0);
                 let n = try!(bigint::Positive::from_der(input));
                 let e = try!(bigint::Positive::from_der(input));
                 let d = try!(bigint::Positive::from_der(input));
@@ -180,7 +180,7 @@ impl RSAKeyPair {
                 //
                 // Second, stop if `p > 2**(nBits/2) - 1`.
                 let half_n_bits = n_bits.half_rounded_up();
-                try!(error::check(p.bit_length() == half_n_bits));
+                check!(p.bit_length() == half_n_bits);
                 let p = try!(p.into_odd_positive());
 
                 // TODO: Step 5.d: Verify GCD(p - 1, e) == 1.
@@ -192,7 +192,7 @@ impl RSAKeyPair {
                 // TODO: First, stop if `q < (√2) * 2**((nBits/2) - 1)`.
                 //
                 // Second, stop if `q > 2**(nBits/2) - 1`.
-                try!(error::check(p.bit_length() == q.bit_length()));
+                check!(p.bit_length() == q.bit_length());
                 let q = try!(q.into_odd_positive());
 
                 // TODO: Step 5.h: Verify GCD(p - 1, e) == 1.
@@ -237,7 +237,7 @@ impl RSAKeyPair {
                     };
                     let min_pq_bitlen_diff = try!(half_n_bits.try_sub(
                             bits::BitLength::from_usize_bits(100)));
-                    try!(error::check(p_minus_q_bits > min_pq_bitlen_diff));
+                    check!(p_minus_q_bits > min_pq_bitlen_diff);
                 }
 
                 // 6.4.1.4.3 - Step 3.a (out of order).
@@ -258,7 +258,7 @@ impl RSAKeyPair {
                 };
                 let pq_mod_n =
                     try!(bigint::elem_mul(&q_mod_n, p_mod_n, &n));
-                try!(error::check(pq_mod_n.is_zero()));
+                check!(pq_mod_n.is_zero());
 
                 // 6.4.1.4.3/6.4.1.2.1 - Step 6.
 
@@ -268,7 +268,7 @@ impl RSAKeyPair {
                 // has a bit length of half_n_bits + 1, this check gives us
                 // 2**half_n_bits <= d, and knowing d is odd makes the
                 // inequality strict.
-                try!(error::check(half_n_bits < d.bit_length()));
+                check!(half_n_bits < d.bit_length());
 
                 // XXX: This check should be `d < LCM(p - 1, q - 1)`, but we
                 // don't have a good way of calculating LCM, so it is omitted,
@@ -308,7 +308,7 @@ impl RSAKeyPair {
                 };
                 let qInv_times_q_mod_p =
                     try!(bigint::elem_mul(&qInv, q_mod_p, &p.modulus));
-                try!(error::check(qInv_times_q_mod_p.is_one()));
+                check!(qInv_times_q_mod_p.is_one());
 
                 // Step 7.b (out of order). Same proof as for `dP < p - 1`.
                 let q = try!(PrivatePrime::new(q, dQ));
@@ -502,8 +502,7 @@ impl RSASigningState {
                 rng: &rand::SecureRandom, msg: &[u8], signature: &mut [u8])
                 -> Result<(), error::Unspecified> {
         let mod_bits = self.key_pair.n_bits;
-        try!(error::check(signature.len() ==
-                          mod_bits.as_usize_bytes_rounded_up()));
+        check!(signature.len() == mod_bits.as_usize_bytes_rounded_up());
 
         let &mut RSASigningState {
             key_pair: ref key,

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -122,9 +122,7 @@ impl RSAKeyPair {
         input.read_all(error::Unspecified, |input| {
             der::nested(input, der::Tag::Sequence, error::Unspecified, |input| {
                 let version = try!(der::small_nonnegative_integer(input));
-                if version != 0 {
-                    return Err(error::Unspecified);
-                }
+                try!(error::check(version == 0));
                 let n = try!(bigint::Positive::from_der(input));
                 let e = try!(bigint::Positive::from_der(input));
                 let d = try!(bigint::Positive::from_der(input));
@@ -182,9 +180,7 @@ impl RSAKeyPair {
                 //
                 // Second, stop if `p > 2**(nBits/2) - 1`.
                 let half_n_bits = n_bits.half_rounded_up();
-                if p.bit_length() != half_n_bits {
-                    return Err(error::Unspecified);
-                }
+                try!(error::check(p.bit_length() == half_n_bits));
                 let p = try!(p.into_odd_positive());
 
                 // TODO: Step 5.d: Verify GCD(p - 1, e) == 1.
@@ -196,9 +192,7 @@ impl RSAKeyPair {
                 // TODO: First, stop if `q < (√2) * 2**((nBits/2) - 1)`.
                 //
                 // Second, stop if `q > 2**(nBits/2) - 1`.
-                if p.bit_length() != q.bit_length() {
-                    return Err(error::Unspecified);
-                }
+                try!(error::check(p.bit_length() == q.bit_length()));
                 let q = try!(q.into_odd_positive());
 
                 // TODO: Step 5.h: Verify GCD(p - 1, e) == 1.
@@ -243,9 +237,7 @@ impl RSAKeyPair {
                     };
                     let min_pq_bitlen_diff = try!(half_n_bits.try_sub(
                             bits::BitLength::from_usize_bits(100)));
-                    if p_minus_q_bits <= min_pq_bitlen_diff {
-                        return Err(error::Unspecified);
-                    }
+                    try!(error::check(p_minus_q_bits > min_pq_bitlen_diff));
                 }
 
                 // 6.4.1.4.3 - Step 3.a (out of order).
@@ -266,9 +258,7 @@ impl RSAKeyPair {
                 };
                 let pq_mod_n =
                     try!(bigint::elem_mul(&q_mod_n, p_mod_n, &n));
-                if !pq_mod_n.is_zero() {
-                    return Err(error::Unspecified);
-                }
+                try!(error::check(pq_mod_n.is_zero()));
 
                 // 6.4.1.4.3/6.4.1.2.1 - Step 6.
 
@@ -278,9 +268,8 @@ impl RSAKeyPair {
                 // has a bit length of half_n_bits + 1, this check gives us
                 // 2**half_n_bits <= d, and knowing d is odd makes the
                 // inequality strict.
-                if !(half_n_bits < d.bit_length()) {
-                    return Err(error::Unspecified);
-                }
+                try!(error::check(half_n_bits < d.bit_length()));
+
                 // XXX: This check should be `d < LCM(p - 1, q - 1)`, but we
                 // don't have a good way of calculating LCM, so it is omitted,
                 // as explained above.
@@ -319,9 +308,7 @@ impl RSAKeyPair {
                 };
                 let qInv_times_q_mod_p =
                     try!(bigint::elem_mul(&qInv, q_mod_p, &p.modulus));
-                if !qInv_times_q_mod_p.is_one() {
-                    return Err(error::Unspecified);
-                }
+                try!(error::check(qInv_times_q_mod_p.is_one()));
 
                 // Step 7.b (out of order). Same proof as for `dP < p - 1`.
                 let q = try!(PrivatePrime::new(q, dQ));
@@ -515,9 +502,8 @@ impl RSASigningState {
                 rng: &rand::SecureRandom, msg: &[u8], signature: &mut [u8])
                 -> Result<(), error::Unspecified> {
         let mod_bits = self.key_pair.n_bits;
-        if signature.len() != mod_bits.as_usize_bytes_rounded_up() {
-            return Err(error::Unspecified);
-        }
+        try!(error::check(signature.len() ==
+                          mod_bits.as_usize_bytes_rounded_up()));
 
         let &mut RSASigningState {
             key_pair: ref key,

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -129,7 +129,7 @@ pub fn verify_rsa(params: &RSAParameters,
     let n = try!(n.into_modulus::<N>());
 
     // The signature must be the same length as the modulus, in bytes.
-    try!(error::check(signature.len() == n_bits.as_usize_bytes_rounded_up()));
+    check!(signature.len() == n_bits.as_usize_bytes_rounded_up());
 
     // RFC 8017 Section 5.2.2: RSAVP1.
 

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -129,9 +129,7 @@ pub fn verify_rsa(params: &RSAParameters,
     let n = try!(n.into_modulus::<N>());
 
     // The signature must be the same length as the modulus, in bytes.
-    if signature.len() != n_bits.as_usize_bytes_rounded_up() {
-        return Err(error::Unspecified);
-    }
+    try!(error::check(signature.len() == n_bits.as_usize_bytes_rounded_up()));
 
     // RFC 8017 Section 5.2.2: RSAVP1.
 


### PR DESCRIPTION
Picking up from be4e25ad7b43d27e37082fc84b95e042535c9a44.

I'm experimenting a bit with whether this should be a function that simply does the mapping from `bool` to `Result<(), error::Unspecified>`, or if it should actually be a _macro_ that always performs an early return itself. The latter might result in nicer looking code, but I don't want to bikeshed it too much, so I'm starting with the function implementation, as it seems a bit more idiomatic to use `try!`.

FYI, for now, I'm going to push a bunch of separate commits that I expect to be squashed/dropped.