### PR TITLE
Check __ANDROID_API__ instead of defining it automatically

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -58,6 +58,9 @@ Note in particular that if you are cross-compiling an x86 build on a 64-bit
 version of Linux, then you need to have the proper gcc-multilibs and
 g++-multilibs packages or equivalent installed.
 
+On Android, you will need to define the `__ANDROID_API__` constant to at least
+`21` on 64-bit and `18` on 32-bit.
+
 
 
 Additional Features that are Useful for Development

--- a/build.rs
+++ b/build.rs
@@ -587,17 +587,6 @@ fn cc(file: &Path, ext: &str, target: &Target, warnings_are_errors: bool,
         // http://www.openwall.com/lists/musl/2015/06/17/1
         let _ = c.flag("-U_FORTIFY_SOURCE");
     }
-    if target.os() == "android" {
-        // Define __ANDROID_API__ to the Android API level we want.
-        // Needed for Android NDK Unified Headers, see:
-        // https://android.googlesource.com/platform/ndk/+/master/docs/UnifiedHeaders.md#Supporting-Unified-Headers-in-Your-Build-System
-        if target.arch() == "aarch64" {
-            // Minimum API level where AArch64 is available is 21.
-            let _ = c.define("__ANDROID_API__", Some("21"));
-        } else {
-            let _ = c.define("__ANDROID_API__", Some("18"));
-        }
-    }
 
     let mut c = c.get_compiler().to_command();
     let _ = c.arg("-c")


### PR DESCRIPTION
This pull requests removes the code that automatically defines the `__ANDROID_API__` constant, and replaces it by a code that checks whether the constant has been defined by something else.
In other words, we now assume that the user manually defines `__ANDROID_API__`, for example through the `CFLAGS` environment variable.

The main reason is practical. If you generate a standalone NDK toolchain in order to compile your project, the wrapper automatically passes the `__ANDROID_API__` constant to the actual compiler. Therefore if you try to compile *ring* for the standalone toolchain, you will most likely get a compilation error because the constant passed by the standalone conflicts with the one defined by ring.

I don't know how widely used *ring* for Android is, but I'm open to feedback about this change. I don't really have a very strong opinion ; my goal is mainly to make Android compilation as smooth as possible.
