### PR TITLE
Add support for x86_64-unknown-uefi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,19 +59,8 @@
     unused_results,
     warnings
 )]
-#![cfg_attr(
-    any(
-        target_os = "redox",
-        all(
-            not(test),
-            not(feature = "use_heap"),
-            unix,
-            not(any(target_os = "macos", target_os = "ios")),
-            any(not(target_os = "linux"), feature = "dev_urandom_fallback")
-        )
-    ),
-    no_std
-)]
+// std is only used in tests or when gated with #[cfg(use_heap)]
+#![cfg_attr(not(any(test, feature = "use_heap")), no_std)]
 #![cfg_attr(feature = "internal_benches", allow(unstable_features))]
 #![cfg_attr(feature = "internal_benches", feature(test))]
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -100,14 +100,14 @@ impl sealed::Sealed for SystemRandom {}
         target_os = "macos",
         target_os = "ios",
         target_os = "fuchsia",
-        windows
+        target_os = "windows"
     ))
 ))]
 use self::urandom::fill as fill_impl;
 
 #[cfg(any(
     all(target_os = "linux", not(feature = "dev_urandom_fallback")),
-    windows
+    target_os = "windows",
 ))]
 use self::sysrand::fill as fill_impl;
 
@@ -158,7 +158,7 @@ mod sysrand_chunk {
     }
 }
 
-#[cfg(windows)]
+#[cfg(target_os = "windows")]
 mod sysrand_chunk {
     use crate::{error, polyfill};
     use core;
@@ -183,7 +183,7 @@ mod sysrand_chunk {
     }
 }
 
-#[cfg(any(target_os = "linux", windows))]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 mod sysrand {
     use super::sysrand_chunk::chunk;
     use crate::error;
@@ -198,13 +198,13 @@ mod sysrand {
     }
 }
 
-// Keep the `cfg` conditions in sync with the conditions in lib.rs.
 #[cfg(all(
     feature = "use_heap",
-    any(target_os = "redox", unix),
-    not(any(target_os = "macos", target_os = "ios")),
     not(all(target_os = "linux", not(feature = "dev_urandom_fallback"))),
-    not(any(target_os = "fuchsia")),
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "fuchsia"),
+    not(target_os = "windows"),
 ))]
 mod urandom {
     use crate::error;
@@ -215,7 +215,7 @@ mod urandom {
 
         #[cfg(target_os = "redox")]
         static RANDOM_PATH: &str = "rand:";
-        #[cfg(unix)]
+        #[cfg(not(target_os = "redox"))]
         static RANDOM_PATH: &str = "/dev/urandom";
 
         lazy_static! {
@@ -233,7 +233,6 @@ mod urandom {
     }
 }
 
-// Keep the `cfg` conditions in sync with the conditions in lib.rs.
 #[cfg(all(target_os = "linux", feature = "dev_urandom_fallback"))]
 mod sysrand_or_urandom {
     use crate::error;


### PR DESCRIPTION
Right now, ring contains a lot of long `cfg` clauses to determine which RNG implementation to use or if the crate should be `no_std`. This change simplifies them, mainly by using the fact that `std` in only ever used in tests or if `use_heap` is enabled. It also avoids using the confusing `windows` and `unix` attributes, and now makes all target decisions based on `target_os`.

This also fixes a bug arising from the fact that `#[cfg(windows)] != #[cfg(target_os = "windows")]`. [Some custom targets](https://github.com/rust-osdev/uefi-rs/blob/master/uefi-test-runner/x86_64-uefi.json) base themselves off of the windows family of LLVM, but these targets do _not_ have any of the Windows OS services.

The remaining issues blocking use of `x86_64-unknown-uefi` are:
- [ ] support for `libc` types: (https://github.com/rust-lang/libc/pull/1244)
- [ ] RDRAND support: part of https://github.com/briansmith/ring/pull/738
- [ ] Implement `fill_impl` to check for and then use RDRAND.
- [ ] Add UEFI testing to CI: see https://github.com/rust-osdev/uefi-rs