### PR TITLE
Replace libstd with spin crate in `cpu::cache_detected_features`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,6 +300,9 @@ name = "ring"
 [dependencies]
 untrusted = "0.6.2"
 
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+spin = { version = "0.5.0" }
+
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.45" }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -28,8 +28,8 @@ pub(crate) fn features() -> Features {
     // assumed to be present; see `arm::Feature`.
     #[cfg(not(target_os = "ios"))]
     {
-        static INIT: std::sync::Once = std::sync::ONCE_INIT;
-        INIT.call_once(|| {
+        static INIT: spin::Once<()> = spin::Once::new();
+        let () = INIT.call_once(|| {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {
                 extern "C" {


### PR DESCRIPTION
Eliminate one of the two remaining problems with `#![no_std]` support
and reduce platform variance.