### PR TITLE
Switch `dev_urandom_fallback` to use `once_cell` instead of `lazy_static!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ spin = { version = "0.5.2", default-features = false }
 libc = { version = "0.2.48", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
-lazy_static = { version = "1.3", default-features = false, optional = true }
+once_cell = { version = "1.3.1", default-features = false, features=["std"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
 web-sys = { version = "0.3.25", default-features = false, features = ["Crypto", "Window"] }
@@ -333,7 +333,7 @@ cc = { version = "1.0.37", default-features = false }
 # These features are documented in the top-level module's documentation.
 default = ["alloc", "dev_urandom_fallback"]
 alloc = []
-dev_urandom_fallback = ["lazy_static"]
+dev_urandom_fallback = ["once_cell"]
 internal_benches = []
 slow_tests = []
 std = ["alloc"]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -329,18 +329,15 @@ mod sysrand_or_urandom {
 
     #[inline]
     pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-        use lazy_static::lazy_static;
-
-        lazy_static! {
-            static ref MECHANISM: Mechanism = {
-                let mut dummy = [0u8; 1];
-                if super::sysrand_chunk::chunk(&mut dummy[..]).is_err() {
-                    Mechanism::DevURandom
-                } else {
-                    Mechanism::Sysrand
-                }
-            };
-        }
+        use once_cell::sync::Lazy;
+        static MECHANISM: Lazy<Mechanism> = Lazy::new(|| {
+            let mut dummy = [0u8; 1];
+            if super::sysrand_chunk::chunk(&mut dummy[..]).is_err() {
+                Mechanism::DevURandom
+            } else {
+                Mechanism::Sysrand
+            }
+        });
 
         match *MECHANISM {
             Mechanism::Sysrand => super::sysrand::fill(dest),
@@ -366,12 +363,10 @@ mod urandom {
     pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
         extern crate std;
 
-        use lazy_static::lazy_static;
+        use once_cell::sync::Lazy;
 
-        lazy_static! {
-            static ref FILE: Result<std::fs::File, std::io::Error> =
-                std::fs::File::open("/dev/urandom");
-        }
+        static FILE: Lazy<Result<std::fs::File, std::io::Error>> =
+            Lazy::new(|| std::fs::File::open("/dev/urandom"));
 
         match *FILE {
             Ok(ref file) => {


### PR DESCRIPTION
This is a step towards removing the spin-rs dependency. `lazy_static!`'s
conditial use of spin-rs based on a feature flag was particularly problematic
because often other dependencies would enable that feature flag even in cases
where the `std::sync::Once` implementation was preferable.