### PR TITLE
Use modern C initialization syntax

### DIFF
--- a/crypto/fipsmodule/ec/gfp_p256.c
+++ b/crypto/fipsmodule/ec/gfp_p256.c
@@ -77,9 +77,9 @@ void GFp_nistz256_select_w5(P256_POINT *out, const P256_POINT table[16],
   assert(index >= 0);
   size_t index_s = (size_t)index; /* XXX: constant time? */
 
-  alignas(32) Elem x; limbs_zero(x, P256_LIMBS);
-  alignas(32) Elem y; limbs_zero(y, P256_LIMBS);
-  alignas(32) Elem z; limbs_zero(z, P256_LIMBS);
+  alignas(32) Elem x = {0};
+  alignas(32) Elem y = {0};
+  alignas(32) Elem z = {0};
 
   for (size_t i = 0; i < 16; ++i) {
     Limb mask = constant_time_eq_w(index_s, i + 1);

--- a/crypto/fipsmodule/ec/gfp_p384.c
+++ b/crypto/fipsmodule/ec/gfp_p384.c
@@ -221,9 +221,9 @@ void GFp_p384_scalar_mul_mont(ScalarMont r, const ScalarMont a,
 
 static void gfp_p384_point_select_w5(P384_POINT *out,
                                      const P384_POINT table[16], size_t index) {
-  Elem x; limbs_zero(x, P384_LIMBS);
-  Elem y; limbs_zero(y, P384_LIMBS);
-  Elem z; limbs_zero(z, P384_LIMBS);
+  Elem x = {0};
+  Elem y = {0};
+  Elem z = {0};
 
   for (size_t i = 0; i < 16; ++i) {
     Limb mask = constant_time_eq_w(index, i + 1);


### PR DESCRIPTION
Closes #844

I reviewed the C code for how we handle uninitialized variables. It
looks like the uses of limbs_zero were the only times we immdiately
zero a value right after declaring it in `crypto/`.

We could switch some of the initializations in `third_party/fiat`,
but those are in the "Proven by Coq" section, so I'll just leave them
be.