### PR TITLE
Feature gate web-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ libc = { version = "0.2.48", default-features = false }
 lazy_static = { version = "1.3", default-features = false, optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
-web-sys = { version = "0.3.25", default-features = false, features = ["Crypto", "Window"] }
+web-sys = { version = "0.3.25", default-features = false, features = ["Crypto", "Window"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", default-features = false, features = ["ntsecapi", "wtypesbase"] }
@@ -338,6 +338,7 @@ internal_benches = []
 slow_tests = []
 std = ["alloc"]
 test_logging = []
+wasm = ["web-sys"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/build.rs
+++ b/build.rs
@@ -636,11 +636,13 @@ where
 
 fn run_command(mut cmd: Command) {
     println!("running {:?}", cmd);
-    let status = cmd.status().unwrap_or_else(|e| {
+    let output = cmd.output().unwrap_or_else(|e| {
         panic!("failed to execute [{:?}]: {}", cmd, e);
     });
-    if !status.success() {
-        panic!("execution failed");
+    if !output.status.success() {
+        println!("{}", std::str::from_utf8(&output.stdout).unwrap());
+        eprintln!("{}", std::str::from_utf8(&output.stderr).unwrap());
+        panic!("execution failed: {}", output.status.code().unwrap());
     }
 }
 


### PR DESCRIPTION
The `web-sys` crate brings in a ton of extra dependencies unconditionally, this just feature gates `web-sys` behind the `wasm` feature so that users can opt in to those extra dependencies, if they are even targeting wasm at all.