### PR TITLE
Implement PartialEq and Eq for algorithm types

### DIFF
--- a/src/aead/aead.rs
+++ b/src/aead/aead.rs
@@ -279,6 +279,7 @@ pub struct Algorithm {
              tag_out: &mut [u8; TAG_LEN]) -> Result<(), error::Unspecified>,
 
     key_len: usize,
+    id: AlgorithmID,
 }
 
 impl Algorithm {
@@ -309,6 +310,19 @@ impl Algorithm {
     pub fn nonce_len(&self) -> usize { NONCE_LEN }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Eq, PartialEq)]
+enum AlgorithmID {
+    AES_128_GCM,
+    AES_256_GCM,
+    CHACHA20_POLY1305,
+}
+
+impl PartialEq for Algorithm {
+    fn eq(&self, other: &Self) -> bool { self.id == other.id }
+}
+
+impl Eq for Algorithm {}
 
 /// The maximum length of a tag for the algorithms in this module.
 pub const MAX_TAG_LEN: usize = TAG_LEN;

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -24,6 +24,7 @@ pub static AES_128_GCM: aead::Algorithm = aead::Algorithm {
     init: aes_gcm_init,
     seal: aes_gcm_seal,
     open: aes_gcm_open,
+    id: aead::AlgorithmID::AES_128_GCM,
 };
 
 /// AES-256 in GCM mode with 128-bit tags and 96 bit nonces.
@@ -36,6 +37,7 @@ pub static AES_256_GCM: aead::Algorithm = aead::Algorithm {
     init: aes_gcm_init,
     seal: aes_gcm_seal,
     open: aes_gcm_open,
+    id: aead::AlgorithmID::AES_256_GCM,
 };
 
 fn aes_gcm_init(ctx_buf: &mut [u8], key: &[u8])

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -24,6 +24,7 @@ pub static CHACHA20_POLY1305: aead::Algorithm = aead::Algorithm {
     init: chacha20_poly1305_init,
     seal: chacha20_poly1305_seal,
     open: chacha20_poly1305_open,
+    id: aead::AlgorithmID::CHACHA20_POLY1305,
 };
 
 /// Copies |key| into |ctx_buf|.

--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -96,6 +96,12 @@ pub struct Algorithm {
     pub i: ec::AgreementAlgorithmImpl,
 }
 
+impl PartialEq for Algorithm {
+    fn eq(&self, other: &Self) -> bool { self.i.curve.id == other.i.curve.id }
+}
+
+impl Eq for Algorithm {}
+
 /// An ephemeral private key for use (only) with `agree_ephemeral`. The
 /// signature of `agree_ephemeral` ensures that an `EphemeralPrivateKey` can be
 /// used for at most one key agreement.

--- a/src/digest/digest.rs
+++ b/src/digest/digest.rs
@@ -295,7 +295,25 @@ pub struct Algorithm {
     format_output: fn(input: &State) -> Output,
 
     initial_state: State,
+
+    id: AlgorithmID,
 }
+
+#[derive(Eq, PartialEq)]
+#[allow(non_camel_case_types)]
+enum AlgorithmID {
+    SHA1,
+    SHA256,
+    SHA384,
+    SHA512,
+    SHA512_256,
+}
+
+impl PartialEq for Algorithm {
+    fn eq(&self, other: &Self) -> bool { self.id == other.id }
+}
+
+impl Eq for Algorithm {}
 
 impl core::fmt::Debug for Algorithm {
     fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -330,6 +348,7 @@ pub static SHA1: Algorithm = Algorithm {
         u32x2!(0xc3d2e1f0u32, 0u32),
         0, 0, 0, 0, 0,
     ],
+    id: AlgorithmID::SHA1,
 };
 
 /// SHA-256 as specified in [FIPS 180-4].
@@ -349,6 +368,7 @@ pub static SHA256: Algorithm = Algorithm {
         u32x2!(0x1f83d9abu32, 0x5be0cd19u32),
         0, 0, 0, 0,
     ],
+    id: AlgorithmID::SHA256,
 };
 
 /// SHA-384 as specified in [FIPS 180-4].
@@ -371,6 +391,7 @@ pub static SHA384: Algorithm = Algorithm {
         0xdb0c2e0d64f98fa7,
         0x47b5481dbefa4fa4,
     ],
+    id: AlgorithmID::SHA384,
 };
 
 /// SHA-512 as specified in [FIPS 180-4].
@@ -393,6 +414,7 @@ pub static SHA512: Algorithm = Algorithm {
         0x1f83d9abfb41bd6b,
         0x5be0cd19137e2179,
     ],
+    id: AlgorithmID::SHA512,
 };
 
 /// SHA-512/256 as specified in [FIPS 180-4].
@@ -419,6 +441,7 @@ pub static SHA512_256: Algorithm = Algorithm {
         0x2b0199fc2c85b8aa,
         0x0eb72ddc81c52ca2,
     ],
+    id: AlgorithmID::SHA512_256,
 };
 
 // We use u64 to try to ensure 64-bit alignment/padding.

--- a/src/ec/suite_b/ecdsa.rs
+++ b/src/ec/suite_b/ecdsa.rs
@@ -26,8 +26,23 @@ use untrusted;
 pub struct ECDSASigningAlgorithm {
     curve: &'static ec::Curve,
     pkcs8_template: &'static pkcs8::Template,
+    id: ECDSASigningAlgorithmID
 }
 
+#[allow(non_camel_case_types)]
+#[derive(PartialEq, Eq)]
+enum ECDSASigningAlgorithmID {
+    ECDSA_P256_SHA256_FIXED_SIGNING,
+    ECDSA_P384_SHA384_FIXED_SIGNING,
+    ECDSA_P256_SHA256_ASN1_SIGNING,
+    ECDSA_P384_SHA384_ASN1_SIGNING,
+}
+
+impl PartialEq for ECDSASigningAlgorithm {
+    fn eq(&self, other: &Self) -> bool { self.id == other.id }
+}
+
+impl Eq for ECDSASigningAlgorithm {}
 
 /// An ECDSA verification algorithm.
 pub struct ECDSAVerificationAlgorithm {
@@ -41,6 +56,7 @@ pub struct ECDSAVerificationAlgorithm {
 }
 
 #[allow(non_camel_case_types)]
+#[derive(PartialEq, Eq)]
 enum ECDSAVerificationAlgorithmID {
     ECDSA_P256_SHA256_ASN1,
     ECDSA_P256_SHA256_FIXED,
@@ -318,6 +334,7 @@ pub static ECDSA_P256_SHA256_FIXED_SIGNING: ECDSASigningAlgorithm =
         ECDSASigningAlgorithm {
     curve: &ec::suite_b::curve::P256,
     pkcs8_template: &EC_PUBLIC_KEY_P256_PKCS8_V1_TEMPLATE,
+    id: ECDSASigningAlgorithmID::ECDSA_P256_SHA256_FIXED_SIGNING,
 };
 
 /// Verification of fixed-length (PKCS#11 style) ECDSA signatures using the
@@ -343,6 +360,7 @@ pub static ECDSA_P384_SHA384_FIXED_SIGNING: ECDSASigningAlgorithm =
         ECDSASigningAlgorithm {
     curve: &ec::suite_b::curve::P384,
     pkcs8_template: &EC_PUBLIC_KEY_P384_PKCS8_V1_TEMPLATE,
+    id: ECDSASigningAlgorithmID::ECDSA_P384_SHA384_FIXED_SIGNING,
 };
 
 /// Verification of fixed-length (PKCS#11 style) ECDSA signatures using the
@@ -368,6 +386,7 @@ pub static ECDSA_P256_SHA256_ASN1_SIGNING: ECDSASigningAlgorithm =
         ECDSASigningAlgorithm {
     curve: &ec::suite_b::curve::P256,
     pkcs8_template: &EC_PUBLIC_KEY_P256_PKCS8_V1_TEMPLATE,
+    id: ECDSASigningAlgorithmID::ECDSA_P256_SHA256_ASN1_SIGNING,
 };
 
 /// Verification of ASN.1 DER-encoded ECDSA signatures using the P-256 curve
@@ -429,6 +448,7 @@ pub static ECDSA_P384_SHA384_ASN1_SIGNING: ECDSASigningAlgorithm =
         ECDSASigningAlgorithm {
     curve: &ec::suite_b::curve::P384,
     pkcs8_template: &EC_PUBLIC_KEY_P384_PKCS8_V1_TEMPLATE,
+    id: ECDSASigningAlgorithmID::ECDSA_P384_SHA384_ASN1_SIGNING,
 };
 
 /// Verification of ASN.1 DER-encoded ECDSA signatures using the P-384 curve


### PR DESCRIPTION
PR for #542 

`#[derive(Eq)]` seems to not work for algorithm types because of other fields (with `fn` types for example), so explicit `impl Eq for Type {}` were added.

Also, some unintended diff in `aead/chacha20_poly1305.rs` and `agreement.rs`, because I use `rustfmt` tool in my emacs. If this is a problem, I will restore it.