### PR TITLE
[cargo] Remove no-op 'exclude' field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,6 @@ version = "0.16.12"
 # Prevent multiple versions of *ring* from being linked into the same program.
 links = "ring-asm"
 
-exclude = [
-    # The presence of .gitignore is used to differentiate non-packaged builds
-    # from packaged builds in build.rs.
-    ".gitignore",
-    "pregenerated/tmp",
-]
 include = [
     "LICENSE",
     "Cargo.toml",


### PR DESCRIPTION
From
https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields

"The options are mutually exclusive: setting include will override an
exclude."

I agree to license my contributions to each file under the terms given
at the top of each file I changed.