### PR TITLE
Add {OpeningKey, LessSafeKey}::open_in_place_separate_tag

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -731,7 +731,7 @@ impl Tag {
     /// Fails if `bytes` isn't `TAG_LEN` bytes long.
     pub fn new(bytes: &[u8]) -> Result<Tag, error::Unspecified> {
         use core::convert::TryInto;
-        let bytes: &[u8; BLOCK_LEN] = bytes.try_into().unwrap();
+        let bytes: &[u8; BLOCK_LEN] = bytes.try_into()?;
         Ok(Tag(bytes.into()))
     }
 }


### PR DESCRIPTION
* For API parity with `seal_in_place_separate_tag`.

* And because this allows not-in-place decryption without allocation: the ciphertext can be copied to the output buffer, and the tag can be passed separately.