### PR TITLE
Add PBKDF2-HMAC-SHA256 test vectors from RFC 7914

### DIFF
--- a/tests/pbkdf2_tests.txt
+++ b/tests/pbkdf2_tests.txt
@@ -248,3 +248,19 @@ S = "salt"
 c = 8
 DK = ""
 Verify = Err
+
+# PBKDF2 test vectors from RFC 7914
+
+Hash = SHA256
+P = "passwd"
+S = "salt"
+c = 1
+DK = 55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783
+Verify = OK
+
+Hash = SHA256
+P = "Password"
+S = "NaCl"
+c = 80000
+DK = 4ddcd8f60b98be21830cee5ef22701f9641a4418d04c0414aeff08876b34ab56a1d425a1225833549adb841b51c9b3176a272bdebba1d078478f62b397f33c8d
+Verify = OK


### PR DESCRIPTION
[RFC link](https://tools.ietf.org/html/rfc7914#section-11).