### PR TITLE
rand: replace lazy_static with std::sync::Once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,9 +280,6 @@ untrusted = "0.6.2"
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { version = "0.2.34" }
 
-[target.'cfg(any(target_os = "redox", all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies]
-lazy_static = "1.0"
-
 # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
 [build-dependencies]
 # we do not use the gcc parallel feature because we do the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,14 +74,6 @@ extern crate libc;
 #[cfg(feature = "internal_benches")]
 extern crate test as bench;
 
-#[cfg(any(target_os = "redox",
-          all(unix,
-              not(any(target_os = "macos", target_os = "ios")),
-              any(not(target_os = "linux"),
-                  feature = "dev_urandom_fallback"))))]
-#[macro_use]
-extern crate lazy_static;
-
 #[macro_use]
 mod debug;
 


### PR DESCRIPTION
This replaces the use of `lazy_static` with mutable statics.  I'm pretty new to Rust, would love any feedback!

fixes #706

I agree to license my contributions to each file under the terms given at the top of each file I changed.
