### PR TITLE
Requesting Feedback: WIP changes to `rand.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,8 +321,7 @@ cc = "1.0.26"
 
 [features]
 # These features are documented in the top-level module's documentation.
-default = ["use_heap", "dev_urandom_fallback"]
-dev_urandom_fallback = ["use_heap"]
+default = ["use_heap"]
 internal_benches = []
 slow_tests = []
 test_logging = []

--- a/src/c.rs
+++ b/src/c.rs
@@ -28,6 +28,3 @@ pub(crate) type uint = libc::c_uint;
     any(target_arch = "aarch64", target_arch = "arm")
 ))]
 pub(crate) type ulong = libc::c_ulong;
-
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub(crate) type long = libc::c_long;

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,6 +113,19 @@ impl From<TryFromSliceError> for Unspecified {
     }
 }
 
+impl From<&Unspecified> for Unspecified {
+    fn from(_: &Unspecified) -> Self {
+        Unspecified
+    }
+}
+
+#[cfg(feature = "use_heap")]
+impl From<std::io::Error> for Unspecified {
+    fn from(_: std::io::Error) -> Self {
+        Unspecified
+    }
+}
+
 /// An error parsing or validating a key.
 ///
 /// The `Display` implementation and `<KeyRejected as Error>::description()`

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -115,26 +115,11 @@ use crate::sealed;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod sysrand_chunk {
-    use crate::{c, error};
+    use crate::error;
 
     #[inline]
     pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
-        // See `SYS_getrandom` in #include <sys/syscall.h>.
-
-        #[cfg(target_arch = "aarch64")]
-        const SYS_GETRANDOM: c::long = 278;
-
-        #[cfg(target_arch = "arm")]
-        const SYS_GETRANDOM: c::long = 384;
-
-        #[cfg(target_arch = "x86")]
-        const SYS_GETRANDOM: c::long = 355;
-
-        #[cfg(target_arch = "x86_64")]
-        const SYS_GETRANDOM: c::long = 318;
-
-        let chunk_len: c::size_t = dest.len();
-        let r = unsafe { libc::syscall(SYS_GETRANDOM, dest.as_mut_ptr(), chunk_len, 0) };
+        let r = unsafe { libc::syscall(libc::SYS_getrandom, dest.as_mut_ptr(), dest.len(), 0) };
         if r < 0 {
             let errno;
 


### PR DESCRIPTION
This PR is a collection of all the potential improvements to `rand.rs`. This won't be merged as-is, and will need to be split off into smaller PRs like #839. Not all of the ideas here will end up being merged. I'm just putting this up to get feedback from @briansmith @sconybeare @myfreeweb @oherrala @tatsuya6502 and anyone else who interested.

This was motivated by the work I've been doing for the [`getrandom`](https://github.com/rust-random/getrandom) crate.

Things this patch does:
  - Organizes code based on how we try to get randomness:
    - `sysrand`: get randomness via a syscall or system function
    - `file`: get randomness from a file
    - some implementations choose between `sysrand` and `file`
  - Unifies the Linux and Android implementations
  - Read 1 byte from `/dev/random` before reading from `/dev/urandom`
  - Removes `dev_urandom_fallback` feature, as it is no longer needed for security. If you want to force Linux to use `getrandom` just don't enable the `use_heap` feature.
  - Linux: use `libc::SYS_getrandom` (#839)
  - Linux: use `GRND_NONBLOCK` for `getrandom()` detection
  - Redox: Adds support back
  - NetBSD: Adds support (easy as it just does the same thing as Linux)
  - Windows: Simplifies implementation 
  - Minor formatting and naming fixes
  - Adds more implementations for `error::Unspecified` to make error handling easier.
  - Documentation update