### PR TITLE
Add musl targets to CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,28 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=musl-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=stable
+      rust: stable
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - musl
+            - musl-dev
+            - musl-tools
+
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=musl-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=stable
+      rust: stable
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - musl
+            - musl-dev
+            - musl-tools
+
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=stable
       rust: stable
       os: linux
@@ -330,6 +352,28 @@ matrix:
             - gcc-7
           sources:
             - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=musl-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=nightly
+      rust: nightly
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - musl
+            - musl-dev
+            - musl-tools
+
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=musl-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=nightly
+      rust: nightly
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - musl
+            - musl-dev
+            - musl-tools
 
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=nightly
       rust: nightly
@@ -555,6 +599,28 @@ matrix:
             - gcc-7
           sources:
             - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=musl-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=beta
+      rust: beta
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - musl
+            - musl-dev
+            - musl-tools
+
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=musl-gcc FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=beta
+      rust: beta
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - musl
+            - musl-dev
+            - musl-tools
 
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=beta
       rust: beta

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -69,6 +69,12 @@ if [[ ! "$TARGET_X" =~ "x86_64-" ]]; then
   fi
 fi
 
+# This stanza is separate from the above because MUSL requires a target install,
+# but does *not* require special linking / multilib.
+if [[ "$TARGET_X" =~ "x86_64-unknown-linux-musl" ]]; then
+  rustup target add "$TARGET_X"
+fi
+
 if [[ ! -z "${CC_X-}" ]]; then
   export CC=$CC_X
   $CC --version

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -1,4 +1,4 @@
-﻿# Run this as "python mk/update-travis-yml.py"
+﻿# Run this as "python2 mk/update-travis-yml.py"
 
 # Copyright 2015 Brian Smith.
 #
@@ -48,6 +48,7 @@ compilers = {
     "arm-unknown-linux-gnueabihf" : [ "arm-linux-gnueabihf-gcc" ],
     "i686-unknown-linux-gnu" : linux_compilers,
     "x86_64-unknown-linux-gnu" : linux_compilers,
+    "x86_64-unknown-linux-musl" : [ "musl-gcc" ], # TODO: musl-clang
     "x86_64-apple-darwin" : osx_compilers,
 }
 
@@ -75,6 +76,7 @@ targets = {
         "aarch64-linux-android",
         "armv7-linux-androideabi",
         "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-gnu",
         "i686-unknown-linux-gnu",
         "arm-unknown-linux-gnueabihf",
@@ -211,6 +213,10 @@ def get_linux_packages_to_install(target, compiler, arch, kcov):
     if target == "arm-unknown-linux-gnueabihf":
         packages += ["gcc-arm-linux-gnueabihf",
                      "libc6-dev-armhf-cross"]
+    if target == "x86_64-unknown-linux-musl":
+        packages += ["musl", "musl-dev"]
+        if compiler == "musl-gcc":
+            packages += ["musl-tools"]
 
     if arch == "i686":
         if kcov == True:


### PR DESCRIPTION
I've added musl-gcc here, and not musl-clang, because I can't figure out
what the package name for musl-clang is on Ubuntu.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.