### PR TITLE
Use `#[inline(always)]` consistently in sha2.rs `rotr` functions.

### DIFF
--- a/src/digest/sha2.rs
+++ b/src/digest/sha2.rs
@@ -278,7 +278,7 @@ impl Word for Wrapping<u64> {
         Wrapping(u64::from_be_bytes(input))
     }
 
-    #[inline]
+    #[inline(always)]
     fn rotr(self, count: u32) -> Self {
         Wrapping(self.0.rotate_right(count))
     }


### PR DESCRIPTION
It is important that the SHA-2 implementation is inlined all the time
because performance on debug builds is way too bad if it isn't, and that
bad performance badly hurts testing.