### PR TITLE
Add diagnostic when compiling for a non-supported platform

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -368,7 +368,7 @@ fn build_c_code(target: &Target, pregenerated: PathBuf, out_dir: &Path) {
             let &(entry_arch, entry_os, _) = *entry;
             entry_arch == target.arch() && is_none_or_equals(entry_os, target.os())
         })
-        .unwrap();
+        .expect("Target platform is not supported");
 
     let is_git = std::fs::metadata(".git").is_ok();
 


### PR DESCRIPTION
Tried to compile for WASM, had to read the source code to figure out. This may save someone a few minutes in the future.