### PR TITLE
Port Curve25519 encoding operations

### DIFF
--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -30,10 +30,12 @@
 
 
 /* Prevent -Wmissing-prototypes warnings. */
+void GFp_fe_invert(fe out, const fe z);
+uint8_t GFp_fe_isnegative(const fe f);
+void GFp_fe_mul(fe h, const fe f, const fe g);
+void GFp_fe_tobytes(uint8_t *s, const fe h);
 void GFp_ge_double_scalarmult_vartime(ge_p2 *r, const uint8_t *a,
                                       const ge_p3 *A, const uint8_t *b);
-void GFp_ge_p3_tobytes(uint8_t *s, const ge_p3 *h);
-void GFp_x25519_ge_tobytes(uint8_t *s, const ge_p2 *h);
 int GFp_x25519_ge_frombytes_vartime(ge_p3 *h, const uint8_t *s);
 void GFp_x25519_ge_scalarmult_base(ge_p3 *h, const uint8_t a[32]);
 void GFp_x25519_sc_muladd(uint8_t *s, const uint8_t *a, const uint8_t *b,
@@ -131,7 +133,7 @@ static void fe_frombytes(fe h, const uint8_t *s) {
  *
  *   Have q+2^(-255)x = 2^(-255)(h + 19 2^(-25) h9 + 2^(-1))
  *   so floor(2^(-255)(h + 19 2^(-25) h9 + 2^(-1))) = q. */
-static void fe_tobytes(uint8_t *s, const fe h) {
+void GFp_fe_tobytes(uint8_t *s, const fe h) {
   int32_t h0 = h[0];
   int32_t h1 = h[1];
   int32_t h2 = h[2];
@@ -284,7 +286,7 @@ static void fe_sub(fe h, const fe f, const fe g) {
  * Can get away with 11 carries, but then data flow is much deeper.
  *
  * With tighter constraints on inputs can squeeze carries into int32. */
-static void fe_mul(fe h, const fe f, const fe g) {
+void GFp_fe_mul(fe h, const fe f, const fe g) {
   int32_t f0 = f[0];
   int32_t f1 = f[1];
   int32_t f2 = f[2];
@@ -507,9 +509,7 @@ static void fe_mul(fe h, const fe f, const fe g) {
  *    |f| bounded by 1.65*2^26,1.65*2^25,1.65*2^26,1.65*2^25,etc.
  *
  * Postconditions:
- *    |h| bounded by 1.01*2^25,1.01*2^24,1.01*2^25,1.01*2^24,etc.
- *
- * See fe_mul.c for discussion of implementation strategy. */
+ *    |h| bounded by 1.01*2^25,1.01*2^24,1.01*2^25,1.01*2^24,etc. */
 static void fe_sq(fe h, const fe f) {
   int32_t f0 = f[0];
   int32_t f1 = f[1];
@@ -641,7 +641,7 @@ static void fe_sq(fe h, const fe f) {
   h[9] = (int32_t)h9;
 }
 
-static void fe_invert(fe out, const fe z) {
+void GFp_fe_invert(fe out, const fe z) {
   fe t0;
   fe t1;
   fe t2;
@@ -653,50 +653,50 @@ static void fe_invert(fe out, const fe z) {
   for (i = 1; i < 2; ++i) {
     fe_sq(t1, t1);
   }
-  fe_mul(t1, z, t1);
-  fe_mul(t0, t0, t1);
+  GFp_fe_mul(t1, z, t1);
+  GFp_fe_mul(t0, t0, t1);
   fe_sq(t2, t0);
-  fe_mul(t1, t1, t2);
+  GFp_fe_mul(t1, t1, t2);
   fe_sq(t2, t1);
   for (i = 1; i < 5; ++i) {
     fe_sq(t2, t2);
   }
-  fe_mul(t1, t2, t1);
+  GFp_fe_mul(t1, t2, t1);
   fe_sq(t2, t1);
   for (i = 1; i < 10; ++i) {
     fe_sq(t2, t2);
   }
-  fe_mul(t2, t2, t1);
+  GFp_fe_mul(t2, t2, t1);
   fe_sq(t3, t2);
   for (i = 1; i < 20; ++i) {
     fe_sq(t3, t3);
   }
-  fe_mul(t2, t3, t2);
+  GFp_fe_mul(t2, t3, t2);
   fe_sq(t2, t2);
   for (i = 1; i < 10; ++i) {
     fe_sq(t2, t2);
   }
-  fe_mul(t1, t2, t1);
+  GFp_fe_mul(t1, t2, t1);
   fe_sq(t2, t1);
   for (i = 1; i < 50; ++i) {
     fe_sq(t2, t2);
   }
-  fe_mul(t2, t2, t1);
+  GFp_fe_mul(t2, t2, t1);
   fe_sq(t3, t2);
   for (i = 1; i < 100; ++i) {
     fe_sq(t3, t3);
   }
-  fe_mul(t2, t3, t2);
+  GFp_fe_mul(t2, t3, t2);
   fe_sq(t2, t2);
   for (i = 1; i < 50; ++i) {
     fe_sq(t2, t2);
   }
-  fe_mul(t1, t2, t1);
+  GFp_fe_mul(t1, t2, t1);
   fe_sq(t1, t1);
   for (i = 1; i < 5; ++i) {
     fe_sq(t1, t1);
   }
-  fe_mul(out, t1, t0);
+  GFp_fe_mul(out, t1, t0);
 }
 
 /* h = -f
@@ -734,7 +734,7 @@ static void fe_cmov(fe f, const fe g, unsigned b) {
  *    |f| bounded by 1.1*2^26,1.1*2^25,1.1*2^26,1.1*2^25,etc. */
 static int fe_isnonzero(const fe f) {
   uint8_t s[32];
-  fe_tobytes(s, f);
+  GFp_fe_tobytes(s, f);
 
   static const uint8_t zero[32] = {0};
   return GFp_memcmp(s, zero, sizeof(zero)) != 0;
@@ -745,9 +745,9 @@ static int fe_isnonzero(const fe f) {
  *
  * Preconditions:
  *    |f| bounded by 1.1*2^26,1.1*2^25,1.1*2^26,1.1*2^25,etc. */
-static int fe_isnegative(const fe f) {
+uint8_t GFp_fe_isnegative(const fe f) {
   uint8_t s[32];
-  fe_tobytes(s, f);
+  GFp_fe_tobytes(s, f);
   return s[0] & 1;
 }
 
@@ -758,9 +758,7 @@ static int fe_isnegative(const fe f) {
  *    |f| bounded by 1.65*2^26,1.65*2^25,1.65*2^26,1.65*2^25,etc.
  *
  * Postconditions:
- *    |h| bounded by 1.01*2^25,1.01*2^24,1.01*2^25,1.01*2^24,etc.
- *
- * See fe_mul.c for discussion of implementation strategy. */
+ *    |h| bounded by 1.01*2^25,1.01*2^24,1.01*2^25,1.01*2^24,etc. */
 static void fe_sq2(fe h, const fe f) {
   int32_t f0 = f[0];
   int32_t f1 = f[1];
@@ -914,74 +912,50 @@ static void fe_pow22523(fe out, const fe z) {
   for (i = 1; i < 2; ++i) {
     fe_sq(t1, t1);
   }
-  fe_mul(t1, z, t1);
-  fe_mul(t0, t0, t1);
+  GFp_fe_mul(t1, z, t1);
+  GFp_fe_mul(t0, t0, t1);
   fe_sq(t0, t0);
-  fe_mul(t0, t1, t0);
+  GFp_fe_mul(t0, t1, t0);
   fe_sq(t1, t0);
   for (i = 1; i < 5; ++i) {
     fe_sq(t1, t1);
   }
-  fe_mul(t0, t1, t0);
+  GFp_fe_mul(t0, t1, t0);
   fe_sq(t1, t0);
   for (i = 1; i < 10; ++i) {
     fe_sq(t1, t1);
   }
-  fe_mul(t1, t1, t0);
+  GFp_fe_mul(t1, t1, t0);
   fe_sq(t2, t1);
   for (i = 1; i < 20; ++i) {
     fe_sq(t2, t2);
   }
-  fe_mul(t1, t2, t1);
+  GFp_fe_mul(t1, t2, t1);
   fe_sq(t1, t1);
   for (i = 1; i < 10; ++i) {
     fe_sq(t1, t1);
   }
-  fe_mul(t0, t1, t0);
+  GFp_fe_mul(t0, t1, t0);
   fe_sq(t1, t0);
   for (i = 1; i < 50; ++i) {
     fe_sq(t1, t1);
   }
-  fe_mul(t1, t1, t0);
+  GFp_fe_mul(t1, t1, t0);
   fe_sq(t2, t1);
   for (i = 1; i < 100; ++i) {
     fe_sq(t2, t2);
   }
-  fe_mul(t1, t2, t1);
+  GFp_fe_mul(t1, t2, t1);
   fe_sq(t1, t1);
   for (i = 1; i < 50; ++i) {
     fe_sq(t1, t1);
   }
-  fe_mul(t0, t1, t0);
+  GFp_fe_mul(t0, t1, t0);
   fe_sq(t0, t0);
   for (i = 1; i < 2; ++i) {
     fe_sq(t0, t0);
   }
-  fe_mul(out, t0, z);
-}
-
-void GFp_x25519_ge_tobytes(uint8_t *s, const ge_p2 *h) {
-  fe recip;
-  fe x;
-  fe y;
-
-  fe_invert(recip, h->Z);
-  fe_mul(x, h->X, recip);
-  fe_mul(y, h->Y, recip);
-  fe_tobytes(s, y);
-  s[31] ^= fe_isnegative(x) << 7;
-}
-
-void GFp_ge_p3_tobytes(uint8_t s[32], const ge_p3 *h) {
-  fe recip;
-  fe x;
-  fe y;
-
-  fe_invert(recip, h->Z);
-  fe_mul(x, h->X, recip);
-  fe_mul(y, h->Y, recip);
-  fe_tobytes(s, y);
-  s[31] ^= fe_isnegative(x) << 7;
+  GFp_fe_mul(out, t0, z);
 }
 
 static const fe d = {-10913610, 13857413, -15372611, 6949391,   114729,
@@ -1000,36 +974,36 @@ int GFp_x25519_ge_frombytes_vartime(ge_p3 *h, const uint8_t *s) {
   fe_frombytes(h->Y, s);
   fe_1(h->Z);
   fe_sq(u, h->Y);
-  fe_mul(v, u, d);
+  GFp_fe_mul(v, u, d);
   fe_sub(u, u, h->Z); /* u = y^2-1 */
   fe_add(v, v, h->Z); /* v = dy^2+1 */
 
   fe_sq(v3, v);
-  fe_mul(v3, v3, v); /* v3 = v^3 */
+  GFp_fe_mul(v3, v3, v); /* v3 = v^3 */
   fe_sq(h->X, v3);
-  fe_mul(h->X, h->X, v);
-  fe_mul(h->X, h->X, u); /* x = uv^7 */
+  GFp_fe_mul(h->X, h->X, v);
+  GFp_fe_mul(h->X, h->X, u); /* x = uv^7 */
 
   fe_pow22523(h->X, h->X); /* x = (uv^7)^((q-5)/8) */
-  fe_mul(h->X, h->X, v3);
-  fe_mul(h->X, h->X, u); /* x = uv^3(uv^7)^((q-5)/8) */
+  GFp_fe_mul(h->X, h->X, v3);
+  GFp_fe_mul(h->X, h->X, u); /* x = uv^3(uv^7)^((q-5)/8) */
 
   fe_sq(vxx, h->X);
-  fe_mul(vxx, vxx, v);
+  GFp_fe_mul(vxx, vxx, v);
   fe_sub(check, vxx, u); /* vx^2-u */
   if (fe_isnonzero(check)) {
     fe_add(check, vxx, u); /* vx^2+u */
     if (fe_isnonzero(check)) {
       return 0;
     }
-    fe_mul(h->X, h->X, sqrtm1);
+    GFp_fe_mul(h->X, h->X, sqrtm1);
   }
 
-  if (fe_isnegative(h->X) != (s[31] >> 7)) {
+  if (GFp_fe_isnegative(h->X) != (s[31] >> 7)) {
     fe_neg(h->X, h->X);
   }
 
-  fe_mul(h->T, h->X, h->Y);
+  GFp_fe_mul(h->T, h->X, h->Y);
   return 1;
 }
 
@@ -1067,22 +1041,22 @@ static void x25519_ge_p3_to_cached(ge_cached *r, const ge_p3 *p) {
   fe_add(r->YplusX, p->Y, p->X);
   fe_sub(r->YminusX, p->Y, p->X);
   fe_copy(r->Z, p->Z);
-  fe_mul(r->T2d, p->T, d2);
+  GFp_fe_mul(r->T2d, p->T, d2);
 }
 
 /* r = p */
 static void x25519_ge_p1p1_to_p2(ge_p2 *r, const ge_p1p1 *p) {
-  fe_mul(r->X, p->X, p->T);
-  fe_mul(r->Y, p->Y, p->Z);
-  fe_mul(r->Z, p->Z, p->T);
+  GFp_fe_mul(r->X, p->X, p->T);
+  GFp_fe_mul(r->Y, p->Y, p->Z);
+  GFp_fe_mul(r->Z, p->Z, p->T);
 }
 
 /* r = p */
 static void x25519_ge_p1p1_to_p3(ge_p3 *r, const ge_p1p1 *p) {
-  fe_mul(r->X, p->X, p->T);
-  fe_mul(r->Y, p->Y, p->Z);
-  fe_mul(r->Z, p->Z, p->T);
-  fe_mul(r->T, p->X, p->Y);
+  GFp_fe_mul(r->X, p->X, p->T);
+  GFp_fe_mul(r->Y, p->Y, p->Z);
+  GFp_fe_mul(r->Z, p->Z, p->T);
+  GFp_fe_mul(r->T, p->X, p->Y);
 }
 
 /* r = 2 * p */
@@ -1113,9 +1087,9 @@ static void ge_madd(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q) {
 
   fe_add(r->X, p->Y, p->X);
   fe_sub(r->Y, p->Y, p->X);
-  fe_mul(r->Z, r->X, q->yplusx);
-  fe_mul(r->Y, r->Y, q->yminusx);
-  fe_mul(r->T, q->xy2d, p->T);
+  GFp_fe_mul(r->Z, r->X, q->yplusx);
+  GFp_fe_mul(r->Y, r->Y, q->yminusx);
+  GFp_fe_mul(r->T, q->xy2d, p->T);
   fe_add(t0, p->Z, p->Z);
   fe_sub(r->X, r->Z, r->Y);
   fe_add(r->Y, r->Z, r->Y);
@@ -1129,9 +1103,9 @@ static void ge_msub(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q) {
 
   fe_add(r->X, p->Y, p->X);
   fe_sub(r->Y, p->Y, p->X);
-  fe_mul(r->Z, r->X, q->yminusx);
-  fe_mul(r->Y, r->Y, q->yplusx);
-  fe_mul(r->T, q->xy2d, p->T);
+  GFp_fe_mul(r->Z, r->X, q->yminusx);
+  GFp_fe_mul(r->Y, r->Y, q->yplusx);
+  GFp_fe_mul(r->T, q->xy2d, p->T);
   fe_add(t0, p->Z, p->Z);
   fe_sub(r->X, r->Z, r->Y);
   fe_add(r->Y, r->Z, r->Y);
@@ -1145,10 +1119,10 @@ static void x25519_ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q) {
 
   fe_add(r->X, p->Y, p->X);
   fe_sub(r->Y, p->Y, p->X);
-  fe_mul(r->Z, r->X, q->YplusX);
-  fe_mul(r->Y, r->Y, q->YminusX);
-  fe_mul(r->T, q->T2d, p->T);
-  fe_mul(r->X, p->Z, q->Z);
+  GFp_fe_mul(r->Z, r->X, q->YplusX);
+  GFp_fe_mul(r->Y, r->Y, q->YminusX);
+  GFp_fe_mul(r->T, q->T2d, p->T);
+  GFp_fe_mul(r->X, p->Z, q->Z);
   fe_add(t0, r->X, r->X);
   fe_sub(r->X, r->Z, r->Y);
   fe_add(r->Y, r->Z, r->Y);
@@ -1162,10 +1136,10 @@ static void x25519_ge_sub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q) {
 
   fe_add(r->X, p->Y, p->X);
   fe_sub(r->Y, p->Y, p->X);
-  fe_mul(r->Z, r->X, q->YminusX);
-  fe_mul(r->Y, r->Y, q->YplusX);
-  fe_mul(r->T, q->T2d, p->T);
-  fe_mul(r->X, p->Z, q->Z);
+  GFp_fe_mul(r->Z, r->X, q->YminusX);
+  GFp_fe_mul(r->Y, r->Y, q->YplusX);
+  GFp_fe_mul(r->T, q->T2d, p->T);
+  GFp_fe_mul(r->X, p->Z, q->Z);
   fe_add(t0, r->X, r->X);
   fe_sub(r->X, r->Z, r->Y);
   fe_add(r->Y, r->Z, r->Y);
@@ -1207,8 +1181,8 @@ static void x25519_ge_scalarmult_small_precomp(
     ge_precomp *out = &multiples[i];
     fe_add(out->yplusx, y, x);
     fe_sub(out->yminusx, y, x);
-    fe_mul(out->xy2d, x, y);
-    fe_mul(out->xy2d, out->xy2d, d2);
+    GFp_fe_mul(out->xy2d, x, y);
+    GFp_fe_mul(out->xy2d, out->xy2d, d2);
   }
 
   /* See the comment above |k25519SmallPrecomp| about the structure of the
@@ -1247,7 +1221,7 @@ static void x25519_ge_scalarmult_small_precomp(
  * one. The standard table is 30,720 bytes while this one is just 960.
  *
  * This table contains 15 pairs of group elements, (x, y), where each field
- * element is serialised with |fe_tobytes|. If |i| is the index of the group
+ * element is serialised with |GFp_fe_tobytes|. If |i| is the index of the group
  * element then consider i+1 as a four-bit number: (i_0, i_1, i_2, i_3) where
  * i_0 is the most significant bit). The value of the group element is then
  * (i_x2^192 + i_1x2^128 + i_2x2^64 + i_3)G, where G is the generator. */
@@ -4586,7 +4560,7 @@ static void fe_cswap(fe f, fe g, unsigned int b) {
  *
  * Postconditions:
  *    |h| bounded by 1.1*2^25,1.1*2^24,1.1*2^25,1.1*2^24,etc. */
-static void fe_mul121666(fe h, fe f) {
+static void GFp_fe_mul121666(fe h, fe f) {
   int32_t f0 = f[0];
   int32_t f1 = f[1];
   int32_t f2 = f[2];
@@ -4674,27 +4648,27 @@ static void x25519_scalar_mult_generic(uint8_t out[32],
     fe_sub(tmp1, x2, z2);
     fe_add(x2, x2, z2);
     fe_add(z2, x3, z3);
-    fe_mul(z3, tmp0, x2);
-    fe_mul(z2, z2, tmp1);
+    GFp_fe_mul(z3, tmp0, x2);
+    GFp_fe_mul(z2, z2, tmp1);
     fe_sq(tmp0, tmp1);
     fe_sq(tmp1, x2);
     fe_add(x3, z3, z2);
     fe_sub(z2, z3, z2);
-    fe_mul(x2, tmp1, tmp0);
+    GFp_fe_mul(x2, tmp1, tmp0);
     fe_sub(tmp1, tmp1, tmp0);
     fe_sq(z2, z2);
-    fe_mul121666(z3, tmp1);
+    GFp_fe_mul121666(z3, tmp1);
     fe_sq(x3, x3);
     fe_add(tmp0, tmp0, z3);
-    fe_mul(z3, x1, z2);
-    fe_mul(z2, tmp1, tmp0);
+    GFp_fe_mul(z3, x1, z2);
+    GFp_fe_mul(z2, tmp1, tmp0);
   }
   fe_cswap(x2, x3, swap);
   fe_cswap(z2, z3, swap);
 
-  fe_invert(z2, z2);
-  fe_mul(x2, x2, z2);
-  fe_tobytes(out, x2);
+  GFp_fe_invert(z2, z2);
+  GFp_fe_mul(x2, x2, z2);
+  GFp_fe_tobytes(out, x2);
 }
 
 static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
@@ -4764,9 +4738,9 @@ void GFp_x25519_public_from_private(uint8_t out_public_value[32],
   fe zplusy, zminusy, zminusy_inv;
   fe_add(zplusy, A.Z, A.Y);
   fe_sub(zminusy, A.Z, A.Y);
-  fe_invert(zminusy_inv, zminusy);
-  fe_mul(zplusy, zplusy, zminusy_inv);
-  fe_tobytes(out_public_value, zplusy);
+  GFp_fe_invert(zminusy_inv, zminusy);
+  GFp_fe_mul(zplusy, zplusy, zminusy_inv);
+  GFp_fe_tobytes(out_public_value, zplusy);
 }
 
 #endif  /* BORINGSSL_X25519_X86_64 */

--- a/crypto/curve25519/internal.h
+++ b/crypto/curve25519/internal.h
@@ -49,7 +49,7 @@ void GFp_x25519_NEON(uint8_t out[32], const uint8_t scalar[32],
  * t[3]+2^102 t[4]+...+2^230 t[9]. Bounds on each t[i] vary depending on
  * context.
  *
- * Keep in sync with `Elem` and `ELEM_LIMBS` in eddsa.rs. */
+ * Keep in sync with `Elem` and `ELEM_LIMBS` in curve25519/ops.rs. */
 typedef int32_t fe[10];
 
 /* ge means group element.
@@ -65,7 +65,7 @@ typedef int32_t fe[10];
  *   ge_precomp (Duif): (y+x,y-x,2dxy)
  */
 
-/* Keep in sync with `Point` in eddsa.rs. */
+/* Keep in sync with `Point` in curve25519/ops.rs. */
 typedef struct {
   fe X;
   fe Y;
@@ -73,7 +73,7 @@ typedef struct {
 } ge_p2;
 
 
-/* Keep in sync with `ExtPoint` in eddsa.rs. */
+/* Keep in sync with `ExtPoint` in curve25519/ops.rs. */
 typedef struct {
   fe X;
   fe Y;

--- a/src/ec/curve25519/curve25519.rs
+++ b/src/ec/curve25519/curve25519.rs
@@ -12,7 +12,9 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-//! Elliptic curve operations on Curve25519.
+//! Elliptic curve operations and schemes using Curve25519.
 
 pub mod ed25519;
 pub mod x25519;
+
+mod ops;

--- a/src/ec/curve25519/ed25519.rs
+++ b/src/ec/curve25519/ed25519.rs
@@ -15,6 +15,7 @@
 //! EdDSA Signatures.
 
 use {bssl, c, digest, error, private, rand, signature};
+use super::ops::{ELEM_LEN, ExtPoint, Point};
 use untrusted;
 
 /// Parameters for EdDSA signing and verification.
@@ -247,56 +248,6 @@ extern  {
     fn GFp_x25519_sc_muladd(s: &mut Scalar, a: &Scalar, b: &Scalar, c: &Scalar);
     fn GFp_x25519_sc_reduce(s: &mut UnreducedScalar);
 }
-
-// Keep this in sync with `ge_p3` in curve25519/internal.h.
-#[repr(C)]
-struct ExtPoint {
-    x: Elem,
-    y: Elem,
-    z: Elem,
-    t: Elem,
-}
-
-impl ExtPoint {
-    fn new_at_infinity() -> Self {
-        ExtPoint {
-            x: [0; ELEM_LIMBS],
-            y: [0; ELEM_LIMBS],
-            z: [0; ELEM_LIMBS],
-            t: [0; ELEM_LIMBS],
-        }
-    }
-
-    fn invert_vartime(&mut self) {
-        for i in 0..ELEM_LIMBS {
-            self.x[i] = -self.x[i];
-            self.t[i] = -self.t[i];
-        }
-    }
-}
-
-// Keep this in sync with `ge_p2` in curve25519/internal.h.
-#[repr(C)]
-struct Point {
-    x: Elem,
-    y: Elem,
-    z: Elem,
-}
-
-impl Point {
-    fn new_at_infinity() -> Self {
-        Point {
-            x: [0; ELEM_LIMBS],
-            y: [0; ELEM_LIMBS],
-            z: [0; ELEM_LIMBS],
-        }
-    }
-}
-
-// Keep this in sync with `fe` in curve25519/internal.h.
-type Elem = [i32; ELEM_LIMBS];
-const ELEM_LIMBS: usize = 10;
-const ELEM_LEN: usize = 32;
 
 type PublicKey = [u8; PUBLIC_KEY_LEN];
 const PUBLIC_KEY_LEN: usize = ELEM_LEN;

--- a/src/ec/curve25519/ed25519.rs
+++ b/src/ec/curve25519/ed25519.rs
@@ -15,7 +15,7 @@
 //! EdDSA Signatures.
 
 use {digest, error, private, rand, signature};
-use super::ops::{ELEM_LEN, ExtPoint, Point};
+use super::ops::*;
 use untrusted;
 
 /// Parameters for EdDSA signing and verification.
@@ -244,12 +244,6 @@ type Prefix = [u8; PREFIX_LEN];
 const PREFIX_LEN: usize = digest::SHA512_OUTPUT_LEN - SCALAR_LEN;
 
 const SIGNATURE_LEN: usize = ELEM_LEN + SCALAR_LEN;
-
-type Scalar = [u8; SCALAR_LEN];
-const SCALAR_LEN: usize = 32;
-
-type UnreducedScalar = [u8; UNREDUCED_SCALAR_LEN];
-const UNREDUCED_SCALAR_LEN: usize = SCALAR_LEN * 2;
 
 type Seed = [u8; SEED_LEN];
 const SEED_LEN: usize = 32;

--- a/src/ec/curve25519/ed25519.rs
+++ b/src/ec/curve25519/ed25519.rs
@@ -14,7 +14,7 @@
 
 //! EdDSA Signatures.
 
-use {bssl, c, digest, error, private, rand, signature};
+use {digest, error, private, rand, signature};
 use super::ops::{ELEM_LEN, ExtPoint, Point};
 use untrusted;
 
@@ -109,15 +109,11 @@ impl<'a> Ed25519KeyPair {
         unsafe {
             GFp_x25519_ge_scalarmult_base(&mut a, &scalar);
         }
-        let mut public_key = [0; PUBLIC_KEY_LEN];
-        unsafe {
-            GFp_ge_p3_tobytes(&mut public_key, &a);
-        }
 
         Ed25519KeyPair {
             private_scalar: scalar,
             private_prefix: prefix,
-            public_key: public_key,
+            public_key: a.into_encoded_point(),
         }
     }
 
@@ -148,9 +144,8 @@ impl<'a> Ed25519KeyPair {
             let mut r = ExtPoint::new_at_infinity();
             unsafe {
                 GFp_x25519_ge_scalarmult_base(&mut r, &nonce);
-                GFp_ge_p3_tobytes(signature_r, &r);
             }
-
+            signature_r.copy_from_slice(&r.into_encoded_point());
             let hram_digest = eddsa_digest(signature_r, &self.public_key, msg);
             let hram = digest_scalar(hram_digest);
             unsafe {
@@ -194,10 +189,7 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
             return Err(error::Unspecified);
         }
 
-        let mut a = ExtPoint::new_at_infinity();
-        try!(bssl::map_result(unsafe {
-            GFp_x25519_ge_frombytes_vartime(&mut a, public_key)
-        }));
+        let mut a = try!(ExtPoint::from_encoded_point_vartime(public_key));
         a.invert_vartime();
 
         let h_digest =
@@ -208,8 +200,7 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
         unsafe {
             GFp_ge_double_scalarmult_vartime(&mut r, &h, &a, &signature_s)
         };
-        let mut r_check = [0u8; ELEM_LEN];
-        unsafe { GFp_x25519_ge_tobytes(&mut r_check, &r) };
+        let r_check = r.into_encoded_point();
         if signature_r != r_check {
             return Err(error::Unspecified);
         }
@@ -241,10 +232,7 @@ extern  {
     fn GFp_ed25519_scalar_mask(a: &mut Scalar);
     fn GFp_ge_double_scalarmult_vartime(r: &mut Point, a_coeff: &Scalar,
                                         a: &ExtPoint, b_coeff: &Scalar);
-    fn GFp_ge_p3_tobytes(s: &mut [u8; ELEM_LEN], h: &ExtPoint);
-    fn GFp_x25519_ge_frombytes_vartime(h: &mut ExtPoint, s: &Scalar) -> c::int;
     fn GFp_x25519_ge_scalarmult_base(h: &mut ExtPoint, a: &Seed);
-    fn GFp_x25519_ge_tobytes(s: &mut Scalar, h: &Point);
     fn GFp_x25519_sc_muladd(s: &mut Scalar, a: &Scalar, b: &Scalar, c: &Scalar);
     fn GFp_x25519_sc_reduce(s: &mut UnreducedScalar);
 }

--- a/src/ec/curve25519/ops.rs
+++ b/src/ec/curve25519/ops.rs
@@ -24,6 +24,12 @@ const ELEM_LIMBS: usize = 10;
 type EncodedPoint = [u8; ELEM_LEN];
 pub const ELEM_LEN: usize = 32;
 
+pub type Scalar = [u8; SCALAR_LEN];
+pub const SCALAR_LEN: usize = 32;
+
+pub type UnreducedScalar = [u8; UNREDUCED_SCALAR_LEN];
+const UNREDUCED_SCALAR_LEN: usize = SCALAR_LEN * 2;
+
 // Keep this in sync with `ge_p3` in curve25519/internal.h.
 #[repr(C)]
 pub struct ExtPoint {

--- a/src/ec/curve25519/ops.rs
+++ b/src/ec/curve25519/ops.rs
@@ -14,10 +14,14 @@
 
 //! Elliptic curve operations on Curve25519.
 
+use {bssl, c, error};
 
 // Keep this in sync with `fe` in curve25519/internal.h.
 pub type Elem = [i32; ELEM_LIMBS];
 const ELEM_LIMBS: usize = 10;
+
+// A point on Curve25519, encoded as described in section 5.1.2 of RFC 8032.
+type EncodedPoint = [u8; ELEM_LEN];
 pub const ELEM_LEN: usize = 32;
 
 // Keep this in sync with `ge_p3` in curve25519/internal.h.
@@ -37,6 +41,24 @@ impl ExtPoint {
             z: [0; ELEM_LIMBS],
             t: [0; ELEM_LIMBS],
         }
+    }
+
+    pub fn from_encoded_point_vartime(encoded: &EncodedPoint)
+                          -> Result<Self, error::Unspecified> {
+        let mut point = Self::new_at_infinity();
+
+        try!(bssl::map_result(unsafe {
+            GFp_x25519_ge_frombytes_vartime(&mut point, encoded)
+        }));
+
+        Ok(point)
+    }
+
+    pub fn into_encoded_point(self) -> EncodedPoint {
+        let mut bytes = [0u8; ELEM_LEN];
+        unsafe { GFp_ge_p3_tobytes(&mut bytes, &self); }
+
+        bytes
     }
 
     pub fn invert_vartime(&mut self) {
@@ -63,4 +85,18 @@ impl Point {
             z: [0; ELEM_LIMBS],
         }
     }
+
+    pub fn into_encoded_point(self) -> EncodedPoint {
+        let mut bytes = [0u8; ELEM_LEN];
+        unsafe { GFp_x25519_ge_tobytes(&mut bytes, &self); }
+
+        bytes
+    }
+}
+
+extern {
+    fn GFp_ge_p3_tobytes(s: &mut EncodedPoint, h: &ExtPoint);
+    fn GFp_x25519_ge_frombytes_vartime(h: &mut ExtPoint, s: &EncodedPoint)
+                                       -> c::int;
+    fn GFp_x25519_ge_tobytes(s: &mut EncodedPoint, h: &Point);
 }

--- a/src/ec/curve25519/ops.rs
+++ b/src/ec/curve25519/ops.rs
@@ -1,0 +1,66 @@
+// Copyright 2017 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+//! Elliptic curve operations on Curve25519.
+
+
+// Keep this in sync with `fe` in curve25519/internal.h.
+pub type Elem = [i32; ELEM_LIMBS];
+const ELEM_LIMBS: usize = 10;
+pub const ELEM_LEN: usize = 32;
+
+// Keep this in sync with `ge_p3` in curve25519/internal.h.
+#[repr(C)]
+pub struct ExtPoint {
+    x: Elem,
+    y: Elem,
+    z: Elem,
+    t: Elem,
+}
+
+impl ExtPoint {
+    pub fn new_at_infinity() -> Self {
+        ExtPoint {
+            x: [0; ELEM_LIMBS],
+            y: [0; ELEM_LIMBS],
+            z: [0; ELEM_LIMBS],
+            t: [0; ELEM_LIMBS],
+        }
+    }
+
+    pub fn invert_vartime(&mut self) {
+        for i in 0..ELEM_LIMBS {
+            self.x[i] = -self.x[i];
+            self.t[i] = -self.t[i];
+        }
+    }
+}
+
+// Keep this in sync with `ge_p2` in curve25519/internal.h.
+#[repr(C)]
+pub struct Point {
+    x: Elem,
+    y: Elem,
+    z: Elem,
+}
+
+impl Point {
+    pub fn new_at_infinity() -> Self {
+        Point {
+            x: [0; ELEM_LIMBS],
+            y: [0; ELEM_LIMBS],
+            z: [0; ELEM_LIMBS],
+        }
+    }
+}


### PR DESCRIPTION
In support of #500, we want to oxidize the callers of `fe_invert()`. This work is in support of that intermediate step, as well as inching the Curve25519 arithmetic operations into alignment with the Suite B EC code.