### PR TITLE
Permit algorithms to be used in associated consts

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -19,7 +19,7 @@ use super::{
 use crate::{aead, cpu, endian::*, error, polyfill};
 
 /// AES-128 in GCM mode with 128-bit tags and 96 bit nonces.
-pub static AES_128_GCM: aead::Algorithm = aead::Algorithm {
+pub const AES_128_GCM: aead::Algorithm = aead::Algorithm {
     key_len: 16,
     init: init_128,
     seal: aes_gcm_seal,
@@ -29,7 +29,7 @@ pub static AES_128_GCM: aead::Algorithm = aead::Algorithm {
 };
 
 /// AES-256 in GCM mode with 128-bit tags and 96 bit nonces.
-pub static AES_256_GCM: aead::Algorithm = aead::Algorithm {
+pub const AES_256_GCM: aead::Algorithm = aead::Algorithm {
     key_len: 32,
     init: init_256,
     seal: aes_gcm_seal,

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -29,7 +29,7 @@ use crate::{
 /// The keys are 256 bits long and the nonces are 96 bits long.
 ///
 /// [RFC 7539]: https://tools.ietf.org/html/rfc7539
-pub static CHACHA20_POLY1305: aead::Algorithm = aead::Algorithm {
+pub const CHACHA20_POLY1305: aead::Algorithm = aead::Algorithm {
     key_len: chacha::KEY_LEN,
     init: chacha20_poly1305_init,
     seal: chacha20_poly1305_seal,

--- a/src/aead/quic.rs
+++ b/src/aead/quic.rs
@@ -101,7 +101,7 @@ impl PartialEq for Algorithm {
 impl Eq for Algorithm {}
 
 /// AES-128.
-pub static AES_128: Algorithm = Algorithm {
+pub const AES_128: Algorithm = Algorithm {
     key_len: 16,
     init: aes_init_128,
     new_mask: aes_new_mask,
@@ -109,7 +109,7 @@ pub static AES_128: Algorithm = Algorithm {
 };
 
 /// AES-256.
-pub static AES_256: Algorithm = Algorithm {
+pub const AES_256: Algorithm = Algorithm {
     key_len: 32,
     init: aes_init_256,
     new_mask: aes_new_mask,
@@ -136,7 +136,7 @@ fn aes_new_mask(key: &KeyInner, sample: Block) -> [u8; 5] {
 }
 
 /// ChaCha20.
-pub static CHACHA20: Algorithm = Algorithm {
+pub const CHACHA20: Algorithm = Algorithm {
     key_len: chacha::KEY_LEN,
     init: chacha20_init,
     new_mask: chacha20_new_mask,

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -275,7 +275,7 @@ derive_debug_via_id!(Algorithm);
 /// SHA-1 as specified in [FIPS 180-4]. Deprecated.
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA1: Algorithm = Algorithm {
+pub const SHA1: Algorithm = Algorithm {
     output_len: sha1::OUTPUT_LEN,
     chaining_len: sha1::CHAINING_LEN,
     block_len: sha1::BLOCK_LEN,
@@ -300,7 +300,7 @@ pub static SHA1: Algorithm = Algorithm {
 /// SHA-256 as specified in [FIPS 180-4].
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA256: Algorithm = Algorithm {
+pub const SHA256: Algorithm = Algorithm {
     output_len: SHA256_OUTPUT_LEN,
     chaining_len: SHA256_OUTPUT_LEN,
     block_len: 512 / 8,
@@ -325,7 +325,7 @@ pub static SHA256: Algorithm = Algorithm {
 /// SHA-384 as specified in [FIPS 180-4].
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA384: Algorithm = Algorithm {
+pub const SHA384: Algorithm = Algorithm {
     output_len: SHA384_OUTPUT_LEN,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,
@@ -350,7 +350,7 @@ pub static SHA384: Algorithm = Algorithm {
 /// SHA-512 as specified in [FIPS 180-4].
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA512: Algorithm = Algorithm {
+pub const SHA512: Algorithm = Algorithm {
     output_len: SHA512_OUTPUT_LEN,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,
@@ -379,7 +379,7 @@ pub static SHA512: Algorithm = Algorithm {
 /// state.
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA512_256: Algorithm = Algorithm {
+pub const SHA512_256: Algorithm = Algorithm {
     output_len: SHA512_256_OUTPUT_LEN,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,
@@ -489,7 +489,7 @@ extern "C" {
 pub mod test_util {
     use super::super::digest;
 
-    pub static ALL_ALGORITHMS: [&digest::Algorithm; 5] = [
+    pub const ALL_ALGORITHMS: [&digest::Algorithm; 5] = [
         &digest::SHA1,
         &digest::SHA256,
         &digest::SHA384,

--- a/src/ec/curve25519/ed25519/verification.rs
+++ b/src/ec/curve25519/ed25519/verification.rs
@@ -35,7 +35,7 @@ impl core::fmt::Debug for EdDSAParameters {
 /// Ed25519 uses SHA-512 as the digest algorithm.
 ///
 /// [Ed25519]: https://ed25519.cr.yp.to/
-pub static ED25519: EdDSAParameters = EdDSAParameters {};
+pub const ED25519: EdDSAParameters = EdDSAParameters {};
 
 impl signature::VerificationAlgorithm for EdDSAParameters {
     fn verify(

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -18,7 +18,7 @@ use super::ops;
 use crate::{agreement, constant_time, cpu, ec, error, polyfill::convert::*, rand};
 use untrusted;
 
-static CURVE25519: ec::Curve = ec::Curve {
+const CURVE25519: ec::Curve = ec::Curve {
     public_key_len: PUBLIC_KEY_LEN,
     elem_scalar_seed_len: ELEM_AND_SCALAR_LEN,
     id: ec::CurveID::Curve25519,
@@ -35,7 +35,7 @@ static CURVE25519: ec::Curve = ec::Curve {
 ///
 /// [RFC 7748]: https://tools.ietf.org/html/rfc7748
 /// [RFC 7748 section 6.1]: https://tools.ietf.org/html/rfc7748#section-6.1
-pub static X25519: agreement::Algorithm = agreement::Algorithm {
+pub const X25519: agreement::Algorithm = agreement::Algorithm {
     curve: &CURVE25519,
     ecdh: x25519_ecdh,
 };

--- a/src/ec/suite_b/curve.rs
+++ b/src/ec/suite_b/curve.rs
@@ -32,7 +32,7 @@ macro_rules! suite_b_curve {
         ///     http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf
         /// [Suite B Implementer's Guide to NIST SP 800-56A]:
         ///     https://github.com/briansmith/ring/blob/master/doc/ecdh.pdf
-        pub static $NAME: ec::Curve = ec::Curve {
+        pub const $NAME: ec::Curve = ec::Curve {
             public_key_len: 1 + (2 * (($bits + 7) / 8)),
             elem_scalar_seed_len: ($bits + 7) / 8,
             id: $id,

--- a/src/ec/suite_b/ecdh.rs
+++ b/src/ec/suite_b/ecdh.rs
@@ -39,7 +39,7 @@ macro_rules! ecdh {
         ///     http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf
         /// [Suite B Implementer's Guide to NIST SP 800-56A]:
         ///     https://github.com/briansmith/ring/blob/master/doc/ecdh.pdf
-        pub static $NAME: agreement::Algorithm = agreement::Algorithm {
+        pub const $NAME: agreement::Algorithm = agreement::Algorithm {
             curve: $curve,
             ecdh: $ecdh,
         };

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -311,7 +311,7 @@ fn format_rs_asn1<'a>(ops: &'static ScalarOps, r: &Scalar, s: &Scalar, out: &'a 
 ///
 /// See "`ECDSA_*_FIXED` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P256_SHA256_FIXED_SIGNING: Algorithm = Algorithm {
+pub const ECDSA_P256_SHA256_FIXED_SIGNING: Algorithm = Algorithm {
     curve: &ec::suite_b::curve::P256,
     private_scalar_ops: &p256::PRIVATE_SCALAR_OPS,
     private_key_ops: &p256::PRIVATE_KEY_OPS,
@@ -326,7 +326,7 @@ pub static ECDSA_P256_SHA256_FIXED_SIGNING: Algorithm = Algorithm {
 ///
 /// See "`ECDSA_*_FIXED` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P384_SHA384_FIXED_SIGNING: Algorithm = Algorithm {
+pub const ECDSA_P384_SHA384_FIXED_SIGNING: Algorithm = Algorithm {
     curve: &ec::suite_b::curve::P384,
     private_scalar_ops: &p384::PRIVATE_SCALAR_OPS,
     private_key_ops: &p384::PRIVATE_KEY_OPS,
@@ -341,7 +341,7 @@ pub static ECDSA_P384_SHA384_FIXED_SIGNING: Algorithm = Algorithm {
 ///
 /// See "`ECDSA_*_ASN1` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P256_SHA256_ASN1_SIGNING: Algorithm = Algorithm {
+pub const ECDSA_P256_SHA256_ASN1_SIGNING: Algorithm = Algorithm {
     curve: &ec::suite_b::curve::P256,
     private_scalar_ops: &p256::PRIVATE_SCALAR_OPS,
     private_key_ops: &p256::PRIVATE_KEY_OPS,
@@ -356,7 +356,7 @@ pub static ECDSA_P256_SHA256_ASN1_SIGNING: Algorithm = Algorithm {
 ///
 /// See "`ECDSA_*_ASN1` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P384_SHA384_ASN1_SIGNING: Algorithm = Algorithm {
+pub const ECDSA_P384_SHA384_ASN1_SIGNING: Algorithm = Algorithm {
     curve: &ec::suite_b::curve::P384,
     private_scalar_ops: &p384::PRIVATE_SCALAR_OPS,
     private_key_ops: &p384::PRIVATE_KEY_OPS,
@@ -366,14 +366,14 @@ pub static ECDSA_P384_SHA384_ASN1_SIGNING: Algorithm = Algorithm {
     id: AlgorithmID::ECDSA_P384_SHA384_ASN1_SIGNING,
 };
 
-static EC_PUBLIC_KEY_P256_PKCS8_V1_TEMPLATE: pkcs8::Template = pkcs8::Template {
+const EC_PUBLIC_KEY_P256_PKCS8_V1_TEMPLATE: pkcs8::Template = pkcs8::Template {
     bytes: include_bytes!("ecPublicKey_p256_pkcs8_v1_template.der"),
     alg_id_range: core::ops::Range { start: 8, end: 27 },
     curve_id_index: 9,
     private_key_index: 0x24,
 };
 
-static EC_PUBLIC_KEY_P384_PKCS8_V1_TEMPLATE: pkcs8::Template = pkcs8::Template {
+const EC_PUBLIC_KEY_P384_PKCS8_V1_TEMPLATE: pkcs8::Template = pkcs8::Template {
     bytes: include_bytes!("ecPublicKey_p384_pkcs8_v1_template.der"),
     alg_id_range: core::ops::Range { start: 8, end: 24 },
     curve_id_index: 9,

--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -194,7 +194,7 @@ fn twin_mul(
 ///
 /// See "`ECDSA_*_FIXED` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P256_SHA256_FIXED: Algorithm = Algorithm {
+pub const ECDSA_P256_SHA256_FIXED: Algorithm = Algorithm {
     ops: &p256::PUBLIC_SCALAR_OPS,
     digest_alg: &digest::SHA256,
     split_rs: split_rs_fixed,
@@ -206,7 +206,7 @@ pub static ECDSA_P256_SHA256_FIXED: Algorithm = Algorithm {
 ///
 /// See "`ECDSA_*_FIXED` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P384_SHA384_FIXED: Algorithm = Algorithm {
+pub const ECDSA_P384_SHA384_FIXED: Algorithm = Algorithm {
     ops: &p384::PUBLIC_SCALAR_OPS,
     digest_alg: &digest::SHA384,
     split_rs: split_rs_fixed,
@@ -218,7 +218,7 @@ pub static ECDSA_P384_SHA384_FIXED: Algorithm = Algorithm {
 ///
 /// See "`ECDSA_*_ASN1` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P256_SHA256_ASN1: Algorithm = Algorithm {
+pub const ECDSA_P256_SHA256_ASN1: Algorithm = Algorithm {
     ops: &p256::PUBLIC_SCALAR_OPS,
     digest_alg: &digest::SHA256,
     split_rs: split_rs_asn1,
@@ -235,7 +235,7 @@ pub static ECDSA_P256_SHA256_ASN1: Algorithm = Algorithm {
 ///
 /// See "`ECDSA_*_ASN1` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P256_SHA384_ASN1: Algorithm = Algorithm {
+pub const ECDSA_P256_SHA384_ASN1: Algorithm = Algorithm {
     ops: &p256::PUBLIC_SCALAR_OPS,
     digest_alg: &digest::SHA384,
     split_rs: split_rs_asn1,
@@ -252,7 +252,7 @@ pub static ECDSA_P256_SHA384_ASN1: Algorithm = Algorithm {
 ///
 /// See "`ECDSA_*_ASN1` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P384_SHA256_ASN1: Algorithm = Algorithm {
+pub const ECDSA_P384_SHA256_ASN1: Algorithm = Algorithm {
     ops: &p384::PUBLIC_SCALAR_OPS,
     digest_alg: &digest::SHA256,
     split_rs: split_rs_asn1,
@@ -264,7 +264,7 @@ pub static ECDSA_P384_SHA256_ASN1: Algorithm = Algorithm {
 ///
 /// See "`ECDSA_*_ASN1` Details" in `ring::signature`'s module-level
 /// documentation for more details.
-pub static ECDSA_P384_SHA384_ASN1: Algorithm = Algorithm {
+pub const ECDSA_P384_SHA384_ASN1: Algorithm = Algorithm {
     ops: &p384::PUBLIC_SCALAR_OPS,
     digest_alg: &digest::SHA384,
     split_rs: split_rs_asn1,

--- a/src/ec/suite_b/ops/p256.rs
+++ b/src/ec/suite_b/ops/p256.rs
@@ -27,7 +27,7 @@ macro_rules! p256_limbs {
     };
 }
 
-pub static COMMON_OPS: CommonOps = CommonOps {
+pub const COMMON_OPS: CommonOps = CommonOps {
     num_limbs: 256 / LIMB_BITS,
 
     q: Modulus {
@@ -74,7 +74,7 @@ pub static COMMON_OPS: CommonOps = CommonOps {
     point_add_jacobian_impl: GFp_nistz256_point_add,
 };
 
-pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
+pub const PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
     common: &COMMON_OPS,
     elem_inv_squared: p256_elem_inv_squared,
     point_mul_base_impl: p256_point_mul_base_impl,
@@ -134,17 +134,17 @@ fn p256_point_mul_base_impl(g_scalar: &Scalar) -> Point {
     r
 }
 
-pub static PUBLIC_KEY_OPS: PublicKeyOps = PublicKeyOps {
+pub const PUBLIC_KEY_OPS: PublicKeyOps = PublicKeyOps {
     common: &COMMON_OPS,
 };
 
-pub static SCALAR_OPS: ScalarOps = ScalarOps {
+pub const SCALAR_OPS: ScalarOps = ScalarOps {
     common: &COMMON_OPS,
     scalar_inv_to_mont_impl: p256_scalar_inv_to_mont,
     scalar_mul_mont: GFp_p256_scalar_mul_mont,
 };
 
-pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
+pub const PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
     scalar_ops: &SCALAR_OPS,
     public_key_ops: &PUBLIC_KEY_OPS,
     private_key_ops: &PRIVATE_KEY_OPS,
@@ -156,7 +156,7 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
     },
 };
 
-pub static PRIVATE_SCALAR_OPS: PrivateScalarOps = PrivateScalarOps {
+pub const PRIVATE_SCALAR_OPS: PrivateScalarOps = PrivateScalarOps {
     scalar_ops: &SCALAR_OPS,
 
     oneRR_mod_n: Scalar {

--- a/src/ec/suite_b/ops/p384.rs
+++ b/src/ec/suite_b/ops/p384.rs
@@ -28,7 +28,7 @@ macro_rules! p384_limbs {
     };
 }
 
-pub static COMMON_OPS: CommonOps = CommonOps {
+pub const COMMON_OPS: CommonOps = CommonOps {
     num_limbs: 384 / LIMB_BITS,
 
     q: Modulus {
@@ -72,7 +72,7 @@ pub static COMMON_OPS: CommonOps = CommonOps {
     point_add_jacobian_impl: GFp_nistz384_point_add,
 };
 
-pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
+pub const PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
     common: &COMMON_OPS,
     elem_inv_squared: p384_elem_inv_squared,
     point_mul_base_impl: p384_point_mul_base_impl,
@@ -159,17 +159,17 @@ fn p384_point_mul_base_impl(a: &Scalar) -> Point {
     PRIVATE_KEY_OPS.point_mul(a, &P384_GENERATOR)
 }
 
-pub static PUBLIC_KEY_OPS: PublicKeyOps = PublicKeyOps {
+pub const PUBLIC_KEY_OPS: PublicKeyOps = PublicKeyOps {
     common: &COMMON_OPS,
 };
 
-pub static SCALAR_OPS: ScalarOps = ScalarOps {
+pub const SCALAR_OPS: ScalarOps = ScalarOps {
     common: &COMMON_OPS,
     scalar_inv_to_mont_impl: p384_scalar_inv_to_mont,
     scalar_mul_mont: GFp_p384_scalar_mul_mont,
 };
 
-pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
+pub const PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
     scalar_ops: &SCALAR_OPS,
     public_key_ops: &PUBLIC_KEY_OPS,
     private_key_ops: &PRIVATE_KEY_OPS,
@@ -185,7 +185,7 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
     },
 };
 
-pub static PRIVATE_SCALAR_OPS: PrivateScalarOps = PrivateScalarOps {
+pub const PRIVATE_SCALAR_OPS: PrivateScalarOps = PrivateScalarOps {
     scalar_ops: &SCALAR_OPS,
 
     oneRR_mod_n: Scalar {

--- a/src/rsa/padding.rs
+++ b/src/rsa/padding.rs
@@ -122,7 +122,7 @@ macro_rules! rsa_pkcs1_padding {
     ( $PADDING_ALGORITHM:ident, $digest_alg:expr, $digestinfo_prefix:expr,
       $doc_str:expr ) => {
         #[doc=$doc_str]
-        pub static $PADDING_ALGORITHM: PKCS1 = PKCS1 {
+        pub const $PADDING_ALGORITHM: PKCS1 = PKCS1 {
             digest_alg: $digest_alg,
             digestinfo_prefix: $digestinfo_prefix,
         };
@@ -157,7 +157,7 @@ rsa_pkcs1_padding!(
 macro_rules! pkcs1_digestinfo_prefix {
     ( $name:ident, $digest_len:expr, $digest_oid_len:expr,
       [ $( $digest_oid:expr ),* ] ) => {
-        static $name: [u8; 2 + 8 + $digest_oid_len] = [
+        const $name: [u8; 2 + 8 + $digest_oid_len] = [
             der::Tag::Sequence as u8, 8 + $digest_oid_len + $digest_len,
                 der::Tag::Sequence as u8, 2 + $digest_oid_len + 2,
                     der::Tag::OID as u8, $digest_oid_len, $( $digest_oid ),*,
@@ -462,7 +462,7 @@ fn pss_digest(
 macro_rules! rsa_pss_padding {
     ( $PADDING_ALGORITHM:ident, $digest_alg:expr, $doc_str:expr ) => {
         #[doc=$doc_str]
-        pub static $PADDING_ALGORITHM: PSS = PSS {
+        pub const $PADDING_ALGORITHM: PSS = PSS {
             digest_alg: $digest_alg,
         };
     };

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -102,7 +102,7 @@ macro_rules! rsa_params {
         #[doc=$doc_str]
         ///
         /// Only available in `use_heap` mode.
-        pub static $VERIFY_ALGORITHM: Parameters = Parameters {
+        pub const $VERIFY_ALGORITHM: Parameters = Parameters {
             padding_alg: $PADDING_ALGORITHM,
             min_bits: bits::BitLength::from_usize_bits($min_bits),
         };


### PR DESCRIPTION
All I did was change a ton of algorithms' `pub static`s to `pub const`. This should not affect runtime performance or memory usage.

The reason I think this is necessary is the following use case that I cannot currently get to work: (playground link [here](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=7a78e278dd48b2e7e267298542f2c4e0))
```rust
struct Algorithm {
    details: u8,
}

static MyAlgorithm: Algorithm = Algorithm {
    details: 100,
};

trait SomeFunctionality {
    const assoc_alg: &'static Algorithm;
}

struct Implementor;

impl SomeFunctionality for Implementor {
    const assoc_alg: &'static Algorithm = &MyAlgorithm;
}
```
The error the compiler gives me is
```
error[E0013]: constants cannot refer to statics, use a constant instead
  --> src/main.rs:16:43
   |
16 |     const assoc_alg: &'static Algorithm = &MyAlgorithm;
   |                                           ^^^^^^^^^^^^
```
From [RFC 1440](https://github.com/rust-lang/rfcs/pull/1440), my guess at the reason consts can't refer to statics is because statics can be types that have destructors, but consts cannot. Anyways, the problem is solved entirely by changing the `static MyAlgorithm` line to `const MyAlgorithm`.

Please let me know if you have any issues with this. Thank you for your work!