### PR TITLE
Make caller enforce invariants when setting AES encryption key

### DIFF
--- a/crypto/fipsmodule/aes/internal.h
+++ b/crypto/fipsmodule/aes/internal.h
@@ -26,8 +26,8 @@ extern "C" {
 #if defined(OPENSSL_NO_ASM) || \
     (!defined(OPENSSL_X86) && !defined(OPENSSL_X86_64) && !defined(OPENSSL_ARM))
 #define GFp_C_AES
-int GFp_aes_c_set_encrypt_key(const uint8_t *key, unsigned bits,
-                              AES_KEY *aeskey);
+void GFp_aes_c_set_encrypt_key(const uint8_t *key, unsigned bits,
+                               AES_KEY *aeskey);
 void GFp_aes_c_encrypt(const uint8_t *in, uint8_t *out, const AES_KEY *key);
 #endif
 


### PR DESCRIPTION
Resolves #113.

`GFp_AES_set_encrypt_key` can fail if and only if the following invariants are violated.

* All pointer arguments must be non-null.
* The key size must be either 128 or 256 bits (192 bit keys [aren't supported](https://github.com/briansmith/ring/commit/b3e91be71edde28f5d2884d3c3c34260b6a79378)).

The first invariant should not be checked at runtime (except via assertion) as it is the responsibility of the caller.

The second could be expressed statically by accepting an enum with the valid key lengths, but enums don't provide any type safety in C. Instead, we document the acceptable key lengths and make them the responsibility of the caller.

As a result of these changes, `GFp_AES_set_encrypt_key` (as well as `GFp_aes_c_set_encrypt_key`) no longer needs to return an error code. The assembly functions still return an error code and do input validation.