### PR TITLE
Very small fix so the PrivateKey and EphemeralPrivateKey structs can be copied.

### DIFF
--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -98,6 +98,7 @@ derive_debug_from_field!(Algorithm, i);
 /// An ephemeral private key for use (only) with `agree_ephemeral`. The
 /// signature of `agree_ephemeral` ensures that an `EphemeralPrivateKey` can be
 /// used for at most one key agreement.
+#[derive(Clone, Copy)]
 pub struct EphemeralPrivateKey {
     private_key: ec::PrivateKey,
     alg: &'static Algorithm,

--- a/src/ec/mod.rs
+++ b/src/ec/mod.rs
@@ -62,6 +62,7 @@ pub struct KeyPair {
     pub public_key: [u8; PUBLIC_KEY_MAX_LEN],
 }
 
+#[derive(Clone, Copy)]
 pub struct PrivateKey {
     bytes: [u8; SCALAR_MAX_BYTES],
 }


### PR DESCRIPTION
Nothing exceptional.