### PR TITLE
Prefer Rust types to libc types

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -56,7 +56,7 @@
 
 #include <GFp/mem.h>
 
-int GFp_memcmp(const uint8_t *a, const uint8_t *b, size_t len) {
+uint8_t GFp_memcmp(const uint8_t *a, const uint8_t *b, size_t len) {
   uint8_t x = 0;
   for (size_t i = 0; i < len; i++) {
     x |= a[i] ^ b[i];

--- a/include/GFp/mem.h
+++ b/include/GFp/mem.h
@@ -64,6 +64,6 @@
 // of |a| and |b|. Unlike memcmp, it cannot be used to put elements into a
 // defined order as the return value when a != b is undefined, other than to be
 // non-zero.
-OPENSSL_EXPORT int GFp_memcmp(const uint8_t *a, const uint8_t *b, size_t len);
+OPENSSL_EXPORT uint8_t GFp_memcmp(const uint8_t *a, const uint8_t *b, size_t len);
 
 #endif  // OPENSSL_HEADER_MEM_H

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -17,7 +17,6 @@ use super::{
     shift, Block, Direction, BLOCK_LEN,
 };
 use crate::{bits::BitLength, cpu, endian::*, error, polyfill};
-use libc::size_t;
 
 pub(crate) struct Key {
     inner: AES_KEY,
@@ -176,7 +175,7 @@ impl Key {
                     fn GFp_aes_hw_ctr32_encrypt_blocks(
                         input: *const u8,
                         output: *mut u8,
-                        blocks: size_t,
+                        blocks: usize,
                         key: &AES_KEY,
                         ivec: &Counter,
                     );
@@ -193,7 +192,7 @@ impl Key {
                     fn GFp_bsaes_ctr32_encrypt_blocks(
                         input: *const u8,
                         output: *mut u8,
-                        blocks: size_t,
+                        blocks: usize,
                         key: &AES_KEY,
                         ivec: &Counter,
                     );

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -205,8 +205,6 @@ fn integrated_aes_gcm<'a>(
     direction: Direction,
     cpu_features: cpu::Features,
 ) -> &'a mut [u8] {
-    use libc::size_t;
-
     if !aes_key.is_aes_hw() || !gcm_ctx.is_avx2(cpu_features) {
         return in_out;
     }
@@ -217,11 +215,11 @@ fn integrated_aes_gcm<'a>(
                 fn GFp_aesni_gcm_decrypt(
                     input: *const u8,
                     output: *mut u8,
-                    len: size_t,
+                    len: usize,
                     key: &aes::AES_KEY,
                     ivec: &mut Counter,
                     gcm: &mut gcm::Context,
-                ) -> size_t;
+                ) -> usize;
             }
             unsafe {
                 GFp_aesni_gcm_decrypt(
@@ -239,11 +237,11 @@ fn integrated_aes_gcm<'a>(
                 fn GFp_aesni_gcm_encrypt(
                     input: *const u8,
                     output: *mut u8,
-                    len: size_t,
+                    len: usize,
                     key: &aes::AES_KEY,
                     ivec: &mut Counter,
                     gcm: &mut gcm::Context,
-                ) -> size_t;
+                ) -> usize;
             }
             unsafe {
                 GFp_aesni_gcm_encrypt(

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -19,7 +19,6 @@ use super::{
 };
 use crate::{endian::*, polyfill::convert::*};
 use core;
-use libc::size_t;
 
 #[repr(C)]
 pub struct Key([Block; KEY_BLOCKS]);
@@ -121,7 +120,7 @@ impl Key {
             fn GFp_ChaCha20_ctr32(
                 out: *mut u8,
                 in_: *const u8,
-                in_len: size_t,
+                in_len: usize,
                 key: &Key,
                 first_iv: &Iv,
             );

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -14,7 +14,6 @@
 
 use super::{Aad, Block, BLOCK_LEN};
 use crate::cpu;
-use libc::size_t;
 
 #[repr(transparent)]
 pub struct Key(GCM128_KEY);
@@ -111,7 +110,7 @@ impl Context {
                         ctx: &mut Context,
                         h_table: *const GCM128_KEY,
                         inp: *const u8,
-                        len: size_t,
+                        len: usize,
                     );
                 }
                 unsafe {
@@ -125,7 +124,7 @@ impl Context {
                         ctx: &mut Context,
                         h_table: *const GCM128_KEY,
                         inp: *const u8,
-                        len: size_t,
+                        len: usize,
                     );
                 }
                 unsafe {
@@ -140,7 +139,7 @@ impl Context {
                         ctx: &mut Context,
                         h_table: *const GCM128_KEY,
                         inp: *const u8,
-                        len: size_t,
+                        len: usize,
                     );
                 }
                 unsafe {
@@ -154,7 +153,7 @@ impl Context {
                         ctx: &mut Context,
                         h_table: *const GCM128_KEY,
                         inp: *const u8,
-                        len: size_t,
+                        len: usize,
                     );
                 }
                 unsafe {

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -20,7 +20,6 @@ use super::{
     Tag,
 };
 use crate::{bssl, error};
-use libc::size_t;
 
 /// A Poly1305 key.
 pub struct Key([Block; KEY_BLOCKS]);
@@ -51,7 +50,7 @@ impl Context {
             fn GFp_poly1305_blocks(
                 state: &mut Opaque,
                 input: *const u8,
-                len: size_t,
+                len: usize,
                 should_pad: Pad,
             );
             fn GFp_poly1305_emit(state: &mut Opaque, tag: &mut Tag, nonce: &Nonce);
@@ -123,7 +122,7 @@ struct Nonce(Block);
 #[repr(C)]
 struct Funcs {
     blocks_fn:
-        unsafe extern "C" fn(&mut Opaque, input: *const u8, input_len: size_t, should_pad: Pad),
+        unsafe extern "C" fn(&mut Opaque, input: *const u8, input_len: usize, should_pad: Pad),
     emit_fn: unsafe extern "C" fn(&mut Opaque, &mut Tag, nonce: &Nonce),
 }
 

--- a/src/constant_time.rs
+++ b/src/constant_time.rs
@@ -15,7 +15,6 @@
 //! Constant-time operations.
 
 use crate::error;
-use libc::size_t;
 
 /// Returns `Ok(())` if `a == b` and `Err(error::Unspecified)` otherwise.
 /// The comparison of `a` and `b` is done in constant time with respect to the
@@ -33,7 +32,7 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<(), error::Unspecif
 }
 
 extern "C" {
-    fn GFp_memcmp(a: *const u8, b: *const u8, len: size_t) -> libc::c_int;
+    fn GFp_memcmp(a: *const u8, b: *const u8, len: usize) -> u8;
 }
 
 #[cfg(test)]

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -26,7 +26,6 @@
 
 use crate::{cpu, debug, endian::*, polyfill};
 use core::{self, num::Wrapping};
-use libc::size_t;
 
 mod sha1;
 
@@ -248,7 +247,7 @@ pub struct Algorithm {
     /// The length of the length in the padding.
     len_len: usize,
 
-    block_data_order: unsafe extern "C" fn(state: &mut State, data: *const u8, num: size_t),
+    block_data_order: unsafe extern "C" fn(state: &mut State, data: *const u8, num: usize),
     format_output: fn(input: State) -> Output,
 
     initial_state: State,
@@ -484,8 +483,8 @@ const SHA512_BLOCK_LEN: usize = 1024 / 8;
 const SHA512_LEN_LEN: usize = 128 / 8;
 
 extern "C" {
-    fn GFp_sha256_block_data_order(state: &mut State, data: *const u8, num: size_t);
-    fn GFp_sha512_block_data_order(state: &mut State, data: *const u8, num: size_t);
+    fn GFp_sha256_block_data_order(state: &mut State, data: *const u8, num: usize);
+    fn GFp_sha512_block_data_order(state: &mut State, data: *const u8, num: usize);
 }
 
 #[cfg(test)]

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -15,7 +15,6 @@
 
 use crate::polyfill;
 use core::{self, num::Wrapping};
-use libc::size_t;
 
 pub const BLOCK_LEN: usize = 512 / 8;
 pub const CHAINING_LEN: usize = 160 / 8;
@@ -47,7 +46,7 @@ fn maj(x: W32, y: W32, z: W32) -> W32 {
 pub(super) unsafe extern "C" fn block_data_order(
     state: &mut super::State,
     data: *const u8,
-    num: size_t,
+    num: usize,
 ) {
     let data = data as *const [[u8; 4]; 16];
     let blocks = core::slice::from_raw_parts(data, num);

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -14,7 +14,6 @@
 
 use crate::{arithmetic::montgomery::*, error, limb::*};
 use core::marker::PhantomData;
-use libc::size_t;
 use untrusted;
 
 pub use self::elem::*;
@@ -461,7 +460,7 @@ extern "C" {
         a: *const Limb,
         b: *const Limb,
         m: *const Limb,
-        num_limbs: size_t,
+        num_limbs: usize,
     );
 }
 

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -19,7 +19,6 @@
 //! limbs use the native endianness.
 
 use crate::error;
-use libc::size_t;
 use untrusted;
 
 #[cfg(any(test, feature = "use_heap"))]
@@ -59,7 +58,7 @@ pub const LIMB_BYTES: usize = (LIMB_BITS + 7) / 8;
 #[inline]
 pub fn limbs_equal_limbs_consttime(a: &[Limb], b: &[Limb]) -> LimbMask {
     extern "C" {
-        fn LIMBS_equal(a: *const Limb, b: *const Limb, num_limbs: size_t) -> LimbMask;
+        fn LIMBS_equal(a: *const Limb, b: *const Limb, num_limbs: usize) -> LimbMask;
     }
 
     assert_eq!(a.len(), b.len());
@@ -276,9 +275,9 @@ pub fn fold_5_bit_windows<R, I: FnOnce(Window) -> R, F: Fn(R, Window) -> R>(
 ) -> R {
     #[derive(Clone, Copy)]
     #[repr(transparent)]
-    struct BitIndex(Wrapping<size_t>);
+    struct BitIndex(Wrapping<usize>);
 
-    const WINDOW_BITS: Wrapping<size_t> = Wrapping(5);
+    const WINDOW_BITS: Wrapping<usize> = Wrapping(5);
 
     extern "C" {
         fn LIMBS_window5_split_window(
@@ -335,17 +334,17 @@ pub fn fold_5_bit_windows<R, I: FnOnce(Window) -> R, F: Fn(R, Window) -> R>(
 
 extern "C" {
     #[cfg(any(test, feature = "use_heap"))]
-    fn LIMB_shr(a: Limb, shift: size_t) -> Limb;
+    fn LIMB_shr(a: Limb, shift: usize) -> Limb;
 
     #[cfg(any(test, feature = "use_heap"))]
-    fn LIMBS_are_even(a: *const Limb, num_limbs: size_t) -> LimbMask;
-    fn LIMBS_are_zero(a: *const Limb, num_limbs: size_t) -> LimbMask;
+    fn LIMBS_are_even(a: *const Limb, num_limbs: usize) -> LimbMask;
+    fn LIMBS_are_zero(a: *const Limb, num_limbs: usize) -> LimbMask;
     #[cfg(any(test, feature = "use_heap"))]
-    fn LIMBS_equal_limb(a: *const Limb, b: Limb, num_limbs: size_t) -> LimbMask;
-    fn LIMBS_less_than(a: *const Limb, b: *const Limb, num_limbs: size_t) -> LimbMask;
+    fn LIMBS_equal_limb(a: *const Limb, b: Limb, num_limbs: usize) -> LimbMask;
+    fn LIMBS_less_than(a: *const Limb, b: *const Limb, num_limbs: usize) -> LimbMask;
     #[cfg(feature = "use_heap")]
-    fn LIMBS_less_than_limb(a: *const Limb, b: Limb, num_limbs: size_t) -> LimbMask;
-    fn LIMBS_reduce_once(r: *mut Limb, m: *const Limb, num_limbs: size_t);
+    fn LIMBS_less_than_limb(a: *const Limb, b: Limb, num_limbs: usize) -> LimbMask;
+    fn LIMBS_reduce_once(r: *mut Limb, m: *const Limb, num_limbs: usize);
 }
 
 #[cfg(test)]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -129,26 +129,11 @@ use crate::sealed;
 #[cfg(target_os = "linux")]
 mod sysrand_chunk {
     use crate::error;
-    use libc::{self, size_t};
+    use libc;
 
     #[inline]
     pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        // See `SYS_getrandom` in #include <sys/syscall.h>.
-
-        #[cfg(target_arch = "aarch64")]
-        const SYS_GETRANDOM: libc::c_long = 278;
-
-        #[cfg(target_arch = "arm")]
-        const SYS_GETRANDOM: libc::c_long = 384;
-
-        #[cfg(target_arch = "x86")]
-        const SYS_GETRANDOM: libc::c_long = 355;
-
-        #[cfg(target_arch = "x86_64")]
-        const SYS_GETRANDOM: libc::c_long = 318;
-
-        let chunk_len: size_t = dest.len();
-        let r = unsafe { libc::syscall(SYS_GETRANDOM, dest.as_mut_ptr(), chunk_len, 0) };
+        let r = unsafe { libc::syscall(libc::SYS_getrandom, dest.as_mut_ptr(), dest.len(), 0) };
         if r < 0 {
             if unsafe { *libc::__errno_location() } == libc::EINTR {
                 // If an interrupt occurs while getrandom() is blocking to wait
@@ -295,7 +280,7 @@ mod darwin {
         #[must_use]
         fn SecRandomCopyBytes(
             rnd: &'static SecRandomRef,
-            count: libc::size_t,
+            count: usize,
             bytes: *mut u8,
         ) -> libc::c_int;
     }

--- a/src/rsa/bigint.rs
+++ b/src/rsa/bigint.rs
@@ -50,7 +50,6 @@ use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
-use libc::size_t;
 use std::borrow::ToOwned as _; // TODO: Remove; Redundant as of Rust 1.36.
 use untrusted;
 
@@ -487,7 +486,7 @@ where
 
 fn elem_mul_by_2<M, AF>(a: &mut Elem<M, AF>, m: &PartialModulus<M>) {
     extern "C" {
-        fn LIMBS_shl_mod(r: *mut Limb, a: *const Limb, m: *const Limb, num_limbs: size_t);
+        fn LIMBS_shl_mod(r: *mut Limb, a: *const Limb, m: *const Limb, num_limbs: usize);
     }
     unsafe {
         LIMBS_shl_mod(
@@ -523,11 +522,11 @@ pub fn elem_reduced<Larger, Smaller: NotMuchSmallerModulus<Larger>>(
     extern "C" {
         fn GFp_bn_from_montgomery_in_place(
             r: *mut Limb,
-            num_r: size_t,
+            num_r: usize,
             a: *mut Limb,
-            num_a: size_t,
+            num_a: usize,
             n: *const Limb,
-            num_n: size_t,
+            num_n: usize,
             n0: &N0,
         ) -> bssl::Result;
     }
@@ -583,7 +582,7 @@ pub fn elem_add<M, E>(mut a: Elem<M, E>, b: Elem<M, E>, m: &Modulus<M>) -> Elem<
             a: *const Limb,
             b: *const Limb,
             m: *const Limb,
-            num_limbs: size_t,
+            num_limbs: usize,
         );
     }
     unsafe {
@@ -607,7 +606,7 @@ pub fn elem_sub<M, E>(mut a: Elem<M, E>, b: &Elem<M, E>, m: &Modulus<M>) -> Elem
             a: *const Limb,
             b: *const Limb,
             m: *const Limb,
-            num_limbs: size_t,
+            num_limbs: usize,
         );
     }
     unsafe {
@@ -853,7 +852,7 @@ pub fn elem_exp_consttime<M>(
             fn LIMBS_select_512_32(
                 r: *mut Limb,
                 table: *const Limb,
-                num_limbs: size_t,
+                num_limbs: usize,
                 i: Window,
             ) -> bssl::Result;
         }
@@ -977,7 +976,7 @@ pub fn elem_exp_consttime<M>(
 
     fn scatter(table: &mut [Limb], state: &[Limb], i: Window, num_limbs: usize) {
         extern "C" {
-            fn GFp_bn_scatter5(a: *const Limb, a_len: size_t, table: *mut Limb, i: Window);
+            fn GFp_bn_scatter5(a: *const Limb, a_len: usize, table: *mut Limb, i: Window);
         }
         unsafe {
             GFp_bn_scatter5(
@@ -991,7 +990,7 @@ pub fn elem_exp_consttime<M>(
 
     fn gather(table: &[Limb], state: &mut [Limb], i: Window, num_limbs: usize) {
         extern "C" {
-            fn GFp_bn_gather5(r: *mut Limb, a_len: size_t, table: *const Limb, i: Window);
+            fn GFp_bn_gather5(r: *mut Limb, a_len: usize, table: *const Limb, i: Window);
         }
         unsafe {
             GFp_bn_gather5(
@@ -1019,7 +1018,7 @@ pub fn elem_exp_consttime<M>(
                 table: *const Limb,
                 np: *const Limb,
                 n0: &N0,
-                num: size_t,
+                num: usize,
                 power: Window,
             );
         }
@@ -1044,7 +1043,7 @@ pub fn elem_exp_consttime<M>(
                 table: *const Limb,
                 n: *const Limb,
                 n0: &N0,
-                num: size_t,
+                num: usize,
                 i: Window,
             );
         }
@@ -1102,7 +1101,7 @@ pub fn elem_exp_consttime<M>(
             not_used: *const Limb,
             n: *const Limb,
             n0: &N0,
-            num: size_t,
+            num: usize,
         ) -> bssl::Result;
     }
     Result::from(unsafe {
@@ -1286,7 +1285,7 @@ extern "C" {
         b: *const Limb,
         n: *const Limb,
         n0: &N0,
-        num_limbs: size_t,
+        num_limbs: usize,
     );
 }
 


### PR DESCRIPTION
Part of addressing https://github.com/briansmith/ring/issues/744

For many types in `libc` (`uint8_t`, `int32_t`, etc...) we assume these types are equivalent to certain Rust types (`u8`, `i32`, etc...) even if `libc` is empty. This PR does three things:

  - Moves `size_t` to `usize`, as they are definitionally the same type. This is equivalence is currently assumed by *ring* anyway, and it is also assumed by Rust itself [in things like `memcpy`](https://docs.rs/rlibc/1.0.0/rlibc/fn.memcpy.html).
  - Changes the C implementation of `GFp_memcmp` to return a `u8` instead of a int. This fits better with the functions implementation, and the return value is only ever compared to zero anyway. As a side note, is there any reason this function cannot be written in Rust?
  - Cleans up the usage of libc to use the constants for the `getrandom` syscall. This has been in `libc` for a while, so we don't need to increment the `libc` version in `Cargo.toml`.

Now the only necessary C types are for `bssl::Result` and a bunch of one-off code in `aead/aes.rs`, which I'll address in a future CL. 