### PR TITLE
convert doc comment to regular comment

### DIFF
--- a/tests/digest_tests.rs
+++ b/tests/digest_tests.rs
@@ -270,7 +270,7 @@ macro_rules! test_large_digest {
     };
 }
 
-/// XXX: This test is too slow on Android ARM.
+// XXX: This test is too slow on Android ARM.
 #[cfg(any(not(target_os = "android"), not(target_arch = "arm")))]
 test_large_digest!(
     digest_test_large_digest_sha1,


### PR DESCRIPTION
[rust-lang/rust#57882](https://github.com/rust-lang/rust/pull/57882) is modifying the `unused_doc_comments` lint to fire on mistakenly documented macro expansions. A crater run detected that this crate will break due to this change, likely because of the use of `deny(unused_doc_comments)` or `deny(warnings)`.

While this kind of breakage is allowed under Rust's stability guarantees, I am opening PRs to affected crates to reduce the impact.

This PR protects your crate from future breakage by converting the offending doc comment to a regular comment.