### PR TITLE
SystemRandom: Fix #326 - Prefer getrandom(2) on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,7 +307,7 @@ untrusted = { version = "0.7.0" }
 spin = { version = "0.5.2", default-features = false }
 
 
-[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.48", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,11 @@
 //! <tr><td><code>alloc (default)</code>
 //!     <td>Enable features that require use of the heap, RSA in particular.
 //! <tr><td><code>dev_urandom_fallback (default)</code>
-//!     <td>This is only applicable to Linux. On Linux, by default,
-//!         <code>ring::rand::SystemRandom</code> will fall back to reading
-//!         from <code>/dev/urandom</code> if the <code>getrandom()</code>
-//!         syscall isn't supported at runtime. When the
-//!         <code>dev_urandom_fallback</code> feature is disabled, such
+//!     <td>This is only applicable to Linux and FreeBSD. On these platforms,
+//!         by default, <code>ring::rand::SystemRandom</code> will fall back
+//!         to reading from <code>/dev/urandom</code> if the
+//!         <code>getrandom()</code> syscall isn't supported at runtime. When
+//!         the <code>dev_urandom_fallback</code> feature is disabled, such
 //!         fallbacks will not occur. See the documentation for
 //!         <code>rand::SystemRandom</code> for more details.
 //! <tr><td><code>std</code>


### PR DESCRIPTION
FreeBSD added the Linux-compatible getrandom(2) API in 12.0.  Like Linux,
prefer it to the /dev/urandom device, but fallback to the earlier method if
the syscall is not available.