### PR TITLE
Add missing forward declaration for |LIMBS_equal_limb|.

### DIFF
--- a/crypto/limbs/limbs.h
+++ b/crypto/limbs/limbs.h
@@ -30,6 +30,7 @@ typedef BN_ULONG Limb;
 Limb LIMBS_are_zero(const Limb a[], size_t num_limbs);
 void LIMBS_copy(Limb r[], const Limb a[], size_t num_limbs);
 Limb LIMBS_equal(const Limb a[], const Limb b[], size_t num_limbs);
+Limb LIMBS_equal_limb(const Limb a[], Limb b, size_t num_limbs);
 void LIMBS_reduce_once(Limb r[], const Limb m[], size_t num_limbs);
 void LIMBS_add_mod(Limb r[], const Limb a[], const Limb b[], const Limb m[],
                    size_t num_limbs);


### PR DESCRIPTION
|LIMBS_equal_limb| was added in:

* e70787436f03b84cf08601352460d51b23ba4366

But the header was not updated, resulting in compile failures.