### PR TITLE
Use "stable" instead of an explicit version for rust on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ platform:
 environment:
   matrix:
     - TOOLCHAIN_VERSION: 14.0
-      RUST: 1.26.0
+      RUST: stable
     - TOOLCHAIN_VERSION: 14.0
       RUST: beta
     - TOOLCHAIN_VERSION: 14.0


### PR DESCRIPTION
*ring* only supports the latest version of each rust release channel.

I might be missing the rationale for the current behavior. Many CI templates also [use the channel name](https://github.com/japaric/trust/blob/bbeaa9b8282f5faf2a2e276d41e2960082edbd2b/appveyor.yml#L8).