### PR TITLE
Add support for fuchsia system feature detection on aarch64

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -47,6 +47,11 @@ pub(crate) fn features() -> Features {
             {
                 arm::linux_setup();
             }
+
+            #[cfg(target_os = "fuchsia")]
+            {
+                arm::fuchsia_setup();
+            }
         });
     }
 
@@ -110,6 +115,44 @@ pub(crate) mod arm {
         }
     }
 
+    #[cfg(target_os = "fuchsia")]
+    pub fn fuchsia_setup() {
+        type zx_status_t = i32;
+
+        #[link(name = "zircon")]
+        extern "C" {
+            fn zx_system_get_features(kind: u32, features: *mut u32) -> zx_status_t;
+        }
+
+        const ZX_OK: i32 = 0;
+        const ZX_FEATURE_KIND_CPU: u32 = 0;
+        const ZX_ARM64_FEATURE_ISA_ASIMD: u32 = 1 << 2;
+        const ZX_ARM64_FEATURE_ISA_AES: u32 = 1 << 3;
+        const ZX_ARM64_FEATURE_ISA_PMULL: u32 = 1 << 4;
+        const ZX_ARM64_FEATURE_ISA_SHA2: u32 = 1 << 6;
+
+        let mut caps = 0;
+        let rc = unsafe { zx_system_get_features(ZX_FEATURE_KIND_CPU, &mut caps) };
+
+        // OpenSSL and BoringSSL don't enable any other features if NEON isn't
+        // available.
+        if rc == ZX_OK && (caps & ZX_ARM64_FEATURE_ISA_ASIMD == ZX_ARM64_FEATURE_ISA_ASIMD) {
+            let mut features = NEON.mask;
+
+            if caps & ZX_ARM64_FEATURE_ISA_AES == ZX_ARM64_FEATURE_ISA_AES {
+                features |= AES.mask;
+            }
+            if caps & ZX_ARM64_FEATURE_ISA_PMULL == ZX_ARM64_FEATURE_ISA_PMULL {
+                features |= PMULL.mask;
+            }
+            if caps & ZX_ARM64_FEATURE_ISA_SHA2 == ZX_ARM64_FEATURE_ISA_SHA2 {
+                features |= 1 << 4;
+            }
+
+            unsafe { GFp_armcap_P = features };
+        }
+    }
+
     pub(crate) struct Feature {
         #[cfg_attr(
             any(
@@ -133,7 +176,7 @@ pub(crate) mod arm {
             }
 
             #[cfg(all(
-                any(target_os = "android", target_os = "linux"),
+                any(target_os = "android", target_os = "linux", target_os = "fuchsia"),
                 any(target_arch = "arm", target_arch = "aarch64")
             ))]
             {
@@ -167,7 +210,7 @@ pub(crate) mod arm {
     };
 
     #[cfg(all(
-        any(target_os = "android", target_os = "linux"),
+        any(target_os = "android", target_os = "linux", target_os = "fuchsia"),
         any(target_arch = "arm", target_arch = "aarch64")
     ))]
     extern "C" {


### PR DESCRIPTION
This adds support for detecting arm features on a fuchsia device,
which uses the `zx_system_get_features` syscall to extract out
this information, which is described here:

https://fuchsia.googlesource.com/zircon/+/master/docs/syscalls/system_get_features.md

The feature constants can be found here:

https://fuchsia.googlesource.com/zircon/+/master/system/public/zircon/features.h

The type `zx_status_t` and ZX_OK are defined here:

https://fuchsia.googlesource.com/zircon/+/master/system/public/zircon/types.h#39
https://fuchsia.googlesource.com/zircon/+/master/system/public/zircon/errors.h#14

I agree to license my contributions to each file under the terms given
at the top of each file I changed.