### PR TITLE
Temporarily disable armv7-linux-androideabi on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,28 +45,6 @@ matrix:
         - build-tools-26.0.2
       dist: trusty
 
-    - env: TARGET_X=armv7-linux-androideabi CC_X=armv7a-linux-androideabi18-clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=stable
-      rust: stable
-      os: linux
-      language: android
-      android:
-        components:
-        - android-18
-        - build-tools-26.0.2
-        - sys-img-armeabi-v7a-android-18
-      dist: trusty
-
-    - env: TARGET_X=armv7-linux-androideabi CC_X=armv7a-linux-androideabi18-clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=stable
-      rust: stable
-      os: linux
-      language: android
-      android:
-        components:
-        - android-18
-        - build-tools-26.0.2
-        - sys-img-armeabi-v7a-android-18
-      dist: trusty
-
     - env: TARGET_X=x86_64-unknown-linux-gnu  FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=stable
       rust: stable
       os: linux
@@ -259,28 +237,6 @@ matrix:
         components:
         - android-21
         - build-tools-26.0.2
-      dist: trusty
-
-    - env: TARGET_X=armv7-linux-androideabi CC_X=armv7a-linux-androideabi18-clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=nightly
-      rust: nightly
-      os: linux
-      language: android
-      android:
-        components:
-        - android-18
-        - build-tools-26.0.2
-        - sys-img-armeabi-v7a-android-18
-      dist: trusty
-
-    - env: TARGET_X=armv7-linux-androideabi CC_X=armv7a-linux-androideabi18-clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=nightly
-      rust: nightly
-      os: linux
-      language: android
-      android:
-        components:
-        - android-18
-        - build-tools-26.0.2
-        - sys-img-armeabi-v7a-android-18
       dist: trusty
 
     - env: TARGET_X=x86_64-unknown-linux-gnu  FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=nightly
@@ -490,28 +446,6 @@ matrix:
         components:
         - android-21
         - build-tools-26.0.2
-      dist: trusty
-
-    - env: TARGET_X=armv7-linux-androideabi CC_X=armv7a-linux-androideabi18-clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=beta
-      rust: beta
-      os: linux
-      language: android
-      android:
-        components:
-        - android-18
-        - build-tools-26.0.2
-        - sys-img-armeabi-v7a-android-18
-      dist: trusty
-
-    - env: TARGET_X=armv7-linux-androideabi CC_X=armv7a-linux-androideabi18-clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=beta
-      rust: beta
-      os: linux
-      language: android
-      android:
-        components:
-        - android-18
-        - build-tools-26.0.2
-        - sys-img-armeabi-v7a-android-18
       dist: trusty
 
     - env: TARGET_X=x86_64-unknown-linux-gnu  FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=beta

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -73,7 +73,7 @@ targets = {
     ],
     "linux" : [
         "aarch64-linux-android",
-        "armv7-linux-androideabi",
+        # TODO: Emulator is broken "armv7-linux-androideabi",
         "x86_64-unknown-linux-gnu",
         "aarch64-unknown-linux-gnu",
         "i686-unknown-linux-gnu",


### PR DESCRIPTION
Thigns are failing with an "Illegal instruction" error. I initially thought
it was specific to Rust 1.40 but it is now happening with Rust 1.39 too, so
I'm assuming something changed in the emulator or NDK, since the Android SDK
isn't locked in CI/CD yet.