### PR TITLE
Fix iOS builds for 32bit arm targets (armv7/armv7s)

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -206,6 +206,7 @@ pub(crate) mod arm {
     }
 
     // Keep in sync with `ARMV7_NEON`.
+    #[cfg_attr(not(target_arch = "arm"), allow(dead_code))]
     #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
     pub(crate) const NEON: Feature = Feature {
         mask: 1 << 0,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -178,7 +178,10 @@ pub(crate) mod arm {
         )]
         mask: u32,
 
-        #[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+        #[cfg_attr(
+            not(all(target_os = "ios", any(target_arch = "arm", target_arch = "aarch64"))),
+            allow(dead_code)
+        )]
         ios: bool,
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -219,13 +219,19 @@ pub(crate) mod arm {
     // Keep in sync with `ARMV8_AES`.
     pub(crate) const AES: Feature = Feature {
         mask: 1 << 2,
+        #[cfg(target_arch = "aarch64")]
         ios: true,
+        #[cfg(not(target_arch = "aarch64"))]
+        ios: false,
     };
 
     // Keep in sync with `ARMV8_PMULL`.
     pub(crate) const PMULL: Feature = Feature {
         mask: 1 << 5,
+        #[cfg(target_arch = "aarch64")]
         ios: true,
+        #[cfg(not(target_arch = "aarch64"))]
+        ios: false,
     };
 
     #[cfg(all(

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -59,6 +59,7 @@ fn x25519_public_from_private(
 ) -> Result<(), error::Unspecified> {
     let public_out = public_out.try_into()?;
 
+    #[cfg_attr(target_os = "ios", allow(unused_variables))]
     #[cfg(target_arch = "arm")]
     let cpu_features = private_key.cpu_features;
 


### PR DESCRIPTION
This PR does the following:
* Fixes the `AES` and `PMULL` CPU feature configuration for 32-bit iOS arm targets (namely, armv7 and armv7s).
* Fixes 3 "unused" errors when compiling for `ios` targets

The `AES` and `PMULL` CPU features are only supported on Armv8 (target_arch `aarch64`) and above. These features should be declared as not supported for Armv7 and Armv7s (target_arch `arm`). This is self-documented by the preceeding comment which references `ARMV8_AES` and `ARMV8_PMULL`, respectively.