### PR TITLE
Added `RING_DISABLE_PREGENERATED` enviroment flag

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -378,8 +378,9 @@ fn build_c_code(target: &Target, pregenerated: PathBuf, out_dir: &Path) {
     }).unwrap();
 
     let is_git = std::fs::metadata(".git").is_ok();
+    let disable_pregenerated = std::env::var("RING_DISABLE_PREGENERATED").is_ok();
 
-    let use_pregenerated = !is_git;
+    let use_pregenerated = !is_git && !disable_pregenerated;
     let warnings_are_errors = is_git;
 
     let asm_dir = if use_pregenerated { &pregenerated } else { out_dir };


### PR DESCRIPTION
Motivation: https://github.com/paritytech/parity-ethereum/issues/8612

Currently pregenerated asms used in all cases except sources as git
repo. This commit add special flag `RING_DISABLE_PREGENERATED` as
enviroment variable. It helps to disable using of pregenerated files
in some cases like a cargo-vendor builds.