### PR TITLE
Issue #540 - Adds Debug implementation for public algorithm types

### DIFF
--- a/src/aead/mod.rs
+++ b/src/aead/mod.rs
@@ -305,8 +305,10 @@ impl Algorithm {
     pub fn nonce_len(&self) -> usize { NONCE_LEN }
 }
 
+derive_debug_from_field!(Algorithm, id);
+
 #[allow(non_camel_case_types)]
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 enum AlgorithmID {
     AES_128_GCM,
     AES_256_GCM,
@@ -337,4 +339,17 @@ fn check_per_nonce_max_bytes(in_out_len: usize)
         return Err(error::Unspecified);
     }
     Ok(())
+}
+
+#[test]
+fn fmt_algorithm() {
+    let test_cases = [
+        (&AES_128_GCM, "AES_128_GCM"),
+        (&AES_256_GCM, "AES_256_GCM"),
+        (&CHACHA20_POLY1305, "CHACHA20_POLY1305"),
+    ];
+
+    for &(algorithm, expected) in test_cases.iter() {
+        assert_eq!(expected, &format!("{:?}", algorithm));
+    }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 Trent Clarke.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// Generates an implementation of the Debug trait for a type that defers to the
+// Debug implementation for a given field.
+macro_rules! derive_debug_from_field {
+    ($typename:ty, $fieldname:ident) => {
+        impl ::core::fmt::Debug for $typename {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
+                ::core::fmt::Debug::fmt(&self.$fieldname, f)
+            }
+        }
+    };
+}

--- a/src/digest/mod.rs
+++ b/src/digest/mod.rs
@@ -299,7 +299,7 @@ pub struct Algorithm {
     id: AlgorithmID,
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
 enum AlgorithmID {
     SHA1,
@@ -315,22 +315,7 @@ impl PartialEq for Algorithm {
 
 impl Eq for Algorithm {}
 
-impl core::fmt::Debug for Algorithm {
-    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
-        // This would have to change if/when we add other algorithms with the
-        // same lengths.
-        let (n, suffix) =
-            if self.output_len == SHA512_256_OUTPUT_LEN &&
-               self.block_len == SHA512_BLOCK_LEN {
-            (512, "_256")
-        } else if self.output_len == 20 {
-            (1, "")
-        } else {
-            (self.output_len * 8, "")
-        };
-        write!(fmt, "SHA{}{}", n, suffix)
-    }
-}
+derive_debug_from_field!(Algorithm, id);
 
 /// SHA-1 as specified in [FIPS 180-4]. Deprecated.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,9 @@ extern crate test as bench;
 #[macro_use]
 extern crate lazy_static;
 
+#[macro_use]
+mod debug;
+
 // `ring::test` uses the formatting & printing stuff in non-test mode.
 #[macro_use]
 extern crate std;


### PR DESCRIPTION
This changeset adds the ring::debug module, containing the
derive_debug_from_field!() macro, which generates an implementation of
fmt::Debug that defers the formatting to a given field.

This macro is then used to generate fmt::Debug implmentations for
aead::Algorithm and digest::Algorithm which print the algorithm id.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.