### PR TITLE
Clone for aead::UnboundKey, aes::Key, gcm::Key, chacha::Key.

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -401,6 +401,7 @@ impl core::fmt::Debug for UnboundKey {
 }
 
 #[allow(variant_size_differences)]
+#[derive(Clone)]
 enum KeyInner {
     AesGcm(aes_gcm::Key),
     ChaCha20Poly1305(chacha20_poly1305::Key),

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -385,6 +385,7 @@ impl Aad<[u8; 0]> {
 }
 
 /// An AEAD key without a designated role or nonce sequence.
+#[derive(Clone)]
 pub struct UnboundKey {
     inner: KeyInner,
     algorithm: &'static Algorithm,

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -22,6 +22,7 @@ use super::shift;
 
 use crate::{bits::BitLength, c, cpu, endian::*, error, polyfill};
 
+#[derive(Clone)]
 pub(crate) struct Key {
     inner: AES_KEY,
     cpu_features: cpu::Features,
@@ -262,6 +263,7 @@ impl Key {
 
 // Keep this in sync with AES_KEY in aes.h.
 #[repr(C)]
+#[derive(Clone)]
 pub(super) struct AES_KEY {
     pub rd_key: [u32; 4 * (MAX_ROUNDS + 1)],
     pub rounds: c::uint,

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -38,6 +38,7 @@ pub static AES_256_GCM: aead::Algorithm = aead::Algorithm {
     max_input_len: AES_GCM_MAX_INPUT_LEN,
 };
 
+#[derive(Clone)]
 pub struct Key {
     gcm_key: gcm::Key, // First because it has a large alignment requirement.
     aes_key: aes::Key,

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::{c, endian::*, polyfill::convert::*};
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct Key([Block; KEY_BLOCKS]);
 
 impl Key {

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -16,6 +16,7 @@ use super::{Aad, Block, BLOCK_LEN};
 use crate::{c, cpu};
 
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct Key(GCM128_KEY);
 
 impl Key {

--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -421,6 +421,12 @@ fn test_aead_key_debug() {
     );
 }
 
+#[test]
+fn test_unbound_key_clone() {
+    test::compile_time_assert_clone::<aead::UnboundKey>();
+    test::compile_time_assert_send::<aead::UnboundKey>();
+}
+
 fn make_key<K: aead::BoundKey<OneNonceSequence>>(
     algorithm: &'static aead::Algorithm,
     key: &[u8],


### PR DESCRIPTION
Hello!

There have been times where I've wanted to clone these but not been able to (especially upgrading legacy code to newer versions of ring).

If allowing clones sounds okay with you, I'll add the relevant tests!