### PR TITLE
Add support for MIPS architectures in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,54 @@ matrix:
   fast_finish: true
   allow_failures:
     - rust: nightly
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
   include:
     # The lines from "# BEGIN GENERATED" through "# END GENERATED" are
     # generated by running |python mk/update-travis-yml.py|. Any changes
@@ -437,6 +485,102 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: stable
+      os: linux
+      services:
+        - docker
+
     - env: TARGET_X=x86_64-apple-darwin  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: nightly
       os: osx
@@ -857,6 +1001,102 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: nightly
+      os: linux
+      services:
+        - docker
+
     - env: TARGET_X=x86_64-apple-darwin  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
       rust: beta
       os: osx
@@ -1276,6 +1516,102 @@ matrix:
             - libc6-dev-armhf-cross
           sources:
             - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64-unknown-linux-gnuabi64 CC_X=mips64-linux-gnuabi64-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips64el-unknown-linux-gnuabi64 CC_X=mips64el-linux-gnuabi64-gcc  FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mipsel-unknown-linux-gnu CC_X=mipsel-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X=--features=rsa_signing MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
+
+    - env: TARGET_X=mips-unknown-linux-gnu CC_X=mips-linux-gnu-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0
+      rust: beta
+      os: linux
+      services:
+        - docker
 
     # END GENERATED
 


### PR DESCRIPTION
This adds mips/mips64/mipsel/mips64el targets to the build system.

Unfortunately travis `trusty` image doesn't ship with `gcc-mips*`
packages. On these platforms `cargo` is replaced with `cross`[1] to run
those builds on a docker container.

For now all MIPS tests are allowed to fail to make way for future PRs
that will fill the gaps.

This is a first step to bring support to MIPS platforms (#562).

Note that the with this commit matrix really grew up to about 168 builds. This is fine since we have 'fast_finish` (no waiting for `allow_failures` builds).

I'm still waiting for a full build to finish on my fork (https://travis-ci.org/mpapierski/ring). Note that at first I've disabled few tests just to make way for `mips` builds, and I plan to re-run cancelled tests that are known to be green just to make sure everything works as expected.

Expected failure on all mips architectures:

```
--- stderr
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', libcore/option.rs:335:21
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

[1]: https://github.com/japaric/cross