### PR TITLE
Expand QUIC header protection API

### DIFF
--- a/src/aead/quic.rs
+++ b/src/aead/quic.rs
@@ -50,13 +50,19 @@ impl HeaderProtectionKey {
 
     /// Generate a new QUIC Header Protection mask.
     ///
-    /// `sample` must be exactly 16 bytes long.
+    /// `sample` must be exactly `self.algorithm().sample_len()` bytes long.
     pub fn new_mask(&self, sample: &[u8]) -> Result<[u8; 5], error::Unspecified> {
         let sample = <&[u8; SAMPLE_LEN]>::try_from_(sample)?;
         let sample = Block::from(sample);
 
         let out = (self.algorithm.new_mask)(&self.inner, sample);
         Ok(out)
+    }
+
+    /// The key's algorithm.
+    #[inline(always)]
+    pub fn algorithm(&self) -> &'static Algorithm {
+        self.algorithm
     }
 }
 
@@ -76,6 +82,10 @@ impl Algorithm {
     /// The length of the key.
     #[inline(always)]
     pub fn key_len(&self) -> usize { self.key_len }
+
+    /// The required sample length.
+    #[inline(always)]
+    pub fn sample_len(&self) -> usize { SAMPLE_LEN }
 }
 
 derive_debug_via_self!(Algorithm, self.id);


### PR DESCRIPTION
I also threw in the key derivation function, since if the rest is going to live here then I think it makes sense for it to as well. I'm not sure if we should additionally get rid of `new`. Test vector taken from Quinn.

We could further simplify `HeaderProtectionKey::derive` by taking a `&'static super::Algorithm`, but it's not clear to me that it's reasonable to expect the set of AEADs implemented by *ring* to remain a subset of the AEADs supported by QUIC.