### PR TITLE
Remove `#[inline]` attributes on function prototypes

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -57,7 +57,6 @@ pub trait BoundKey<N: NonceSequence>: core::fmt::Debug {
     fn new(key: UnboundKey, nonce_sequence: N) -> Self;
 
     /// The key's AEAD algorithm.
-    #[inline]
     fn algorithm(&self) -> &'static Algorithm;
 }
 

--- a/src/digest/sha2.rs
+++ b/src/digest/sha2.rs
@@ -159,10 +159,8 @@ pub(super) trait Word:
 
     type InputBytes: Copy;
 
-    #[inline(always)]
     fn from_be_bytes(input: Self::InputBytes) -> Self;
 
-    #[inline]
     fn rotr(self, count: u32) -> Self;
 }
 
@@ -275,6 +273,7 @@ impl Word for Wrapping<u64> {
     const ZERO: Self = Wrapping(0);
     type InputBytes = [u8; 8];
 
+    #[inline(always)]
     fn from_be_bytes(input: Self::InputBytes) -> Self {
         Wrapping(u64::from_be_bytes(input))
     }


### PR DESCRIPTION
These attributes now lead to a compile error on nightly. See [this Rust PR](https://github.com/rust-lang/rust/pull/65294) for more information.