### PR TITLE
Introduce EcdsaKeyPair::from_private_key_unchecked.

### DIFF
--- a/tests/ecdsa_from_private_key_unchecked_tests.txt
+++ b/tests/ecdsa_from_private_key_unchecked_tests.txt
@@ -1,0 +1,33 @@
+# Correctly encoded P-256 private key
+Curve = P-256
+PrivateKey = 708309a7449e156b0db70e5b52e606c7e094ed676ce8953bf6c14757c826f590
+PublicKey = 0429578c7ab6ce0d11493c95d5ea05d299d536801ca9cbd50e9924e43b733b83ab08c8049879c6278b2273348474158515accaa38344106ef96803c5a05adc4800
+
+# Short P-256 private key.
+Curve = P-256
+PrivateKey = 708309a7449e156b0db70e5b52e606c7e094ed676ce8953bf6c14757c826f5
+PublicKey = 00
+Error = InvalidEncoding
+
+# P-384 private key loaded as P-256 key.
+Curve = P-256
+PrivateKey = 218ee54a71ef2ccf012aca231fee28a2c665fc395ff5cd20bde9b8df598c282664abf9159c5b3923132983f945056d93
+PublicKey = 00
+Error = InvalidEncoding
+
+# Correctly encoded P-384 private key
+Curve = P-384
+PrivateKey = 218ee54a71ef2ccf012aca231fee28a2c665fc395ff5cd20bde9b8df598c282664abf9159c5b3923132983f945056d93
+PublicKey = 0401989ff07a7a452d8084937448be946bfedac4049cea34b3db6f7c91d07d69e926cce0af3d6e88855a28120cf3dba8dfeb064e029d7539d4b301aabafe8de8870162deffe6383bc63cc005add6ee1d5ced4a5761219c60cd58ad5b2a7c74aaa9
+
+# Short P-384 key.
+Curve = P-384
+PrivateKey = 218ee5
+PublicKey = 00
+Error = InvalidEncoding
+
+# P-256 key loaded as P-384 key
+Curve = P-384
+PrivateKey = 708309a7449e156b0db70e5b52e606c7e094ed676ce8953bf6c14757c826f590
+PublicKey = 00
+Error = InvalidEncoding

--- a/tests/ecdsa_tests.rs
+++ b/tests/ecdsa_tests.rs
@@ -129,6 +129,65 @@ fn ecdsa_generate_pkcs8_test() {
 }
 
 #[test]
+fn ecdsa_from_private_key_unchecked_test() {
+    test::run(
+        test_file!("ecdsa_from_private_key_unchecked_tests.txt"),
+        |section, test_case| {
+            assert_eq!(section, "");
+
+            let curve_name = test_case.consume_string("Curve");
+            let (this_fixed, this_asn1) = match curve_name.as_str() {
+                "P-256" => (
+                    &signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+                    &signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+                ),
+                "P-384" => (
+                    &signature::ECDSA_P384_SHA384_FIXED_SIGNING,
+                    &signature::ECDSA_P384_SHA384_ASN1_SIGNING,
+                ),
+                _ => unreachable!(),
+            };
+
+            let private_key = test_case.consume_bytes("PrivateKey");
+            let public_key = test_case.consume_bytes("PublicKey");
+            let error = test_case.consume_optional_string("Error");
+
+            match (
+                signature::EcdsaKeyPair::from_private_key_unchecked(
+                    this_fixed, &private_key
+                ),
+                error.clone(),
+            ) {
+                (Ok(key_pair), None) => {
+                    assert_eq!(key_pair.public_key().as_ref(), public_key.as_slice());
+                }
+                (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),
+                (Ok(_), Some(e)) => panic!("Succeeded, but expected error \"{}\"", e),
+                (Err(actual), Some(expected)) => assert_eq!(format!("{}", actual), expected),
+            };
+
+            match (
+                signature::EcdsaKeyPair::from_private_key_unchecked(
+                    this_asn1, &private_key
+                ),
+                error.clone(),
+            ) {
+                (Ok(key_pair), None) => {
+                    assert_eq!(key_pair.public_key().as_ref(), public_key.as_slice());
+                }
+                (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),
+                (Ok(_), Some(e)) => panic!("Succeeded, but expected error \"{}\"", e),
+                (Err(actual), Some(expected)) => assert_eq!(format!("{}", actual), expected),
+            };
+
+            Ok(())
+        },
+    );
+}
+                
+
+
+#[test]
 fn signature_ecdsa_verify_asn1_test() {
     test::run(
         test_file!("ecdsa_verify_asn1_tests.txt"),


### PR DESCRIPTION
This PR adds `EcdsaKeyPair::from_private_key_unchecked` which creates an ECDSA key pair from the private key only.

Note: The two private keys in the test case are random specimen from the NIST CAVP 186-4 ECDSA2VS Test Vectors. I think testing for short, long, and correctly sized keys should about cover it?

If merged, fixes #882.