### PR TITLE
Simplify core vs std usage

### DIFF
--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -18,7 +18,6 @@ use super::{
     Block, BLOCK_LEN,
 };
 use crate::{endian::*, polyfill::convert::*};
-use core;
 use libc::size_t;
 
 #[repr(C)]
@@ -145,6 +144,7 @@ pub const KEY_LEN: usize = KEY_BLOCKS * BLOCK_LEN;
 mod tests {
     use super::*;
     use crate::test;
+    use std::vec;
 
     // This verifies the encryption functionality provided by ChaCha20_ctr32
     // is successful when either computed on disjoint input/output buffers,

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -25,7 +25,7 @@
 // as possible.
 
 use crate::{cpu, debug, endian::*, polyfill};
-use core::{self, num::Wrapping};
+use core::num::Wrapping;
 use libc::size_t;
 
 mod sha1;
@@ -507,6 +507,7 @@ mod tests {
     mod max_input {
         use super::super::super::digest;
         use crate::polyfill;
+        use std::vec;
 
         macro_rules! max_input_tests {
             ( $algorithm_name:ident ) => {

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -14,7 +14,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::polyfill;
-use core::{self, num::Wrapping};
+use core::num::Wrapping;
 use libc::size_t;
 
 pub const BLOCK_LEN: usize = 512 / 8;

--- a/src/ec/curve25519/ed25519/signing.rs
+++ b/src/ec/curve25519/ed25519/signing.rs
@@ -23,7 +23,6 @@ use crate::{
     rand,
     signature::{self, KeyPair as SigningKeyPair},
 };
-use core;
 use untrusted;
 
 use super::digest::*;

--- a/src/ec/curve25519/ed25519/verification.rs
+++ b/src/ec/curve25519/ed25519/verification.rs
@@ -16,7 +16,6 @@
 
 use super::super::ops::*;
 use crate::{error, polyfill::convert::*, sealed, signature};
-use core;
 use untrusted;
 
 use super::digest::*;

--- a/src/ec/suite_b/ecdh.rs
+++ b/src/ec/suite_b/ecdh.rs
@@ -143,7 +143,6 @@ fn ecdh(
 mod tests {
     use super::super::ops;
     use crate::{agreement, ec, limb, test};
-    use core;
 
     static SUPPORTED_SUITE_B_ALGS: [(&str, &agreement::Algorithm, &ec::Curve, &ops::CommonOps); 2] = [
         (

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -26,7 +26,6 @@ use crate::{
     io::der,
     limb, pkcs8, rand, sealed, signature,
 };
-use core;
 use untrusted;
 
 /// An ECDSA signing algorithm.

--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -289,6 +289,7 @@ pub static ECDSA_P384_SHA384_ASN1: EcdsaVerificationAlgorithm = EcdsaVerificatio
 mod tests {
     use super::*;
     use crate::test;
+    use std::vec::Vec;
 
     #[test]
     fn test_digest_based_test_vectors() {

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -469,7 +469,7 @@ extern "C" {
 mod tests {
     use super::*;
     use crate::test;
-    use std;
+    use std::{format, print, vec, vec::Vec};
     use untrusted;
 
     const ZERO_SCALAR: Scalar = Scalar {

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,11 +15,7 @@
 //! Error reporting.
 
 use crate::polyfill::convert::*;
-use core;
 use untrusted;
-
-#[cfg(feature = "use_heap")]
-use std;
 
 /// An error with absolutely no details.
 ///
@@ -212,8 +208,7 @@ impl std::error::Error for KeyRejected {
     }
 }
 
-#[cfg(feature = "use_heap")]
-impl std::fmt::Display for KeyRejected {
+impl core::fmt::Display for KeyRejected {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.write_str(self.description_())
     }

--- a/src/io/der_writer.rs
+++ b/src/io/der_writer.rs
@@ -13,6 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{der::*, writer::*, *};
+use std::boxed::Box;
 
 pub(crate) fn write_positive_integer(output: &mut Accumulator, value: &Positive) {
     let first_byte = value.first_byte();

--- a/src/io/writer.rs
+++ b/src/io/writer.rs
@@ -12,6 +12,8 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use std::{boxed::Box, vec::Vec};
+
 pub trait Accumulator {
     fn write_byte(&mut self, value: u8);
     fn write_bytes(&mut self, value: &[u8]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,20 +59,11 @@
     unused_results,
     warnings
 )]
-#![cfg_attr(
-    any(
-        target_os = "redox",
-        all(
-            not(test),
-            not(feature = "use_heap"),
-            unix,
-            not(any(target_os = "macos", target_os = "ios")),
-            any(not(target_os = "linux"), feature = "dev_urandom_fallback")
-        )
-    ),
-    no_std
-)]
+#![no_std]
 #![cfg_attr(feature = "internal_benches", allow(unstable_features), feature(test))]
+
+#[cfg(any(test, feature = "use_heap"))]
+extern crate std;
 
 #[macro_use]
 mod debug;

--- a/src/pkcs8.rs
+++ b/src/pkcs8.rs
@@ -17,7 +17,6 @@
 //! [RFC 5958]: https://tools.ietf.org/html/rfc5958.
 
 use crate::{ec, error, io::der};
-use core;
 use untrusted;
 
 pub(crate) enum Version {

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -15,8 +15,6 @@
 //! Polyfills for functionality that will (hopefully) be added to Rust's
 //! standard library soon.
 
-use core;
-
 #[macro_use]
 pub mod convert;
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -165,7 +165,6 @@ mod sysrand_chunk {
 #[cfg(windows)]
 mod sysrand_chunk {
     use crate::{error, polyfill};
-    use core;
 
     #[inline]
     pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
@@ -212,7 +211,6 @@ mod sysrand {
 ))]
 mod urandom {
     use crate::error;
-    use std;
 
     pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
         use lazy_static::lazy_static;
@@ -321,6 +319,7 @@ mod fuchsia {
 #[cfg(test)]
 mod tests {
     use crate::rand::{self, SecureRandom};
+    use std::vec;
 
     #[test]
     fn test_system_random_lengths() {

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -46,12 +46,16 @@ use crate::{
     limb::{self, Limb, LimbMask, LIMB_BITS, LIMB_BYTES},
 };
 use core::{
-    self,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 use libc::size_t;
-use std::borrow::ToOwned as _; // TODO: Remove; Redundant as of Rust 1.36.
+use std::{
+    borrow::ToOwned as _, // TODO: Remove; Redundant as of Rust 1.36.
+    boxed::Box,
+    vec,
+    vec::Vec,
+};
 use untrusted;
 
 pub unsafe trait Prime {}
@@ -1294,6 +1298,7 @@ extern "C" {
 mod tests {
     use super::*;
     use crate::test;
+    use std::format;
     use untrusted;
 
     // Type-level representation of an arbitrary modulus.

--- a/src/rsa/padding.rs
+++ b/src/rsa/padding.rs
@@ -521,6 +521,7 @@ rsa_pss_padding!(
 mod test {
     use super::*;
     use crate::{digest, error, test};
+    use std::vec;
     use untrusted;
 
     #[test]

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -24,6 +24,7 @@ use crate::{
     io::{self, der, der_writer},
     pkcs8, rand, signature,
 };
+use std::boxed::Box;
 use untrusted;
 
 /// An RSA key pair, used for signing.
@@ -609,6 +610,7 @@ mod tests {
     // We intentionally avoid `use super::*` so that we are sure to use only
     // the public API; this ensures that enough of the API is public.
     use crate::{rand, signature};
+    use std::vec;
 
     // `KeyPair::sign` requires that the output buffer is the same length as
     // the public key modulus. Test what happens when it isn't the same length.

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -257,7 +257,6 @@
 //! ```
 
 use crate::{cpu, ec, error, sealed};
-use core;
 use untrusted;
 
 pub use crate::ec::{

--- a/src/test.rs
+++ b/src/test.rs
@@ -121,8 +121,8 @@ use crate::bits;
 
 use crate::{digest, error};
 
-use core;
-use std::{self, string::String, vec::Vec};
+use std::{format, string::String, vec::Vec};
+use std::{panic, println};
 
 /// `compile_time_assert_clone::<T>();` fails to compile if `T` doesn't
 /// implement `Clone`.
@@ -310,7 +310,7 @@ where
 
     #[allow(box_pointers)]
     while let Some(mut test_case) = parse_test_case(&mut current_section, lines) {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             f(&current_section, &mut test_case)
         }));
         let result = match result {
@@ -455,7 +455,6 @@ fn parse_test_case(
 #[allow(missing_docs)]
 pub mod rand {
     use crate::{error, polyfill, rand, sealed};
-    use core;
 
     /// An implementation of `SecureRandom` that always fills the output slice
     /// with the given byte.


### PR DESCRIPTION
Right now, `src/lib.rs` defines *ring* to be a `no_std` crate conditionally based on the features and CPU architecture. This is sub-optimal, as it requires a lot of `cfg` attributes to be kept in sync. Both [`rand`](https://crates.io/crates/rand) and [`rdrand`](https://crates.io/crates/rdrand) have dealt with this kind of problem, and they use the following solution.
  - The create is unconditionally `#![no_std]`
  - If `std` is needed, it can be brought in with `extern crate std`
  - There are no bare `use std` or `use core` statements (as they are never necessary)

This is what I did in this PR. Some advantages to this PR:
  - It is now very easy to see what ring is depending on from `std`. This helps with:
    - https://github.com/briansmith/ring/issues/744
    - Eventually making ring's tests work with `no_std`
  - After `extern crate alloc` lands in the next stable Rust release, most of the `use std::` statements can be turned into `use alloc::`.
  - It will make it easier to eventually split the `use_heap` feature into two features
    - `std`: Enables getting randomness from files and `std::error::Error` implementations
    - `alloc`: Enables operations that need dynamic memory allocation (RSA signing, etc...)
  - Helps with the porting work in https://github.com/briansmith/ring/pull/787 and https://github.com/briansmith/ring/issues/775