### PR TITLE
Use `/dev/urandom` fallback on Andorid

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -89,13 +89,18 @@ impl SecureRandom for SystemRandom {
 impl sealed::Sealed for SystemRandom {}
 
 #[cfg(any(
-    target_os = "android",
-    all(target_os = "linux", not(feature = "dev_urandom_fallback")),
+    all(
+        any(target_os = "android", target_os = "linux"),
+        not(feature = "dev_urandom_fallback")
+    ),
     windows
 ))]
 use self::sysrand::fill as fill_impl;
 
-#[cfg(all(target_os = "linux", feature = "dev_urandom_fallback"))]
+#[cfg(all(
+    any(target_os = "android", target_os = "linux"),
+    feature = "dev_urandom_fallback"
+))]
 use self::sysrand_or_urandom::fill as fill_impl;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -191,7 +191,10 @@ mod sysrand {
 }
 
 // Keep the `cfg` conditions in sync with the conditions in lib.rs.
-#[cfg(all(target_os = "linux", feature = "dev_urandom_fallback"))]
+#[cfg(all(
+    any(target_os = "android", target_os = "linux"),
+    feature = "dev_urandom_fallback"
+))]
 mod sysrand_or_urandom {
     use crate::error;
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -134,17 +134,10 @@ mod sysrand_chunk {
         let chunk_len: c::size_t = dest.len();
         let r = unsafe { libc::syscall(SYS_GETRANDOM, dest.as_mut_ptr(), chunk_len, 0) };
         if r < 0 {
-            let errno;
-
             #[cfg(target_os = "linux")]
-            {
-                errno = unsafe { *libc::__errno_location() };
-            }
-
+            let errno = unsafe { *libc::__errno_location() };
             #[cfg(target_os = "android")]
-            {
-                errno = unsafe { *libc::__errno() };
-            }
+            let errno = unsafe { *libc::__errno() };
 
             if errno == libc::EINTR {
                 // If an interrupt occurs while getrandom() is blocking to wait


### PR DESCRIPTION
Addresses #852 

Given [current Android device support](https://developer.android.com/about/dashboards) it is unreasonable to expect full support for the `getrandom(2)` syscall.

This PR also adds some minor style fixes for `errno` handling.