### PR TITLE
Add support for Redox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,7 +310,7 @@ spin = { version = "0.5.2", default-features = false }
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.48", default-features = false }
 
-[target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "redox", target_os = "freebsd", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
 lazy_static = { version = "1.3", default-features = false, optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -183,7 +183,8 @@ use self::sysrand_or_urandom::fill as fill_impl;
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
-    target_os = "solaris"
+    target_os = "solaris",
+    target_os = "redox"
 ))]
 use self::urandom::fill as fill_impl;
 
@@ -357,7 +358,8 @@ mod sysrand_or_urandom {
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
-    target_os = "solaris"
+    target_os = "solaris",
+    target_os = "redox"
 ))]
 mod urandom {
     use crate::error;
@@ -368,9 +370,14 @@ mod urandom {
 
         use lazy_static::lazy_static;
 
+        #[cfg(not(target_os = "redox"))]
+        const RAND_LOCATION: &str = "/dev/urandom";
+        #[cfg(target_os = "redox")]
+        const RAND_LOCATION: &str = "rand:";
+
         lazy_static! {
             static ref FILE: Result<std::fs::File, std::io::Error> =
-                std::fs::File::open("/dev/urandom");
+                std::fs::File::open(RAND_LOCATION);
         }
 
         match *FILE {


### PR DESCRIPTION
Add redox to the urandom for src/rand.rs. Use the `rand:` URI on Redox rather than `/dev/urandom`.

cc @jackpot51 