### PR TITLE
build: use -shared when building objects with musl

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -610,6 +610,7 @@ fn cc(file: &Path, ext: &str, target: &Target, warnings_are_errors: bool,
         // http://www.openwall.com/lists/musl/2015/02/04/3
         // http://www.openwall.com/lists/musl/2015/06/17/1
         let _ = c.flag("-U_FORTIFY_SOURCE");
+        let _ = c.flag("-shared");
     }
     if target.os() == "android" {
         // Define __ANDROID_API__ to the Android API level we want.


### PR DESCRIPTION
rustc musl targets have an hardcoded `-static` flag, which results
in ring *.o artifacts not being properly relocatable despite the -fPIC
flag.
This adds a later `-shared` flag to override this behavior when building
library objects.

Fixes #544