### PR TITLE
Allow the verification of an ECDSA signature given just a digest

### DIFF
--- a/src/ec/suite_b/ecdsa/digest_scalar.rs
+++ b/src/ec/suite_b/ecdsa/digest_scalar.rs
@@ -51,8 +51,7 @@ pub fn digest_scalar(ops: &ScalarOps, msg: digest::Digest) -> Scalar {
     digest_scalar_(ops, msg.as_ref())
 }
 
-#[cfg(test)]
-pub(crate) fn digest_bytes_scalar(ops: &ScalarOps, digest: &[u8]) -> Scalar {
+pub fn digest_bytes_scalar(ops: &ScalarOps, digest: &[u8]) -> Scalar {
     digest_scalar_(ops, digest)
 }
 


### PR DESCRIPTION
It seems like currently is only possible to verify an ECDSA signature given a message, the digest is produced internally.

Allow users to verify an ECDSA signature given an existing digest.