### PR TITLE
Use libc::SYS_getrandom

### DIFF
--- a/src/c.rs
+++ b/src/c.rs
@@ -28,6 +28,3 @@ pub(crate) type uint = libc::c_uint;
     any(target_arch = "aarch64", target_arch = "arm")
 ))]
 pub(crate) type ulong = libc::c_ulong;
-
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub(crate) type long = libc::c_long;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -115,26 +115,11 @@ use crate::sealed;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod sysrand_chunk {
-    use crate::{c, error};
+    use crate::error;
 
     #[inline]
     pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        // See `SYS_getrandom` in #include <sys/syscall.h>.
-
-        #[cfg(target_arch = "aarch64")]
-        const SYS_GETRANDOM: c::long = 278;
-
-        #[cfg(target_arch = "arm")]
-        const SYS_GETRANDOM: c::long = 384;
-
-        #[cfg(target_arch = "x86")]
-        const SYS_GETRANDOM: c::long = 355;
-
-        #[cfg(target_arch = "x86_64")]
-        const SYS_GETRANDOM: c::long = 318;
-
-        let chunk_len: c::size_t = dest.len();
-        let r = unsafe { libc::syscall(SYS_GETRANDOM, dest.as_mut_ptr(), chunk_len, 0) };
+        let r = unsafe { libc::syscall(libc::SYS_getrandom, dest.as_mut_ptr(), dest.len(), 0) };
         if r < 0 {
             let errno;
 


### PR DESCRIPTION
This has been in `libc` for a while, so we don't need to increment the
`libc` version in Cargo.toml. Note that we cannot use the `getrandom()`
function from `libc`, as it isn't available on Android.

Originally part of #744