### PR TITLE
Change Sealed to be public and unsafe trait

### DIFF
--- a/src/ec/curve25519/ed25519/verification.rs
+++ b/src/ec/curve25519/ed25519/verification.rs
@@ -67,7 +67,7 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
     }
 }
 
-impl sealed::Sealed for EdDSAParameters {}
+unsafe impl sealed::Sealed for EdDSAParameters {}
 
 extern "C" {
     fn GFp_x25519_ge_double_scalarmult_vartime(

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -57,7 +57,7 @@ impl PartialEq for Algorithm {
 
 impl Eq for Algorithm {}
 
-impl sealed::Sealed for Algorithm {}
+unsafe impl sealed::Sealed for Algorithm {}
 
 /// An ECDSA key pair, used for signing.
 pub struct KeyPair {

--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -159,7 +159,7 @@ impl Algorithm {
     }
 }
 
-impl sealed::Sealed for Algorithm {}
+unsafe impl sealed::Sealed for Algorithm {}
 
 fn split_rs_fixed<'a>(
     ops: &'static ScalarOps, input: &mut untrusted::Reader<'a>,

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -25,7 +25,7 @@ macro_rules! define_endian {
         where
             T: Copy + Clone + Sized;
 
-        impl<T> sealed::Sealed for $endian<T> where T: Copy + Clone + Sized {}
+        unsafe impl<T> sealed::Sealed for $endian<T> where T: Copy + Clone + Sized {}
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,8 @@ pub mod signature;
 #[cfg(any(test, feature = "use_heap"))]
 pub mod test;
 
-mod sealed {
+/// Traits that promise cryptographic safety.
+pub mod sealed {
     /// Traits that are designed to only be implemented internally in *ring*.
     //
     // Usage:
@@ -129,7 +130,7 @@ mod sealed {
     //
     // impl sealed::Sealed for MyType {}
     // ```
-    pub trait Sealed {}
+    pub unsafe trait Sealed {}
 }
 
 #[cfg(test)]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -91,7 +91,7 @@ impl SecureRandom for SystemRandom {
     fn fill(&self, dest: &mut [u8]) -> Result<(), error::Unspecified> { fill_impl(dest) }
 }
 
-impl sealed::Sealed for SystemRandom {}
+unsafe impl sealed::Sealed for SystemRandom {}
 
 #[cfg(all(
     feature = "use_heap",

--- a/src/rsa/padding.rs
+++ b/src/rsa/padding.rs
@@ -60,7 +60,7 @@ pub struct PKCS1 {
     digestinfo_prefix: &'static [u8],
 }
 
-impl crate::sealed::Sealed for PKCS1 {}
+unsafe impl crate::sealed::Sealed for PKCS1 {}
 
 impl Padding for PKCS1 {
     fn digest_alg(&self) -> &'static digest::Algorithm { self.digest_alg }
@@ -206,7 +206,7 @@ pub struct PSS {
     digest_alg: &'static digest::Algorithm,
 }
 
-impl crate::sealed::Sealed for PSS {}
+unsafe impl crate::sealed::Sealed for PSS {}
 
 // Maximum supported length of the salt in bytes.
 // In practice, this is constrained by the maximum digest length.

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -94,7 +94,7 @@ impl signature::VerificationAlgorithm for Parameters {
     }
 }
 
-impl sealed::Sealed for Parameters {}
+unsafe impl sealed::Sealed for Parameters {}
 
 macro_rules! rsa_params {
     ( $VERIFY_ALGORITHM:ident, $min_bits:expr, $PADDING_ALGORITHM:expr,

--- a/src/test.rs
+++ b/src/test.rs
@@ -527,9 +527,9 @@ pub mod rand {
         }
     }
 
-    impl sealed::Sealed for FixedByteRandom {}
-    impl<'a> sealed::Sealed for FixedSliceRandom<'a> {}
-    impl<'a> sealed::Sealed for FixedSliceSequenceRandom<'a> {}
+    unsafe impl sealed::Sealed for FixedByteRandom {}
+    unsafe impl<'a> sealed::Sealed for FixedSliceRandom<'a> {}
+    unsafe impl<'a> sealed::Sealed for FixedSliceSequenceRandom<'a> {}
 
 }
 


### PR DESCRIPTION
This is a different approach in attempting to solve https://github.com/briansmith/ring/issues/661. (See a more basic attempt for solution at PR https://github.com/briansmith/ring/pull/771). 

Although only small changes are made here, this is a big design change which should be considered carefully.

## Abstract

This PR proposes to mark the `Sealed` trait unsafe and make it public. This change allows users of the library to do things that might not be intended by ring's developers, but at the same time forces the user to put an `unsafe` clause in their code.

## Motivation

Ring is strict by design, using Rust's safety guarantees to make it difficult to misuse cryptographic primitives. This is a good thing, because it makes mistakes difficult to do. 
However, it is sometimes possible that users of the Ring library might want to do something outside of those restrictions.

By making the `Sealed` trait unsafe and public, we allow users of Ring a safety trade-off.
This idea is in line with many existing Rust interfaces. Most Rust interfaces offer safety by default, but still leave an unsafe hatch for users that know what they are doing. 

One such example could be seen in issue https://github.com/briansmith/ring/issues/661. Currently if one has any above moderately sophisticated code that uses random from Ring, it becomes very difficult to test. The current solution offered by Ring is adding internal dummy random structs that implement `Sealed`. From `src/test.rs`:
```rust
impl sealed::Sealed for FixedByteRandom {}
impl<'a> sealed::Sealed for FixedSliceRandom<'a> {}
impl<'a> sealed::Sealed for FixedSliceSequenceRandom<'a> {}
```
Note that PR https://github.com/briansmith/ring/pull/771 suggests to add `NotRandom` to this list.

If we introduce a public unsafe Sealed trait, we can remove all the mock random structures, and allow the user to make a mock user struct herself, the way she likes to, for example:

```rust
use ring::sealed::Sealed;
unsafe impl Sealed for MyDummyRandom {}
```
