### PR TITLE
Remove 192-bit key support from AES-NI assembly.

### DIFF
--- a/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl
+++ b/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl
@@ -309,7 +309,7 @@ _aesni_ctr32_ghash_6x:
 	  vmovups	0xb0-0x80($key),$rndkey
 	  vaesenc	$T1,$inout5,$inout5
 	  vmovups	0xc0-0x80($key),$T1
-	  je		.Lenc_tail		# 192-bit key
+	  # 192-bit key support was removed.
 
 	  vaesenc	$rndkey,$inout0,$inout0
 	  vaesenc	$rndkey,$inout1,$inout1


### PR DESCRIPTION
Resolves #705 for code using x86{,_64} AES-NI extensions. 192-bit key support still exists in ARM assembly.

Since *ring* does not support AES with 192-bit keys, we can remove some unused assembly code.

Comments were added to indicate that 192-bit key support was willfully removed, and also to indicate where control-flow changed based on key size.

This extends the work done in commits 1103cf29dfbbf51f0dd8fb757084caa052863869 and b3e91be71edde28f5d2884d3c3c34260b6a79378.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.