### PR TITLE
Use rustup on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ platform:
 environment:
   matrix:
     - TOOLCHAIN_VERSION: 14.0
-      RUST: 1.26.0
+      RUST: stable
     - TOOLCHAIN_VERSION: 14.0
       RUST: beta
     - TOOLCHAIN_VERSION: 14.0

--- a/mk/appveyor.bat
+++ b/mk/appveyor.bat
@@ -50,7 +50,7 @@ set TARGET=%TARGET_ARCH%-pc-windows-msvc
 %RUSTUP_EXE% -y --default-host %TARGET% --default-toolchain %RUST%
 if %ERRORLEVEL% NEQ 0 exit 1
 
-set PATH="C:\Users\appveyor\.cargo\bin";%cd%\windows_build_tools;%PATH%
+set PATH=%USERPROFILE%\.cargo\bin;%cd%\windows_build_tools;%PATH%
 
 if [%Configuration%] == [Release] set CARGO_MODE=--release
 

--- a/mk/appveyor.bat
+++ b/mk/appveyor.bat
@@ -36,19 +36,21 @@ if %ERRORLEVEL% NEQ 0 (
   exit 1
 )
 
-set RUST_URL=https://static.rust-lang.org/dist/rust-%RUST%-%TARGET_ARCH%-pc-windows-msvc.msi
-echo Downloading %RUST_URL%...
 mkdir build
-powershell -Command "(New-Object Net.WebClient).DownloadFile('%RUST_URL%', 'build\rust-%RUST%-%TARGET_ARCH%-pc-windows-msvc.msi')"
+set RUSTUP_URL=https://win.rustup.rs/%TARGET_ARCH%
+set RUSTUP_EXE=build\rustup-init-%TARGET_ARCH%.exe
+echo Downloading %RUSTUP_URL%...
+powershell -Command "(New-Object Net.WebClient).DownloadFile('%RUSTUP_URL%', '%RUSTUP_EXE%')"
 if %ERRORLEVEL% NEQ 0 (
-  echo ...downloading Rust failed.
+  echo ...downloading rustup failed.
   exit 1
 )
 
-start /wait msiexec /i build\rust-%RUST%-%TARGET_ARCH%-pc-windows-msvc.msi INSTALLDIR="%TARGET_PROGRAM_FILES%\Rust %RUST%" /quiet /qn /norestart
+set TARGET=%TARGET_ARCH%-pc-windows-msvc
+%RUSTUP_EXE% -y --default-host %TARGET% --default-toolchain %RUST%
 if %ERRORLEVEL% NEQ 0 exit 1
 
-set PATH="%TARGET_PROGRAM_FILES%\Rust %RUST%\bin";%cd%\windows_build_tools;%PATH%
+set PATH="C:\Users\appveyor\.cargo\bin";%cd%\windows_build_tools;%PATH%
 
 if [%Configuration%] == [Release] set CARGO_MODE=--release
 


### PR DESCRIPTION
Use rustup to install rust on AppVeyor.

Unfortunately rustup always [installs rust's documentation](https://github.com/rust-lang-nursery/rustup.rs/issues/998), so this may slow down CI builds on Windows.

I agree to license my contributions to each file under the terms given at the top of each file I changed.