### PR TITLE
AES-GCM & RSA: Work around "Illegal instruction" in 32-bit ARM Android emulator.

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -23,7 +23,7 @@
 
 use self::block::{Block, BLOCK_LEN};
 use crate::{constant_time, cpu, error, hkdf, polyfill};
-use core::{convert::TryInto, ops::RangeFrom};
+use core::ops::RangeFrom;
 
 pub use self::{
     aes_gcm::{AES_128_GCM, AES_256_GCM},
@@ -684,12 +684,12 @@ unsafe fn aliasing_pointers(
     in_prefix_len: usize,
 ) -> (*const u8, *mut u8, usize) {
     // Compute `in_out.len()` before calling `in_out.as_mut_ptr()`.
-    let in_out_len = in_out.len().checked_sub(in_prefix_len).unwrap();
+    let in_out_len = in_out.len() - in_prefix_len; // TODO: Use `checked_sub`
 
     let output: *mut u8 = in_out.as_mut_ptr();
 
     // Construct the `const` pointer from the `mut` pointer.
-    let input: *const u8 = output.offset(in_prefix_len.try_into().unwrap());
+    let input: *const u8 = output.offset(in_prefix_len as isize); // TODO: use `try_into()`.
 
     (input, output, in_out_len)
 }

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -161,13 +161,10 @@ impl Key {
         direction: Direction,
         ctr: &mut Counter,
     ) {
-        let output: *mut u8 = in_out.as_mut_ptr();
         let in_prefix_len = match direction {
             Direction::Opening { in_prefix_len } => in_prefix_len,
             Direction::Sealing => 0,
         };
-        let input: *const u8 = in_out[in_prefix_len..].as_ptr();
-
         let in_out_len = in_out.len().checked_sub(in_prefix_len).unwrap();
 
         assert_eq!(in_out_len % BLOCK_LEN, 0);
@@ -187,6 +184,7 @@ impl Key {
                     );
                 }
                 unsafe {
+                    let (input, output, _) = super::aliasing_pointers(in_out, in_prefix_len);
                     GFp_aes_hw_ctr32_encrypt_blocks(input, output, blocks, &self.inner, ctr);
                 }
                 ctr.increment_by_less_safe(blocks_u32);
@@ -204,6 +202,7 @@ impl Key {
                     );
                 }
                 unsafe {
+                    let (input, output, _) = super::aliasing_pointers(in_out, in_prefix_len);
                     GFp_vpaes_ctr32_encrypt_blocks(input, output, blocks, &self.inner, ctr);
                 }
                 ctr.increment_by_less_safe(blocks_u32);
@@ -221,6 +220,7 @@ impl Key {
                     );
                 }
                 unsafe {
+                    let (input, output, _) = super::aliasing_pointers(in_out, in_prefix_len);
                     GFp_bsaes_ctr32_encrypt_blocks(input, output, blocks, &self.inner, ctr);
                 }
                 ctr.increment_by_less_safe(blocks_u32);

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -224,10 +224,11 @@ fn integrated_aes_gcm<'a>(
                 ) -> c::size_t;
             }
             unsafe {
+                let (input, output, in_out_len) = super::aliasing_pointers(in_out, in_prefix_len);
                 GFp_aesni_gcm_decrypt(
-                    in_out[in_prefix_len..].as_ptr(),
-                    in_out.as_mut_ptr(),
-                    in_out.len() - in_prefix_len,
+                    input,
+                    output,
+                    in_out_len,
                     aes_key.inner_less_safe(),
                     ctr,
                     gcm_ctx,
@@ -246,10 +247,11 @@ fn integrated_aes_gcm<'a>(
                 ) -> c::size_t;
             }
             unsafe {
+                let (input, output, in_out_len) = super::aliasing_pointers(in_out, 0);
                 GFp_aesni_gcm_encrypt(
-                    in_out.as_ptr(),
-                    in_out.as_mut_ptr(),
-                    in_out.len(),
+                    input,
+                    output,
+                    in_out_len,
                     aes_key.inner_less_safe(),
                     ctr,
                     gcm_ctx,

--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -853,8 +853,9 @@ pub fn elem_exp_consttime<M>(
                 i: Window,
             ) -> bssl::Result;
         }
+        let num_limbs = r.limbs.len();
         Result::from(unsafe {
-            LIMBS_select_512_32(r.limbs.as_mut_ptr(), table.as_ptr(), r.limbs.len(), i)
+            LIMBS_select_512_32(r.limbs.as_mut_ptr(), table.as_ptr(), num_limbs, i)
         })
         .unwrap();
     }


### PR DESCRIPTION
The workaround is to be call `&[u8]::len()` before calling `&[u8]::as_mut_ptr()`.
It isn't clear why this is necessary to get the ARM Android target to do the right
thing. Our current guess is that the pointer returned from `as_mut_ptr()` is being
marked as `noalias` within the compiler, which is causing the compiler to make the
wrong assumptions.