### PR TITLE
Speed up SHA1 computation

### DIFF
--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -59,40 +59,49 @@ fn block_data_order_(mut H: State, M: &[[<W32 as Word>::InputBytes; 16]]) -> Sta
         }
 
         // FIPS 180-4 6.1.2 Step 2
-        let mut a = H[0];
-        let mut b = H[1];
-        let mut c = H[2];
-        let mut d = H[3];
-        let mut e = H[4];
+        let a = H[0];
+        let b = H[1];
+        let c = H[2];
+        let d = H[3];
+        let e = H[4];
 
-        // FIPS 180-4 6.1.2 Step 3
-        for t in 0..ROUNDS {
-            // FIPS 180-4 {4.1.1, 4.2.1}
-            let (k, f) = match t {
-                0..=19 => (Wrapping(0x5a827999), ch(b, c, d)),
-                20..=39 => (Wrapping(0x6ed9eba1), parity(b, c, d)),
-                40..=59 => (Wrapping(0x8f1bbcdc), maj(b, c, d)),
-                60..=79 => (Wrapping(0xca62c1d6), parity(b, c, d)),
-                _ => unreachable!(),
-            };
-
-            let T = rotl(a, 5) + f + e + k + W[t];
-            e = d;
-            d = c;
-            c = rotl(b, 30);
-            b = a;
-            a = T;
-        }
+        // FIPS 180-4 6.1.2 Step 3 with constants and functions from FIPS 180-4 {4.1.1, 4.2.1}
+        let (a, b, c, d, e) = step3(a, b, c, d, e, W[ 0..20].try_into().unwrap(), Wrapping(0x5a827999), ch);
+        let (a, b, c, d, e) = step3(a, b, c, d, e, W[20..40].try_into().unwrap(), Wrapping(0x6ed9eba1), parity);
+        let (a, b, c, d, e) = step3(a, b, c, d, e, W[40..60].try_into().unwrap(), Wrapping(0x8f1bbcdc), maj);
+        let (a, b, c, d, e) = step3(a, b, c, d, e, W[60..80].try_into().unwrap(), Wrapping(0xca62c1d6), parity);
 
         // FIPS 180-4 6.1.2 Step 4
+        H[0] += a;
         H[1] += b;
         H[2] += c;
         H[3] += d;
-        H[0] += a;
         H[4] += e;
     }
 
     H
+}
+
+#[inline(always)]
+fn step3(
+    mut a: W32,
+    mut b: W32,
+    mut c: W32,
+    mut d: W32,
+    mut e: W32,
+    W: [W32; 20],
+    k: W32,
+    f: impl Fn(W32, W32, W32) -> W32
+) -> (W32, W32, W32, W32, W32) {
+    for W_t in W.iter() {
+        let T = rotl(a, 5) + f(b, c, d) + e + k + W_t;
+        e = d;
+        d = c;
+        c = rotl(b, 30);
+        b = a;
+        a = T;
+    }
+    (a, b, c, d, e)
 }
 
 #[inline(always)]


### PR DESCRIPTION
The first commit is just a minor style fix that doesn't really warrant it's own PR.

The second commit speeds up SHA1 computation by ~50-60%. See the commit message for details. Unfortunately it does make the code a bit uglier than I initially expected because Rust doesn't support [destructuring assignments](https://github.com/rust-lang/rfcs/issues/372) (yet?). Still, even for an implementation like ring's, that favors simplicity over speed, the trade-off  is worth it in my opinion.

There's an alternative with much nicer code and the same speedup in [this branch](https://github.com/LingMan/ring/commits/sha1-speedup-crunchy). However, that turned out to increase the binary size by almost 390 KiB. Since ring is targeting small devices, that seamed unacceptable. Therefore I'm PRing this solution instead.

Before:
test digest::sha1::_1000     ... bench:       4,471 ns/iter (+/- 39) = 223 MB/s
test digest::sha1::_16       ... bench:         315 ns/iter (+/- 2) = 50 MB/s
test digest::sha1::_2000     ... bench:       8,903 ns/iter (+/- 208) = 224 MB/s
test digest::sha1::_256      ... bench:       1,452 ns/iter (+/- 14) = 176 MB/s
test digest::sha1::_8192     ... bench:      35,563 ns/iter (+/- 348) = 230 MB/s
test digest::sha1::block_len ... bench:         622 ns/iter (+/- 16) = 102 MB/s

After:
test digest::sha1::_1000     ... bench:       2,801 ns/iter (+/- 22) = 357 MB/s
test digest::sha1::_16       ... bench:         215 ns/iter (+/- 20) = 74 MB/s
test digest::sha1::_2000     ... bench:       5,556 ns/iter (+/- 86) = 359 MB/s
test digest::sha1::_256      ... bench:         922 ns/iter (+/- 35) = 277 MB/s
test digest::sha1::_8192     ... bench:      22,141 ns/iter (+/- 270) = 369 MB/s
test digest::sha1::block_len ... bench:         403 ns/iter (+/- 10) = 158 MB/s