### PR TITLE
Adds rng support for Fuchsia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,3 +321,6 @@ rpath = false
 lto = true
 debug-assertions = false
 codegen-units = 1
+
+[target.'cfg(target_os = "fuchsia")'.dependencies]
+fuchsia-zircon = "0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ extern crate test as bench;
 #[cfg(any(target_os = "redox",
           all(unix,
               not(any(target_os = "macos", target_os = "ios")),
+              not(any(target_os = "fuchsia")),
               any(not(target_os = "linux"),
                   feature = "dev_urandom_fallback"))))]
 #[macro_use]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -97,6 +97,7 @@ impl SecureRandom for SystemRandom {
 #[cfg(not(any(target_os = "linux",
               target_os = "macos",
               target_os = "ios",
+              target_os = "fuchsia",
               windows)))]
 use self::urandom::fill as fill_impl;
 
@@ -109,6 +110,9 @@ use self::sysrand_or_urandom::fill as fill_impl;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use self::darwin::fill as fill_impl;
+
+#[cfg(any(target_os = "fuchsia"))]
+use self::fuchsia::fill as fill_impl;
 
 #[cfg(target_os = "linux")]
 mod sysrand_chunk {
@@ -186,6 +190,7 @@ mod sysrand {
 
 // Keep the `cfg` conditions in sync with the conditions in lib.rs.
 #[cfg(all(any(target_os = "redox", unix),
+          not(any(target_os = "fuchsia")),
           not(any(target_os = "macos", target_os = "ios")),
           not(all(target_os = "linux",
                   not(feature = "dev_urandom_fallback")))))]
@@ -273,6 +278,26 @@ mod darwin {
         // For now `rnd` must be `kSecRandomDefault`.
         fn SecRandomCopyBytes(rnd: &'static SecRandomRef, count: c::size_t,
                               bytes: *mut u8) -> c::int;
+    }
+}
+
+#[cfg(target_os = "fuchsia")]
+mod fuchsia {
+    extern crate fuchsia_zircon;
+
+    use error;
+
+    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        for s in dest.chunks_mut(fuchsia_zircon::sys::ZX_CPRNG_DRAW_MAX_LEN) {
+            let mut filled = 0;
+            while filled < s.len() {
+                match fuchsia_zircon::cprng_draw(&mut s[filled..]) {
+                    Ok(actual) => filled += actual,
+                    Err(e) => panic!("cprng_draw failed: {:?}", e),
+                };
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
We're considering using ring as the basis of our Rust crypto for [Fuchsia](https://fuchsia.googlesource.com/docs/). The std::rand crate already has Fuchsia OS specific support and it would be great if we could get it in ring as well.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.
