### PR TITLE
Make per-nonce input size limit checks for AES-GCM consistent.

### DIFF
--- a/crypto/cipher/e_aes.c
+++ b/crypto/cipher/e_aes.c
@@ -303,7 +303,6 @@ int GFp_aes_gcm_seal(const void *ctx_buf, uint8_t *in_out, size_t in_out_len,
                      const uint8_t nonce[EVP_AEAD_AES_GCM_NONCE_LEN],
                      const uint8_t *ad, size_t ad_len) {
   assert(in_out != NULL || in_out_len == 0);
-  assert(aead_check_in_len(in_out_len));
   assert(ad != NULL || ad_len == 0);
 
   GCM128_CONTEXT gcm;
@@ -327,7 +326,6 @@ int GFp_aes_gcm_open(const void *ctx_buf, uint8_t *out, size_t in_out_len,
                      const uint8_t nonce[EVP_AEAD_AES_GCM_NONCE_LEN],
                      const uint8_t *in, const uint8_t *ad, size_t ad_len) {
   assert(out != NULL || in_out_len == 0);
-  assert(aead_check_in_len(in_out_len));
   assert(aead_check_alias(in, in_out_len, out));
   assert(in != NULL || in_out_len == 0);
   assert(ad != NULL || ad_len == 0);

--- a/crypto/cipher/internal.h
+++ b/crypto/cipher/internal.h
@@ -93,17 +93,6 @@ static inline int aead_check_alias(const uint8_t *in, size_t in_len,
   return 0;
 }
 
-/* |GFp_chacha_20| uses a 32-bit block counter. Therefore we disallow
- * individual operations that work on more than 256GB at a time, for all AEADs.
- * |in_len_64| is needed because, on 32-bit platforms, size_t is only
- * 32-bits and this produces a warning because it's always false.
- * Casting to uint64_t inside the conditional is not sufficient to stop
- * the warning. */
-static inline int aead_check_in_len(size_t in_len) {
-  const uint64_t in_len_64 = in_len;
-  return in_len_64 < (UINT64_C(1) << 32) * 64 - 64;
-}
-
 #if defined(__cplusplus)
 } /* extern C */
 #endif

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -25,7 +25,11 @@ pub static CHACHA20_POLY1305: aead::Algorithm = aead::Algorithm {
     seal: chacha20_poly1305_seal,
     open: chacha20_poly1305_open,
     id: aead::AlgorithmID::CHACHA20_POLY1305,
+    max_input_len: max_input_len!(CHACHA20_BLOCK_LEN, CHACHA20_OVERHEAD_BLOCKS_PER_NONCE),
 };
+
+const CHACHA20_BLOCK_LEN: u64 = 64;
+const CHACHA20_OVERHEAD_BLOCKS_PER_NONCE: u64 = 1;
 
 /// Copies |key| into |ctx_buf|.
 pub fn chacha20_poly1305_init(ctx_buf: &mut [u8], key: &[u8])
@@ -90,5 +94,14 @@ fn poly1305_update_padded_16(ctx: &mut poly1305::SigningContext, data: &[u8]) {
     if data.len() % 16 != 0 {
         static PADDING: [u8; 16] = [0u8; 16];
         ctx.update(&PADDING[..PADDING.len() - (data.len() % 16)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn max_input_len_test() {
+        // Errata 4858 at https://www.rfc-editor.org/errata_search.php?rfc=7539.
+        assert_eq!(super::CHACHA20_POLY1305.max_input_len, 274_877_906_880u64);
     }
 }

--- a/src/aead/mod.rs
+++ b/src/aead/mod.rs
@@ -25,11 +25,6 @@
 //! [AEAD]: http://www-cse.ucsd.edu/~mihir/papers/oem.html
 //! [`crypto.cipher.AEAD`]: https://golang.org/pkg/crypto/cipher/#AEAD
 
-pub mod chacha20_poly1305_openssh;
-
-mod chacha20_poly1305;
-mod aes_gcm;
-
 use {constant_time, error, init, poly1305, polyfill};
 
 pub use self::chacha20_poly1305::CHACHA20_POLY1305;
@@ -133,7 +128,7 @@ pub fn open_in_place<'a>(key: &OpeningKey, nonce: &[u8], ad: &[u8],
                 .checked_sub(in_prefix_len).ok_or(error::Unspecified)?;
     let ciphertext_len =
         ciphertext_and_tag_len.checked_sub(TAG_LEN).ok_or(error::Unspecified)?;
-    check_per_nonce_max_bytes(ciphertext_len)?;
+    check_per_nonce_max_bytes(key.key.algorithm, ciphertext_len)?;
     let (in_out, received_tag) =
         ciphertext_and_tag_modified_in_place
             .split_at_mut(in_prefix_len + ciphertext_len);
@@ -221,7 +216,7 @@ pub fn seal_in_place(key: &SealingKey, nonce: &[u8], ad: &[u8],
     let nonce = slice_as_array_ref!(nonce, NONCE_LEN)?;
     let in_out_len =
         in_out.len().checked_sub(out_suffix_capacity).ok_or(error::Unspecified)?;
-    check_per_nonce_max_bytes(in_out_len)?;
+    check_per_nonce_max_bytes(key.key.algorithm, in_out_len)?;
     let (in_out, tag_out) = in_out.split_at_mut(in_out_len);
     let tag_out = slice_as_array_ref_mut!(tag_out, TAG_LEN)?;
     (key.key.algorithm.seal)(&key.key.ctx_buf, nonce, ad, in_out, tag_out)?;
@@ -280,6 +275,19 @@ pub struct Algorithm {
 
     key_len: usize,
     id: AlgorithmID,
+
+    /// Use `max_input_len!()` to initialize this.
+    // TODO: Make this `usize`.
+    max_input_len: u64,
+}
+
+/// TODO: Make this a `const fn` when those become stable.
+macro_rules! max_input_len {
+    ($block_len:expr, $overhead_blocks_per_nonce:expr) => {
+        /// Each of our AEADs use a 32-bit block counter so the maximum is the
+        /// largest input that will not overflow the counter.
+        (((1u64 << 32) - $overhead_blocks_per_nonce) * $block_len)
+    }
 }
 
 impl Algorithm {
@@ -334,12 +342,14 @@ const TAG_LEN: usize = poly1305::TAG_LEN;
 const NONCE_LEN: usize = 96 / 8;
 
 
-/// |GFp_chacha_20| uses a 32-bit block counter, so we disallow individual
-/// operations that work on more than 256GB at a time, for all AEADs.
-fn check_per_nonce_max_bytes(in_out_len: usize)
+fn check_per_nonce_max_bytes(alg: &Algorithm, in_out_len: usize)
                              -> Result<(), error::Unspecified> {
-    if polyfill::u64_from_usize(in_out_len) >= (1u64 << 32) * 64 - 64 {
+    if polyfill::u64_from_usize(in_out_len) > alg.max_input_len {
         return Err(error::Unspecified);
     }
     Ok(())
 }
+
+pub mod chacha20_poly1305_openssh;
+mod chacha20_poly1305;
+mod aes_gcm;


### PR DESCRIPTION
The checks in gcm.c are correct but the other checks are not correct.
Remove the redundant and not-tight-enough `aead_check_in_len()`
assertions. Fix the checks in the Rust code to match the checks in
gcm.c.

Thanks to Frithjof Schulze for reporting this.