### PR TITLE
Use Fn bound for kdf on agree_ephemeral.

### DIFF
--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -163,7 +163,7 @@ pub fn agree_ephemeral<F, R, E>(
     peer_public_key: untrusted::Input, error_value: E, kdf: F,
 ) -> Result<R, E>
 where
-    F: FnOnce(&[u8]) -> Result<R, E>,
+    F: Fn(&[u8]) -> Result<R, E>,
 {
     // NSA Guide Prerequisite 1.
     //


### PR DESCRIPTION
The purpose of the kdf parameter would seem to be to restrict the use
of the key material.  The most restrictive function bound is Fn, which
requires that the kdf be read-only with respect to its environment.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.