### PR TITLE
Use `lazy_static!` for CPU feature detection to work with `#[no_std]`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,13 +290,11 @@ include = [
 name = "ring"
 
 [dependencies]
+lazy_static = "1.2"
 untrusted = "0.6.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { version = "0.2.45" }
-
-[target.'cfg(any(target_os = "redox", all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies]
-lazy_static = "1.2"
 
 # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
 [build-dependencies]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -16,11 +16,16 @@
 pub fn cache_detected_features() {
     #[cfg(not(target_os = "ios"))]
     {
-        use std;
+        use lazy_static::lazy_static;
+
         extern "C" {
             fn GFp_cpuid_setup();
         }
-        static INIT: std::sync::Once = std::sync::ONCE_INIT;
-        INIT.call_once(|| unsafe { GFp_cpuid_setup() });
+
+        lazy_static! {
+            static ref INIT: () = unsafe { GFp_cpuid_setup() };
+        };
+
+        *INIT
     }
 }


### PR DESCRIPTION
Fixes #745.

@jethrogb Thoughts?