### PR TITLE
Improve Travis CI Android Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,30 @@ matrix:
       os: osx
       osx_image: xcode8.2
 
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      dist: trusty
+      sudo: required
+
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
@@ -557,6 +581,30 @@ matrix:
       rust: nightly
       os: osx
       osx_image: xcode8.2
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      dist: trusty
+      sudo: required
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: nightly
@@ -1097,6 +1145,30 @@ matrix:
       rust: beta
       os: osx
       osx_image: xcode8.2
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      dist: trusty
+      sudo: required
+
+    - env: TARGET_X=aarch64-linux-android CC_X=aarch64-linux-android-gcc CXX_X=aarch64-linux-android-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      dist: trusty
+      sudo: required
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ cache:
   directories:
     - $HOME/kcov-i686-unknown-linux-gnu
     - $HOME/kcov-x86_64-unknown-linux-gnu
-    - $HOME/android/android-sdk-linux
-    - $HOME/android/android-18-arm-linux-androideabi-4.8
+    - $HOME/android/android-ndk
+    - $HOME/android/android-sdk-linux/platform-tools
+    - $HOME/android/android-sdk-linux/tools
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,52 +42,24 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: stable
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: stable
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: stable
@@ -590,52 +562,24 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: nightly
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: nightly
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: nightly
@@ -1158,52 +1102,24 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=DEBUG KCOV=0
       rust: beta
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=armv7-linux-androideabi CC_X=arm-linux-androideabi-gcc CXX_X=arm-linux-androideabi-g++ FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
       rust: beta
       os: linux
       dist: trusty
       sudo: required
-      addons:
-        apt:
-          packages:
-            - expect
-            - openjdk-6-jre-headless
-          sources:
-            - ubuntu-toolchain-r-test
 
     - env: TARGET_X=x86_64-unknown-linux-gnu  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1672,4 +1672,4 @@ matrix:
 
     # END GENERATED
 
-script: if [[ "$TARGET_X" =~ ^a*.*linux-.*eabi && "$MODE_X" == "RELWITHDEBINFO" ]]; then travis_wait 60 mk/travis.sh; else mk/travis.sh; fi
+script: if [[ "$TARGET_X" =~ ^a*.*linux-.*(droid|eabi) && "$MODE_X" == "RELWITHDEBINFO" ]]; then travis_wait 60 mk/travis.sh; else mk/travis.sh; fi

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ the table below. The C compilers listed are used for compiling the C portions.
         <code>qemu-user-arm</code>.</td>
 </tr>
 <tr><td>Android</td>
-    <td>32&#8209;bit&nbsp;ARM</td>
+    <td>32&#8209;bit&nbsp;ARM, AAarch64</td>
     <td>Built using the Android SDK 24.4.1 and Android NDK 14, tested using the
         Android emulator.</td>
 </tr>

--- a/build.rs
+++ b/build.rs
@@ -614,7 +614,12 @@ fn cc(file: &Path, ext: &str, target: &Target, warnings_are_errors: bool,
         // Define __ANDROID_API__ to the Android API level we want.
         // Needed for Android NDK Unified Headers, see:
         // https://android.googlesource.com/platform/ndk/+/master/docs/UnifiedHeaders.md#Supporting-Unified-Headers-in-Your-Build-System
-        let _ = c.define("__ANDROID_API__", Some("18"));
+        if target.arch() == "aarch64" {
+            // Minimum API level where AArch64 is available is 21.
+            let _ = c.define("__ANDROID_API__", Some("21"));
+        } else {
+            let _ = c.define("__ANDROID_API__", Some("18"));
+        }
     }
 
     let mut c = c.get_compiler().to_command();

--- a/mk/travis-install-android.sh
+++ b/mk/travis-install-android.sh
@@ -28,19 +28,23 @@ ANDROID_NDK_VERSION=${ANDROID_NDK_VERSION:-14}
 ANDROID_NDK_URL=https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip
 
 ANDROID_INSTALL_PREFIX="${HOME}/android"
-ANDROID_SDK_INSTALL_DIR="${HOME}/android/android-sdk-linux"
-ANDROID_NDK_INSTALL_DIR="${ANDROID_INSTALL_PREFIX}/android-18-arm-linux-androideabi-4.8"
+ANDROID_SDK_INSTALL_DIR="${ANDROID_INSTALL_PREFIX}/android-sdk-linux"
+ANDROID_NDK_INSTALL_DIR="${ANDROID_INSTALL_PREFIX}/android-ndk"
+
+ANDROID_PKGS="android-18,android-18,sys-img-armeabiv7a-android-18"
+
+mkdir -p "${ANDROID_INSTALL_PREFIX}"
+pushd "${ANDROID_INSTALL_PREFIX}"
 
 if [[ ! -f $ANDROID_SDK_INSTALL_DIR/tools/emulator ]];then
-  mkdir -p "${ANDROID_INSTALL_PREFIX}"
-  pushd "${ANDROID_INSTALL_PREFIX}"
-
   curl ${ANDROID_SDK_URL} | tar -zxf -
 
-  echo y | ./android-sdk-linux/tools/android update sdk -a --no-ui --filter tools,platform-tools,android-18,sys-img-armeabi-v7a-android-18
-
-  popd
+  ANDROID_PKGS="tools,platform-tools,${ANDROID_PKGS}"
 fi
+
+echo y | ./android-sdk-linux/tools/android update sdk -a --no-ui --filter ${ANDROID_PKGS}
+
+popd
 
 if [[ ! -d $ANDROID_NDK_INSTALL_DIR/sysroot/usr/include/arm-linux-androideabi ]];then
   mkdir -p "${ANDROID_INSTALL_PREFIX}/downloads"

--- a/mk/travis-install-android.sh
+++ b/mk/travis-install-android.sh
@@ -37,14 +37,8 @@ if [[ ! -f $ANDROID_SDK_INSTALL_DIR/tools/emulator ]];then
 
   curl ${ANDROID_SDK_URL} | tar -zxf -
 
-  expect -c '
-set timeout 600;
-spawn ./android-sdk-linux/tools/android update sdk -a --no-ui --filter tools,platform-tools,android-18,sys-img-armeabi-v7a-android-18;
-expect {
-    "Do you accept the license" { exp_send "y\r" ; exp_continue }
-    eof
-}
-'
+  echo y | ./android-sdk-linux/tools/android update sdk -a --no-ui --filter tools,platform-tools,android-18,sys-img-armeabi-v7a-android-18
+
   popd
 fi
 

--- a/mk/travis-install-android.sh
+++ b/mk/travis-install-android.sh
@@ -21,6 +21,42 @@
 # SOFTWARE.
 set -ex
 
+ARGS=$(getopt -o a:l:b:s:r: --long arch:,api-level:,abi-name:,sys-img-api-level:,rust-target: -n 'travis-install-android.sh' -- "$@" )
+eval set -- "${ARGS}"
+
+while true; do
+  case $1 in
+  -a|--arch)
+    ARCH="${2}"
+    shift 2
+    ;;
+  -l|--api-level)
+    API="${2}"
+    shift 2
+    ;;
+  -l|--abi-name)
+    ABI="${2}"
+    shift 2
+    ;;
+  -s|--sys-img-api-level)
+    SYS_IMG_API="${2}"
+    shift 2
+    ;;
+  -r|--rust-target)
+    RUST_TARGET="${2}"
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *)
+    echo "Error!"
+    exit 1
+    ;;
+  esac
+done
+
 ANDROID_SDK_VERSION=${ANDROID_SDK_VERSION:-24.4.1}
 ANDROID_SDK_URL=https://dl.google.com/android/android-sdk_r${ANDROID_SDK_VERSION}-linux.tgz
 
@@ -31,7 +67,10 @@ ANDROID_INSTALL_PREFIX="${HOME}/android"
 ANDROID_SDK_INSTALL_DIR="${ANDROID_INSTALL_PREFIX}/android-sdk-linux"
 ANDROID_NDK_INSTALL_DIR="${ANDROID_INSTALL_PREFIX}/android-ndk"
 
-ANDROID_PKGS="android-18,android-18,sys-img-armeabiv7a-android-18"
+# We're using API 21 for AArch24 and 18 for everything else.
+# Unfortunately the only available AArch64 images have API level 24.
+# Install the extra API package and have a different option for the system image.
+ANDROID_PKGS="android-${API},android-${SYS_IMG_API},sys-img-${ABI}-android-${SYS_IMG_API}"
 
 mkdir -p "${ANDROID_INSTALL_PREFIX}"
 pushd "${ANDROID_INSTALL_PREFIX}"
@@ -46,7 +85,11 @@ echo y | ./android-sdk-linux/tools/android update sdk -a --no-ui --filter ${ANDR
 
 popd
 
-if [[ ! -d $ANDROID_NDK_INSTALL_DIR/sysroot/usr/include/arm-linux-androideabi ]];then
+# Test all these directories because of the mismatch between Android arch name and rustc targets.
+if [[ ! ( -d $ANDROID_NDK_INSTALL_DIR/sysroot/usr/include/${ARCH}-linux-androideabi ||
+          -d $ANDROID_NDK_INSTALL_DIR/sysroot/usr/include/${ARCH}-linux-android     ||
+          -d $ANDROID_NDK_INSTALL_DIR/sysroot/usr/include/${RUST_TARGET} )]];then
+
   mkdir -p "${ANDROID_INSTALL_PREFIX}/downloads"
   pushd "${ANDROID_INSTALL_PREFIX}/downloads"
 
@@ -55,8 +98,8 @@ if [[ ! -d $ANDROID_NDK_INSTALL_DIR/sysroot/usr/include/arm-linux-androideabi ]]
 
   ./android-ndk-r${ANDROID_NDK_VERSION}/build/tools/make_standalone_toolchain.py \
 		 --force \
-		 --arch arm \
-		 --api 18 \
+		 --arch ${ARCH} \
+		 --api ${API} \
 		 --unified-headers \
 		 --install-dir ${ANDROID_NDK_INSTALL_DIR}
 

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -26,21 +26,34 @@ aarch64-unknown-linux-gnu)
 arm-unknown-linux-gnueabihf)
   export QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf
   ;;
+aarch64-linux-android)
+  ANDROID_ARCH=arm64
+  ANDROID_ABI=arm64-v8a
+  ANDROID_API=21
+  ANDROID_SYS_IMG_API=24
+  ;;
 armv7-linux-androideabi)
+  ANDROID_ARCH=arm
+  ANDROID_ABI=armeabi-v7a
+  ANDROID_API=18
+  ANDROID_SYS_IMG_API=18
+  ;;
+*)
+  ;;
+esac
+
+if [[ "$TARGET_X" =~ android ]]; then
   # install the android sdk/ndk
-  mk/travis-install-android.sh --arch arm \
-                               --api-level 18 \
-                               --abi-name armeabi-v7a \
-                               --sys-img-api-level 18 \
+  mk/travis-install-android.sh --arch ${ANDROID_ARCH} \
+                               --api-level ${ANDROID_API} \
+                               --abi-name ${ANDROID_ABI} \
+                               --sys-img-api-level ${ANDROID_SYS_IMG_API} \
                                --rust-target ${TARGET_X}
 
   export PATH=$HOME/android/android-ndk/bin:$PATH
   export PATH=$HOME/android/android-sdk-linux/platform-tools:$PATH
   export PATH=$HOME/android/android-sdk-linux/tools:$PATH
-  ;;
-*)
-  ;;
-esac
+fi
 
 if [[ "$TARGET_X" =~ ^(arm|aarch64) && ! "$TARGET_X" =~ android ]]; then
   # We need a newer QEMU than Travis has.
@@ -90,15 +103,17 @@ else
 fi
 
 case $TARGET_X in
-armv7-linux-androideabi)
+*-linux-android*)
   cargo test -vv -j2 --no-run ${mode-} ${FEATURES_X-} --target=$TARGET_X
 
   # Building the AVD is slow. Do it here, after we build the code so that any
   # build breakage is reported sooner, instead of being delayed by this.
-  echo no | android create avd --name arm-18 --target android-18 --abi armeabi-v7a
+  echo no | android create avd --name test --target "android-${ANDROID_SYS_IMG_API}"
   android list avd
 
-  emulator @arm-18 -memory 2048 -no-skin -no-boot-anim -no-window &
+  emulator @test -memory 2048 -no-skin -no-boot-anim -no-window &
+  adb wait-for-device
+  adb root
   adb wait-for-device
 
   # Run the unit tests first.

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -30,7 +30,7 @@ armv7-linux-androideabi)
   # install the android sdk/ndk
   mk/travis-install-android.sh
 
-  export PATH=$HOME/android/android-18-arm-linux-androideabi-4.8/bin:$PATH
+  export PATH=$HOME/android/android-ndk/bin:$PATH
   export PATH=$HOME/android/android-sdk-linux/platform-tools:$PATH
   export PATH=$HOME/android/android-sdk-linux/tools:$PATH
   ;;

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -28,7 +28,11 @@ arm-unknown-linux-gnueabihf)
   ;;
 armv7-linux-androideabi)
   # install the android sdk/ndk
-  mk/travis-install-android.sh
+  mk/travis-install-android.sh --arch arm \
+                               --api-level 18 \
+                               --abi-name armeabi-v7a \
+                               --sys-img-api-level 18 \
+                               --rust-target ${TARGET_X}
 
   export PATH=$HOME/android/android-ndk/bin:$PATH
   export PATH=$HOME/android/android-sdk-linux/platform-tools:$PATH

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -219,9 +219,6 @@ def get_linux_packages_to_install(target, compiler, arch, kcov):
         packages += ["gcc-arm-linux-gnueabihf",
                      "g++-arm-linux-gnueabihf",
                      "libc6-dev-armhf-cross"]
-    if target == "armv7-linux-androideabi":
-        packages += ["expect",
-                     "openjdk-6-jre-headless"]
 
     if arch == "i686":
         if kcov == True:

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -53,6 +53,7 @@ osx_compilers = [
 
 compilers = {
     "aarch64-unknown-linux-gnu" : [ "aarch64-linux-gnu-gcc" ],
+    "aarch64-linux-android" : [ "aarch64-linux-android-gcc" ],
     "armv7-linux-androideabi" : [ "arm-linux-androideabi-gcc" ],
     "arm-unknown-linux-gnueabihf" : [ "arm-linux-gnueabihf-gcc" ],
     "i686-unknown-linux-gnu" : linux_compilers,
@@ -82,6 +83,7 @@ targets = {
         "x86_64-apple-darwin",
     ],
     "linux" : [
+        "aarch64-linux-android",
         "armv7-linux-androideabi",
         "x86_64-unknown-linux-gnu",
         "aarch64-unknown-linux-gnu",
@@ -145,7 +147,7 @@ def format_entry(os, target, compiler, rust, mode, features):
     if sys == "darwin":
         abi = sys
         sys = "macos"
-    elif sys == "androideabi":
+    elif re.match(r'^android.*', sys):
         abi = sys
         sys = "linux"
     else:


### PR DESCRIPTION
This PR improves the Android situation on Travis CI. It caches some of the Android things we need to download for every build and adds AArch64 builds. It fixes both #486 and the issue I wrote about on [#518](https://github.com/briansmith/ring/issues/518#issuecomment-304114391).