### PR TITLE
fix mingw cross compile advapi32 linking

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -144,7 +144,7 @@ mod sysrand_chunk {
     use core;
     use {c, error};
 
-    #[link(name = "Advapi32")]
+    #[link(name = "advapi32")]
     extern "system" {
         #[link_name = "SystemFunction036"]
         fn RtlGenRandom(random_buffer: *mut u8,


### PR DESCRIPTION
Linking against upper case library names breaks cross compiling from Linux to Windows using mingw. This change doesn't affect native Windows builds (case-insensitive) or native Linux builds (don't use advapi32). All Travis tests passed.