### PR TITLE
Reduce the size of `hmac::Key` and `hmac::Context`

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -148,6 +148,14 @@ impl Context {
         }
     }
 
+    pub(crate) fn clone_from(block: &BlockContext) -> Self {
+        Self {
+            block: block.clone(),
+            pending: [0u8; MAX_BLOCK_LEN],
+            num_pending: 0,
+        }
+    }
+
     /// Updates the digest with all the data in `data`. `update` may be called
     /// zero or more times until `finish` is called. It must not be called
     /// after `finish` has been called.


### PR DESCRIPTION
Shrink the size of `hmac::Key` by 256 bytes. Shrink the size of `hmac::Context` by 128 bytes.

In theory it would be possible to eliminate two 'completed_data_blocks: u64' and one `pub algorithm: &'static Algorithm` from each `Key`, and one `completed_data_blocks: u64` and one `pub algorithm: &'static Algorithm` from each `Context` but I don't think those are large enough wins to bother right now.