### PR TITLE
Added NotRandom: A dummy random generator for testing.

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -527,9 +527,24 @@ pub mod rand {
         }
     }
 
+    /// An implementation of `SecureRandom` that fills the output slice
+    /// by calling the inner function.
+    #[derive(Debug)]
+    pub struct NotRandom<F>(pub F);
+
+    impl<F> rand::SecureRandom for NotRandom<F>
+    where
+        F: Fn(&mut [u8]) -> Result<(), error::Unspecified>,
+    {
+        fn fill(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> {
+            self.0(dest)
+        }
+    }
+
     impl sealed::Sealed for FixedByteRandom {}
     impl<'a> sealed::Sealed for FixedSliceRandom<'a> {}
     impl<'a> sealed::Sealed for FixedSliceSequenceRandom<'a> {}
+    impl<F> sealed::Sealed for NotRandom<F> {}
 
 }
 


### PR DESCRIPTION
This is an up to date pull request attempting to solve https://github.com/briansmith/ring/issues/661

This pull request adds `NotRandom`, a structure that implements `SecureRandom` and `Sealed`, allowing to write deterministic tests for random related cryptographic code.