### PR TITLE
Use Once instead of lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,11 +304,6 @@ libc = { version = "0.2.48", default_features = false }
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 spin = { version = "0.5.0" }
 
-[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-
-[target.'cfg(any(target_os = "redox", all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies]
-lazy_static = "1.2"
-
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.6", default_features = false, features = ["ntsecapi", "wtypesbase"] }
 


### PR DESCRIPTION
For RNG detection, we are not really in need of lazy initialization. We're really just trying to cache the result of some function call (in this case `open` and `sysrand::chunk`). This is similar to what we do when detecting CPU features, so using Once in `rand` as well makes sense.

This change lets us eliminate a dependency and allows for consistency with potential future runtime checks in `rand` (this would be for platforms like SGX and UEFI that don't have `std`).

The downside is that it is potentially less efficient on platforms with [`std::sync::Once`](https://doc.rust-lang.org/std/sync/struct.Once.html). This shouldn't be an issue in practice, but if it is we can globally switch between the Once implementations based on `use_heap`.