### PR TITLE
impl Clone for SystemRandom

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -76,6 +76,7 @@ pub trait SecureRandom: sealed::Sealed {
 /// `getrandom` and `read`.
 ///
 /// [`getrandom`]: http://man7.org/linux/man-pages/man2/getrandom.2.html
+#[derive(Clone)]
 pub struct SystemRandom;
 
 impl SystemRandom {


### PR DESCRIPTION
Fixes #808

Per https://github.com/briansmith/ring/issues/808#issuecomment-502572386 I did not add CloneableSecureRandom as to avoid cluttering *ring*'s external API. It's also just equivalent to `SecureRandom + Clone` if anyone needs it.