### PR TITLE
On OpenBSD, use arc4random_buf to implement SystemRandom::fill()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ spin = { version = "0.5.0" }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 
-[target.'cfg(any(target_os = "redox", all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies]
+[target.'cfg(any(target_os = "redox", all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "openbsd")))))'.dependencies]
 lazy_static = "1.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
OpenBSD provides [`arc4random_buf()`](https://man.openbsd.org/arc4random_buf) to provide secure pseudo-random numbers. This PR mimics how fuchsia's `SystemRandom::fill()` is implemented, but just calls `arc4random_buf()` instead.

There have been work done by @tatsuya6502 in #319, but it hasn't seen progress. This PR should implement what has been there (without C) for OpenBSD, but not for FreeBSD. However, FreeBSD can be trivially added.

I tested this with OpenBSD-current (2019-02-22 snapshot) using Rust 1.32.0.

Fixes #316
