### PR TITLE
Replace `slice_as_array_ref!` and `slice_as_array_ref_mut!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ include = [
     "src/agreement.rs",
     "src/arithmetic/mod.rs",
     "src/arithmetic/montgomery.rs",
+    "src/array.rs",
     "src/bits.rs",
     "src/bssl.rs",
     "src/c.rs",

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -138,7 +138,7 @@ extern "C" {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{bits::BitLength, c, test};
+    use crate::{bits::BitLength, c, polyfill::convert::*, test};
 
     #[test]
     pub fn test_aes() {
@@ -146,9 +146,8 @@ mod tests {
             assert_eq!(section, "");
             let key = test_case.consume_bytes("Key");
             let input = test_case.consume_bytes("Input");
-            let input = slice_as_array_ref!(&input, AES_BLOCK_SIZE).unwrap();
+            let input: &[u8; AES_BLOCK_SIZE] = input.as_slice().try_into_().unwrap();
             let expected_output = test_case.consume_bytes("Output");
-            let expected_output = slice_as_array_ref!(&expected_output, AES_BLOCK_SIZE).unwrap();
 
             // Key setup.
             let key_bits = BitLength::from_usize_bytes(key.len()).unwrap();

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -14,45 +14,49 @@
 
 use crate::endian::*;
 
-#[repr(C, align(4))]
+/// An array of 16 bytes that can (in the x86_64 and AAarch64 ABIs, at least)
+/// be efficiently passed by value and returned by value (i.e. in registers),
+/// and which meets the alignment requirements of `u32` and `u64` (at least)
+/// for the target.
+#[repr(C)]
 #[derive(Copy, Clone)]
-pub union Block {
-    subblocks_le: [LittleEndian<u64>; 2],
-    bytes: [u8; BLOCK_LEN],
+pub struct Block {
+    subblocks: [u64; 2],
 }
 
 pub const BLOCK_LEN: usize = 16;
 
 impl Block {
     #[inline]
-    pub fn zero() -> Self {
+    pub fn zero() -> Self { Self { subblocks: [0, 0] } }
+
+    #[inline]
+    pub fn from_u64_le(first: LittleEndian<u64>, second: LittleEndian<u64>) -> Self {
         Self {
-            subblocks_le: [Encoding::ZERO; 2],
+            subblocks: [unsafe { core::mem::transmute(first) }, unsafe {
+                core::mem::transmute(second)
+            }],
         }
     }
 
+    /// Replaces the first `a.len()` bytes of the block's value with `a`,
+    /// leaving the rest of the block unchanged. Panics if `a` is larger
+    /// than a block.
     #[inline]
-    pub fn partial_copy_from(&mut self, a: &[u8]) {
-        let self_bytes = unsafe { &mut self.bytes };
-        self_bytes[..a.len()].copy_from_slice(a);
-    }
+    pub fn partial_copy_from(&mut self, a: &[u8]) { self.as_mut()[..a.len()].copy_from_slice(a); }
 }
 
 impl<'a> From<&'a [u8; BLOCK_LEN]> for Block {
     #[inline]
-    fn from(bytes: &[u8; BLOCK_LEN]) -> Self {
-        Self {
-            bytes: bytes.clone(),
-        }
-    }
-}
-
-impl From<[LittleEndian<u64>; 2]> for Block {
-    #[inline]
-    fn from(subblocks_le: [LittleEndian<u64>; 2]) -> Self { Self { subblocks_le } }
+    fn from(bytes: &[u8; BLOCK_LEN]) -> Self { unsafe { core::mem::transmute_copy(bytes) } }
 }
 
 impl AsRef<[u8; BLOCK_LEN]> for Block {
     #[inline]
-    fn as_ref(&self) -> &[u8; BLOCK_LEN] { unsafe { &self.bytes } }
+    fn as_ref(&self) -> &[u8; BLOCK_LEN] { unsafe { core::mem::transmute(self) } }
+}
+
+impl AsMut<[u8; BLOCK_LEN]> for Block {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8; BLOCK_LEN] { unsafe { core::mem::transmute(self) } }
 }

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -51,6 +51,11 @@ impl<'a> From<&'a [u8; BLOCK_LEN]> for Block {
     fn from(bytes: &[u8; BLOCK_LEN]) -> Self { unsafe { core::mem::transmute_copy(bytes) } }
 }
 
+impl<'a> From_<&'a [u8; 2 * BLOCK_LEN]> for [Block; 2] {
+    #[inline]
+    fn from_(bytes: &[u8; 2 * BLOCK_LEN]) -> Self { unsafe { core::mem::transmute_copy(bytes) } }
+}
+
 impl AsRef<[u8; BLOCK_LEN]> for Block {
     #[inline]
     fn as_ref(&self) -> &[u8; BLOCK_LEN] { unsafe { core::mem::transmute(self) } }
@@ -59,4 +64,10 @@ impl AsRef<[u8; BLOCK_LEN]> for Block {
 impl AsMut<[u8; BLOCK_LEN]> for Block {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8; BLOCK_LEN] { unsafe { core::mem::transmute(self) } }
+}
+
+/// Like `AsMut`.
+impl From_<&mut [Block; 2]> for &mut [u8; 2 * BLOCK_LEN] {
+    #[inline]
+    fn from_(bytes: &mut [Block; 2]) -> Self { unsafe { core::mem::transmute(bytes) } }
 }

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use crate::endian::*;
+use crate::{endian::*, polyfill::convert::*};
 
 /// An array of 16 bytes that can (in the x86_64 and AAarch64 ABIs, at least)
 /// be efficiently passed by value and returned by value (i.e. in registers),

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -14,7 +14,10 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::block::{Block, BLOCK_LEN};
-use crate::{c, polyfill::slice::u32_from_le_u8};
+use crate::{
+    c,
+    polyfill::{convert::*, slice::u32_from_le_u8},
+};
 use core;
 
 #[repr(C)]
@@ -88,9 +91,9 @@ pub type Counter = [u32; 4];
 pub fn make_counter(nonce: &[u8; NONCE_LEN], counter: u32) -> Counter {
     [
         counter.to_le(),
-        u32_from_le_u8(slice_as_array_ref!(&nonce[0..4], 4).unwrap()),
-        u32_from_le_u8(slice_as_array_ref!(&nonce[4..8], 4).unwrap()),
-        u32_from_le_u8(slice_as_array_ref!(&nonce[8..12], 4).unwrap()),
+        u32_from_le_u8(nonce[0..4].try_into_().unwrap()),
+        u32_from_le_u8(nonce[4..8].try_into_().unwrap()),
+        u32_from_le_u8(nonce[8..12].try_into_().unwrap()),
     ]
 }
 
@@ -120,7 +123,8 @@ mod tests {
             assert_eq!(section, "");
 
             let key = test_case.consume_bytes("Key");
-            let key = Key::from(slice_as_array_ref!(&key, KEY_LEN)?);
+            let key: &[u8; KEY_LEN] = key.as_slice().try_into_()?;
+            let key = Key::from(key);
 
             let ctr = test_case.consume_usize("Ctr");
             let nonce_bytes = test_case.consume_bytes("Nonce");

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -24,12 +24,7 @@ use core;
 pub struct Key([Block; KEY_BLOCKS]);
 
 impl<'a> From<&'a [u8; KEY_LEN]> for Key {
-    fn from(value: &[u8; KEY_LEN]) -> Self {
-        Key([
-            Block::from(slice_as_array_ref!(&value[..BLOCK_LEN], BLOCK_LEN).unwrap()),
-            Block::from(slice_as_array_ref!(&value[BLOCK_LEN..], BLOCK_LEN).unwrap()),
-        ])
-    }
+    fn from(value: &[u8; KEY_LEN]) -> Self { Key(<[Block; KEY_BLOCKS]>::from_(value)) }
 }
 
 #[inline]
@@ -128,7 +123,7 @@ mod tests {
 
             let ctr = test_case.consume_usize("Ctr");
             let nonce_bytes = test_case.consume_bytes("Nonce");
-            let nonce = slice_as_array_ref!(&nonce_bytes, NONCE_LEN).unwrap();
+            let nonce: &[u8; NONCE_LEN] = nonce_bytes.as_slice().try_into_().unwrap();
             let ctr = make_counter(&nonce, ctr as u32);
             let input = test_case.consume_bytes("Input");
             let output = test_case.consume_bytes("Output");

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -16,7 +16,12 @@ use super::{
     block::{Block, BLOCK_LEN},
     chacha, poly1305, Direction, Tag,
 };
-use crate::{aead, endian::*, error, polyfill};
+use crate::{
+    aead,
+    endian::*,
+    error,
+    polyfill::{self, convert::*},
+};
 
 /// ChaCha20-Poly1305 as described in [RFC 7539].
 ///
@@ -34,9 +39,8 @@ pub static CHACHA20_POLY1305: aead::Algorithm = aead::Algorithm {
 
 /// Copies |key| into |ctx_buf|.
 fn chacha20_poly1305_init(key: &[u8]) -> Result<aead::KeyInner, error::Unspecified> {
-    Ok(aead::KeyInner::ChaCha20Poly1305(chacha::Key::from(
-        slice_as_array_ref!(key, chacha::KEY_LEN)?,
-    )))
+    let key: &[u8; chacha::KEY_LEN] = key.try_into_()?;
+    Ok(aead::KeyInner::ChaCha20Poly1305(chacha::Key::from(key)))
 }
 
 fn chacha20_poly1305_seal(

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -12,10 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{
-    block::{Block, BLOCK_LEN},
-    chacha, poly1305, Direction, Tag,
-};
+use super::{chacha, poly1305, Block, Direction, Tag, BLOCK_LEN};
 use crate::{
     aead,
     endian::*,
@@ -127,7 +124,8 @@ pub(super) fn derive_poly1305_key(
 ) -> poly1305::Key {
     let mut bytes = [0u8; poly1305::KEY_LEN];
     chacha::chacha20_xor_in_place(chacha_key, counter, &mut bytes);
-    poly1305::Key::from(bytes)
+    let blocks: [Block; poly1305::KEY_BLOCKS] = (&bytes).into();
+    poly1305::Key::from(blocks)
 }
 
 #[cfg(test)]

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -122,9 +122,12 @@ fn poly1305_update_padded_16(ctx: &mut poly1305::Context, input: &[u8]) {
 pub(super) fn derive_poly1305_key(
     chacha_key: &chacha::Key, counter: &chacha::Counter,
 ) -> poly1305::Key {
-    let mut bytes = [0u8; poly1305::KEY_LEN];
-    chacha::chacha20_xor_in_place(chacha_key, counter, &mut bytes);
-    let blocks: [Block; poly1305::KEY_BLOCKS] = (&bytes).into();
+    let mut blocks = [Block::zero(); poly1305::KEY_BLOCKS];
+    chacha::chacha20_xor_in_place(
+        chacha_key,
+        counter,
+        <&mut [u8; poly1305::KEY_BLOCKS * BLOCK_LEN]>::from_(&mut blocks),
+    );
     poly1305::Key::from(blocks)
 }
 

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -93,11 +93,13 @@ fn aead(
         },
     };
 
-    let lengths = [
-        LittleEndian::from(polyfill::u64_from_usize(ad.len())),
-        LittleEndian::from(polyfill::u64_from_usize(in_out_len)),
-    ];
-    ctx.update_block(Block::from(lengths), poly1305::Pad::Pad);
+    ctx.update_block(
+        Block::from_u64_le(
+            LittleEndian::from(polyfill::u64_from_usize(ad.len())),
+            LittleEndian::from(polyfill::u64_from_usize(in_out_len)),
+        ),
+        poly1305::Pad::Pad,
+    );
     ctx.finish()
 }
 

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -22,11 +22,13 @@ use super::{
 use crate::{bssl, c, error};
 
 /// A Poly1305 key.
-pub struct Key([Block; 2]);
+pub struct Key([Block; KEY_BLOCKS]);
 
-impl From<[u8; KEY_LEN]> for Key {
-    fn from(value: [u8; KEY_LEN]) -> Self { unsafe { core::mem::transmute_copy(&value) } }
+impl From<[Block; KEY_BLOCKS]> for Key {
+    fn from(value: [Block; KEY_BLOCKS]) -> Self { Key(value) }
 }
+
+pub const KEY_BLOCKS: usize = 2;
 
 pub struct Context {
     opaque: Opaque,
@@ -102,9 +104,6 @@ pub fn check_state_layout() {
         assert!(core::mem::size_of::<Opaque>() >= required_state_size);
     }
 }
-
-/// The length of a `key`.
-pub const KEY_LEN: usize = 2 * BLOCK_LEN;
 
 #[repr(C)]
 struct DerivedKey(Block);

--- a/src/ec/curve25519/ed25519/signing.rs
+++ b/src/ec/curve25519/ed25519/signing.rs
@@ -15,7 +15,7 @@
 //! EdDSA Signatures.
 
 use super::{super::ops::*, PUBLIC_KEY_LEN};
-use crate::{der, digest, error, pkcs8, rand, signature, signature_impl};
+use crate::{der, digest, error, pkcs8, polyfill::convert::*, rand, signature, signature_impl};
 use core;
 use untrusted;
 
@@ -135,8 +135,10 @@ impl<'a> KeyPair {
     /// the private key. It is not possible to detect misuse or corruption of
     /// the private key since the public key isn't given as input.
     pub fn from_seed_unchecked(seed: untrusted::Input) -> Result<Self, error::KeyRejected> {
-        let seed = slice_as_array_ref!(seed.as_slice_less_safe(), SEED_LEN)
-            .map_err(|error::Unspecified| error::KeyRejected::invalid_encoding())?;
+        let seed = seed
+            .as_slice_less_safe()
+            .try_into_()
+            .map_err(|_| error::KeyRejected::invalid_encoding())?;
         Ok(Self::from_seed_(seed))
     }
 

--- a/src/ec/curve25519/ed25519/signing.rs
+++ b/src/ec/curve25519/ed25519/signing.rs
@@ -173,10 +173,7 @@ impl<'a> KeyPair {
         let mut signature_bytes = [0u8; SIGNATURE_LEN];
         {
             // Borrow `signature_bytes`.
-            let (signature_r, signature_s) = signature_bytes.split_at_mut(ELEM_LEN);
-            let signature_r = slice_as_array_ref_mut!(signature_r, ELEM_LEN).unwrap();
-            let signature_s = slice_as_array_ref_mut!(signature_s, SCALAR_LEN).unwrap();
-
+            let (signature_r, signature_s) = (&mut signature_bytes).into_();
             let nonce = {
                 let mut ctx = digest::Context::new(&digest::SHA512);
                 ctx.update(&self.private_prefix);

--- a/src/ec/curve25519/ed25519/verification.rs
+++ b/src/ec/curve25519/ed25519/verification.rs
@@ -15,7 +15,7 @@
 //! EdDSA Signatures.
 
 use super::super::ops::*;
-use crate::{error, private, signature};
+use crate::{error, polyfill::convert::*, private, signature};
 use core;
 use untrusted;
 
@@ -42,7 +42,7 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
         &self, public_key: untrusted::Input, msg: untrusted::Input, signature: untrusted::Input,
     ) -> Result<(), error::Unspecified> {
         let public_key = public_key.as_slice_less_safe();
-        let public_key = slice_as_array_ref!(public_key, ELEM_LEN)?;
+        let public_key: &[u8; ELEM_LEN] = public_key.try_into_()?;;
 
         let (signature_r, signature_s) = signature.read_all(error::Unspecified, |input| {
             let r = input.skip_and_get_input(ELEM_LEN)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@
 
 //! Error reporting.
 
+use crate::polyfill::convert::*;
 use core;
 use untrusted;
 
@@ -102,6 +103,10 @@ impl std::error::Error for Unspecified {
 
 impl From<untrusted::EndOfInput> for Unspecified {
     fn from(_: untrusted::EndOfInput) -> Self { Unspecified }
+}
+
+impl From<TryFromSliceError> for Unspecified {
+    fn from(_: TryFromSliceError) -> Self { Unspecified }
 }
 
 /// An error parsing or validating a key.

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -66,35 +66,3 @@ pub mod slice {
         }
     }
 }
-
-/// Returns a reference to the elements of `$slice` as an array, verifying that
-/// the slice is of length `$len`.
-macro_rules! slice_as_array_ref {
-    ($slice:expr, $len:expr) => {{
-        use crate::error;
-
-        fn slice_as_array_ref<T>(slice: &[T]) -> Result<&[T; $len], error::Unspecified> {
-            if slice.len() != $len {
-                return Err(error::Unspecified);
-            }
-            Ok(unsafe { &*(slice.as_ptr() as *const [T; $len]) })
-        }
-        slice_as_array_ref($slice)
-    }};
-}
-
-/// Returns a reference to elements of `$slice` as a mutable array, verifying
-/// that the slice is of length `$len`.
-macro_rules! slice_as_array_ref_mut {
-    ($slice:expr, $len:expr) => {{
-        use crate::error;
-
-        fn slice_as_array_ref<T>(slice: &mut [T]) -> Result<&mut [T; $len], error::Unspecified> {
-            if slice.len() != $len {
-                return Err(error::Unspecified);
-            }
-            Ok(unsafe { &mut *(slice.as_mut_ptr() as *mut [T; $len]) })
-        }
-        slice_as_array_ref($slice)
-    }};
-}

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -17,6 +17,8 @@
 
 use core;
 
+pub mod convert;
+
 #[inline(always)]
 pub const fn u64_from_usize(x: usize) -> u64 { x as u64 }
 

--- a/src/polyfill/convert.rs
+++ b/src/polyfill/convert.rs
@@ -1,0 +1,87 @@
+// Copyright 2018 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+/// An approximation of the unstable `core::convert::TryFrom`.
+pub trait TryFrom_<T>: Sized {
+    type Error;
+
+    fn try_from_(value: T) -> Result<Self, Self::Error>;
+}
+
+/// An approximation of the unstable `core::convert::TryInto`.
+pub trait TryInto_<T>
+where
+    T: Sized,
+{
+    type Error;
+
+    fn try_into_(self) -> Result<T, Self::Error>;
+}
+
+impl<T, F> TryInto_<T> for F
+where
+    T: TryFrom_<F>,
+{
+    type Error = <T as TryFrom_<F>>::Error;
+
+    #[inline]
+    fn try_into_(self) -> Result<T, Self::Error> { T::try_from_(self) }
+}
+
+#[derive(Debug)]
+pub struct TryFromSliceError(());
+
+macro_rules! impl_array_try_from {
+    ($ty:ty, $len:expr) => {
+        impl<'a> TryFrom_<&'a [$ty]> for &'a [$ty; $len] {
+            type Error = TryFromSliceError;
+
+            #[inline]
+            fn try_from_(slice: &'a [$ty]) -> Result<Self, Self::Error> {
+                unsafe { transmute_slice::<[$ty; $len], $ty>(slice, $len) }
+            }
+        }
+
+        impl<'a> TryFrom_<&'a mut [$ty]> for &'a mut [$ty; $len] {
+            type Error = TryFromSliceError;
+
+            #[inline]
+            fn try_from_(slice: &'a mut [$ty]) -> Result<Self, Self::Error> {
+                unsafe { transmute_slice_mut::<[$ty; $len], $ty>(slice, $len) }
+            }
+        }
+    };
+}
+
+impl_array_try_from!(u8, 4);
+impl_array_try_from!(u8, 12);
+impl_array_try_from!(u8, 16);
+impl_array_try_from!(u8, 32);
+
+#[inline]
+unsafe fn transmute_slice<A, T>(slice: &[T], expected_len: usize) -> Result<&A, TryFromSliceError> {
+    if slice.len() != expected_len {
+        return Err(TryFromSliceError(()));
+    }
+    Ok(core::mem::transmute(slice.as_ptr()))
+}
+
+unsafe fn transmute_slice_mut<A, T>(
+    slice: &mut [T], expected_len: usize,
+) -> Result<&mut A, TryFromSliceError> {
+    if slice.len() != expected_len {
+        return Err(TryFromSliceError(()));
+    }
+    Ok(core::mem::transmute(slice.as_ptr()))
+}

--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -375,7 +375,7 @@ fn aead_chacha20_poly1305_openssh() {
         |section, test_case| {
             assert_eq!(section, "");
 
-            // XXX: `slice_as_array_ref!` is not available here.
+            // XXX: `polyfill::convert` isn't available here.
             let key_bytes = {
                 let as_vec = test_case.consume_bytes("KEY");
                 let mut as_array = [0u8; aead::chacha20_poly1305_openssh::KEY_LEN];


### PR DESCRIPTION
`TryFrom<&[T]> for &[T; $N]` is in libstd already, but `TryFrom` isn't stable. Add our own `TryFrom_` that's like `TryFrom` to tide us over until it becomes stable.

Similarly, define a new `From_` type that allows us to define conversions from `&[T; $N * 2]` to (&[T; $N], &[T; $N])`, i.e. the array analog of `slice::split_at()`. Currently we only split in half but it's obvious how to extend this to other ratios.