### PR TITLE
Use explicitly uninitialized constants in tests.

### DIFF
--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -34,6 +34,8 @@
 
 extern crate ring;
 
+mod constants;
+
 use ring::{aead, error, test};
 use std::vec::Vec;
 
@@ -148,7 +150,7 @@ fn test_aead(aead_alg: &'static aead::Algorithm, file_path: &str) {
             257, // 16 AES blocks or 8 ChaCha20 blocks, plus 1.
         ];
 
-        let mut more_comprehensive_in_prefix_lengths = [0; 4096];
+        let mut more_comprehensive_in_prefix_lengths = [constants::UNINITIALIZED_USIZE; 4096];
         let in_prefix_lengths;
         if cfg!(debug_assertions) {
             in_prefix_lengths = &MINIMAL_IN_PREFIX_LENS[..];

--- a/tests/constants.rs
+++ b/tests/constants.rs
@@ -1,0 +1,5 @@
+#[allow(dead_code)]
+pub const UNINITIALIZED_BYTE: u8 = 0xDE;
+
+#[allow(dead_code)]
+pub const UNINITIALIZED_USIZE: usize = 9341997;

--- a/tests/digest_tests.rs
+++ b/tests/digest_tests.rs
@@ -34,6 +34,8 @@
 
 extern crate ring;
 
+mod constants;
+
 use std::vec::Vec;
 use ring::{digest, test};
 
@@ -187,7 +189,7 @@ macro_rules! test_i_u_f {
         #[cfg(not(debug_assertions))]
         #[test]
         fn $test_name() {
-            let mut input = [0; (digest::MAX_BLOCK_LEN + 1) * 3];
+            let mut input = [constants::UNINITIALIZED_BYTE; (digest::MAX_BLOCK_LEN + 1) * 3];
             let max = $alg.block_len + 1;
             for i in 0..(max * 3) {
                 input[i] = (i & 0xff) as u8;

--- a/tests/rsa_tests.rs
+++ b/tests/rsa_tests.rs
@@ -35,11 +35,12 @@
 extern crate ring;
 extern crate untrusted;
 
+mod constants;
+
 use ring::{der, error, signature, test};
 
 #[cfg(feature = "rsa_signing")]
 use ring::rand;
-
 
 #[cfg(feature = "rsa_signing")]
 #[test]
@@ -93,7 +94,7 @@ fn test_signature_rsa_pkcs1_sign() {
         let mut signing_state =
             signature::RSASigningState::new(key_pair).unwrap();
         let mut actual =
-            vec![0u8; signing_state.key_pair().public_modulus_len()];
+            vec![constants::UNINITIALIZED_BYTE; signing_state.key_pair().public_modulus_len()];
         signing_state.sign(alg, &rng, &msg, actual.as_mut_slice()).unwrap();
         assert_eq!(actual.as_slice() == &expected[..], result == "Pass");
         Ok(())
@@ -151,7 +152,7 @@ fn test_signature_rsa_pss_sign() {
         let mut signing_state =
             signature::RSASigningState::new(key_pair).unwrap();
         let mut actual =
-            vec![0u8; signing_state.key_pair().public_modulus_len()];
+            vec![constants::UNINITIALIZED_BYTE; signing_state.key_pair().public_modulus_len()];
         signing_state.sign(alg, &new_rng, &msg, actual.as_mut_slice())?;
         assert_eq!(actual.as_slice() == &expected[..], result == "Pass");
         Ok(())


### PR DESCRIPTION
A revision of https://github.com/briansmith/ring/pull/564 (i deleted my fork OOPS lol).
