### PR TITLE
Add AArch64 feature detection for FreeBSD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,6 +65,7 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[], "third_party/fiat/curve25519.c"),
 
     (&[X86_64, X86], "crypto/cpu-intel.c"),
+    (&[AARCH64], "crypto/cpu-aarch64.c"),
 
     (&[X86], "crypto/fipsmodule/aes/asm/aes-586.pl"),
     (&[X86], "crypto/fipsmodule/aes/asm/aesni-x86.pl"),

--- a/crypto/cpu-aarch64.c
+++ b/crypto/cpu-aarch64.c
@@ -1,0 +1,32 @@
+// Copyright 2019 Greg V
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+// Run-time feature detection for aarch64 on any OS that emulates the mrs instruction.
+//
+// On FreeBSD >= 12.0, Linux >= 4.11 and other operating systems, it is possible to use
+// privileged system registers from userspace to check CPU feature support.
+//
+// For proper support of SoCs where different cores have different capabilities
+// the OS has to always report only the features supported by all cores, like FreeBSD does.
+//
+// Only FreeBSD uses this right now.
+
+#include <stdint.h>
+
+uint64_t GFp_aarch64_read_isar0(void) {
+  uint64_t val;
+  __asm __volatile("mrs %0, ID_AA64ISAR0_EL1" : "=&r" (val));
+  return val;
+}

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -170,10 +170,10 @@ pub(crate) mod arm {
 
     pub(crate) struct Feature {
         #[cfg_attr(
-            any(
-                target_os = "ios",
-                not(any(target_arch = "arm", target_arch = "aarch64"))
-            ),
+            not(all(
+                any(target_os = "android", target_os = "linux", target_os = "fuchsia"),
+                any(target_arch = "arm", target_arch = "aarch64")
+            )),
             allow(dead_code)
         )]
         mask: u32,
@@ -198,7 +198,10 @@ pub(crate) mod arm {
                 return self.mask == self.mask & unsafe { GFp_armcap_P };
             }
 
-            #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+            #[cfg(not(all(
+                any(target_os = "android", target_os = "ios", target_os = "linux", target_os = "fuchsia"),
+                any(target_arch = "arm", target_arch = "aarch64")
+            )))]
             {
                 return false;
             }
@@ -206,7 +209,10 @@ pub(crate) mod arm {
     }
 
     // Keep in sync with `ARMV7_NEON`.
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    #[cfg(all(
+        any(target_os = "android", target_os = "ios", target_os = "linux", target_os = "fuchsia"),
+        any(target_arch = "arm", target_arch = "aarch64")
+    ))]
     pub(crate) const NEON: Feature = Feature {
         mask: 1 << 0,
         ios: true,


### PR DESCRIPTION
and fix build on any ARM platform that's not Linux/Fuchsia.

I hope I didn't screw up any platforms.. :D

The `all(target_os = "freebsd", target_arch = "aarch64")` inside of an `all(…, any(target_arch = "arm", target_arch = "aarch64"))` is to exclude FreeBSD/arm 32-bit.

cc #387

```
# before
test digest::sha256::_8192                                    ... bench:      47,207 ns/iter (+/- 228) = 173 MB/s
test aead::seal_in_place::aes_128_gcm::tls12_16               ... bench:  12,084,200 ns/iter (+/- 15,248,988)

# after
test digest::sha256::_8192                                    ... bench:       8,350 ns/iter (+/- 142) = 981 MB/s
test aead::seal_in_place::aes_128_gcm::tls12_16               ... bench:     722,151 ns/iter (+/- 917,484)
```