### PR TITLE
Remove -fdata-sections and -ffunction-sections (let cc set these if needed)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -191,8 +191,6 @@ fn c_flags(target: &Target) -> &'static [&'static str] {
 fn cpp_flags(target: &Target) -> &'static [&'static str] {
     if target.env != MSVC {
         static NON_MSVC_FLAGS: &'static [&'static str] = &[
-            "-fdata-sections",
-            "-ffunction-sections",
             "-pedantic",
             "-pedantic-errors",
             "-Wall",


### PR DESCRIPTION
Since https://github.com/alexcrichton/cc-rs/pull/294 this crate has stopped compiling on iOS targets with:

```
clang: error: -fdata-sections is not supported with -fembed-bitcode
clang: error: -ffunction-sections is not supported with -fembed-bitcode
```