### PR TITLE
Make `std` a non-default feature.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,15 +75,7 @@ benchmarks are only useful for people hacking on the implementation of *ring*.
 The `slow_tests` feature runs additional tests that are too slow to run during
 a normal edit-compile-test cycle.
 
-The `test_logging` feature prints out additional logging information during
-tests, in particular the contents of the test input files, as tests execute.
-When a test fails, the most recently-logged stuff indicates which test vectors
-failed. This isn't enabled by default because it uses too much memory on small
-targets, due to the way that Rust buffers the output until (unless) the test
-fails. For small (embedded) targets, use
-`cargo test --release --no-run --features=test_logging` to build the tests, and
-then run the tests on the target with `<executable-name> --nocapture' to see
-the log.
+The `test_logging` feature prints out the input test vectors when a test fails.
 
 
 [#321]: https://github.com/briansmith/ring/pull/321

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,13 +325,13 @@ cc = { version = "1.0.37", default-features = false }
 
 [features]
 # These features are documented in the top-level module's documentation.
-default = ["alloc", "dev_urandom_fallback", "std"]
+default = ["alloc", "dev_urandom_fallback"]
 alloc = []
-dev_urandom_fallback = ["std", "lazy_static"]
+dev_urandom_fallback = ["lazy_static"]
 internal_benches = []
 slow_tests = []
 std = ["alloc"]
-test_logging = ["std"]
+test_logging = []
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,9 @@
 
 use untrusted;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 /// An error with absolutely no details.
 ///
 /// *ring* uses this unit type as the error type in most of its results

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!         <code>dev_urandom_fallback</code> feature is disabled, such
 //!         fallbacks will not occur. See the documentation for
 //!         <code>rand::SystemRandom</code> for more details.
-//! <tr><td><code>std (default)</code>
+//! <tr><td><code>std</code>
 //!     <td>Enable features that use libstd, in particular `std::error::Error`
 //!         integration.
 //! </table>
@@ -67,9 +67,6 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
-
-#[cfg(feature = "std")]
-extern crate std;
 
 #[macro_use]
 mod debug;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -361,6 +361,8 @@ mod urandom {
 
     #[cfg_attr(any(target_os = "android", target_os = "linux"), cold, inline(never))]
     pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
+        extern crate std;
+
         use lazy_static::lazy_static;
 
         lazy_static! {

--- a/src/test.rs
+++ b/src/test.rs
@@ -123,8 +123,8 @@ use alloc::{format, string::String, vec::Vec};
 #[cfg(feature = "alloc")]
 use crate::{bits, digest, error};
 
-#[cfg(feature = "std")]
-use std::println;
+#[cfg(any(feature = "std", feature = "test_logging"))]
+extern crate std;
 
 /// `compile_time_assert_clone::<T>();` fails to compile if `T` doesn't
 /// implement `Clone`.
@@ -325,16 +325,8 @@ where
     let mut failed = false;
 
     while let Some(mut test_case) = parse_test_case(&mut current_section, lines) {
-        #[cfg(feature = "std")]
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            f(&current_section, &mut test_case)
-        }));
-
-        #[cfg(not(feature = "std"))]
-        let result: Result<_, error::Unspecified> = Ok(f(&current_section, &mut test_case));
-
-        let result = match result {
-            Ok(Ok(())) => {
+        let result = match f(&current_section, &mut test_case) {
+            Ok(()) => {
                 if !test_case
                     .attributes
                     .iter()
@@ -345,23 +337,22 @@ where
                     failed = true;
                     Err("Test didn't consume all attributes.")
                 }
-            }
-            Ok(Err(_)) => Err("Test returned Err(error::Unspecified)."),
-            Err(_) => Err("Test panicked."),
+            },
+            Err(error::Unspecified) => Err("Test returned Err(error::Unspecified).")
         };
 
         if result.is_err() {
             failed = true;
         }
 
-        #[cfg(feature = "std")]
+        #[cfg(feature = "test_logging")]
         {
             if let Err(msg) = result {
-                println!("{}: {}", test_file.file_name, msg);
+                std::println!("{}: {}", test_file.file_name, msg);
 
                 for (name, value, consumed) in test_case.attributes {
                     let consumed_str = if consumed { "" } else { " (unconsumed)" };
-                    println!("{}{} = {}", name, consumed_str, value);
+                    std::println!("{}{} = {}", name, consumed_str, value);
                 }
             };
         }
@@ -418,7 +409,7 @@ fn parse_test_case(
         #[cfg(feature = "test_logging")]
         {
             if let Some(text) = &line {
-                println!("Line: {}", text);
+                std::println!("Line: {}", text);
             }
         }
 
@@ -574,12 +565,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "std", should_panic(expected = "Test failed."))]
-    #[cfg_attr(not(feature = "std"), should_panic)]
+    #[should_panic(expected = "Oh noes!")]
     fn one_panics() {
         test::run(test_file!("test_1_tests.txt"), |_, test_case| {
             let _ = test_case.consume_string("Key");
-            panic!("");
+            panic!("Oh noes!");
         });
     }
 
@@ -616,22 +606,19 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "std", should_panic(expected = "Test failed."))]
-    #[cfg_attr(not(feature = "std"), should_panic)]
+    #[should_panic(expected = "Oh Noes!")]
     fn first_panic() {
         panic_one(0)
     }
 
     #[test]
-    #[cfg_attr(feature = "std", should_panic(expected = "Test failed."))]
-    #[cfg_attr(not(feature = "std"), should_panic)]
+    #[should_panic(expected = "Oh Noes!")]
     fn middle_panic() {
         panic_one(1)
     }
 
     #[test]
-    #[cfg_attr(feature = "std", should_panic(expected = "Test failed."))]
-    #[cfg_attr(not(feature = "std"), should_panic)]
+    #[should_panic(expected = "Oh Noes!")]
     fn last_panic() {
         panic_one(2)
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -155,7 +155,7 @@ pub fn compile_time_assert_std_error_error<T: std::error::Error>() {}
 /// attribute in the test case must be consumed exactly once; this helps catch
 /// typos and omissions.
 ///
-/// Requires the `std` default feature to be enabled.
+/// Requires the `alloc` default feature to be enabled.
 #[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub struct TestCase {
@@ -313,7 +313,7 @@ pub struct File<'a> {
 /// `f` fails or until all the test vectors have been read. `f` can indicate
 /// failure either by returning `Err()` or by panicking.
 ///
-/// Requires the `std` default feature to be enabled
+/// Requires the `alloc` default feature to be enabled
 #[cfg(feature = "alloc")]
 pub fn run<F>(test_file: File, mut f: F)
 where


### PR DESCRIPTION
Dont enable `std`-based functionality unless requested. This requires removing
the `std` feature dependency from `dev_urandom_fallback` and `test_logging`.
Tweak the meaning of `test_logging` to keep this tractable.