### PR TITLE
Clarify GCM FFI code

### DIFF
--- a/crypto/fipsmodule/modes/internal.h
+++ b/crypto/fipsmodule/modes/internal.h
@@ -54,17 +54,4 @@
 // GCM definitions
 typedef struct { uint64_t hi,lo; } u128;
 
-#define GCM128_HTABLE_LEN 16
-
-// Keep in sync with GCK_CONTEXT in gcm.rs.
-typedef struct {
-    // Relative position of Xi, H_unused and pre-computed Htable is used in
-    // some assembler modules, i.e. don't change the order!
-    alignas(16) uint8_t Xi[16];
-    struct {
-        uint64_t u[2];
-    } H_unused;
-    alignas(16) u128 Htable[GCM128_HTABLE_LEN];
-} GCM128_CONTEXT;
-
 #endif  // OPENSSL_HEADER_MODES_INTERNAL_H

--- a/crypto/fipsmodule/modes/internal.h
+++ b/crypto/fipsmodule/modes/internal.h
@@ -56,20 +56,15 @@ typedef struct { uint64_t hi,lo; } u128;
 
 #define GCM128_HTABLE_LEN 16
 
-// Keep in sync with GCM128_KEY in aes_gcm.rs.
+// Keep in sync with GCK_CONTEXT in gcm.rs.
 typedef struct {
-    alignas(16) u128 Htable[GCM128_HTABLE_LEN];
-} GCM128_KEY;
-
-// Keep in sync with GCK_CONTEXT in aes_gcm.rs.
-typedef struct {
-    // Relative position of Xi, H and pre-computed Htable is used in some
-    // assembler modules, i.e. don't change the order!
+    // Relative position of Xi, H_unused and pre-computed Htable is used in
+    // some assembler modules, i.e. don't change the order!
     alignas(16) uint8_t Xi[16];
     struct {
         uint64_t u[2];
     } H_unused;
-    GCM128_KEY key;
+    alignas(16) u128 Htable[GCM128_HTABLE_LEN];
 } GCM128_CONTEXT;
 
 #endif  // OPENSSL_HEADER_MODES_INTERNAL_H

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -189,7 +189,7 @@ fn aead(
     gcm_ctx.pre_finish(|pre_tag| {
         let block = tag_iv.into_block_less_safe();
         let mut tag = aes_key.encrypt_block(block);
-        tag.bitxor_assign(pre_tag);
+        tag.bitxor_assign(pre_tag.into());
         Tag(tag)
     })
 }

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -220,7 +220,7 @@ fn integrated_aes_gcm<'a>(
                     len: c::size_t,
                     key: &aes::AES_KEY,
                     ivec: &mut Counter,
-                    gcm: &mut gcm::Context,
+                    gcm: &mut gcm::ContextInner,
                 ) -> c::size_t;
             }
             unsafe {
@@ -230,7 +230,7 @@ fn integrated_aes_gcm<'a>(
                     in_out.len() - in_prefix_len,
                     aes_key.inner_less_safe(),
                     ctr,
-                    gcm_ctx,
+                    gcm_ctx.inner(),
                 )
             }
         }
@@ -242,7 +242,7 @@ fn integrated_aes_gcm<'a>(
                     len: c::size_t,
                     key: &aes::AES_KEY,
                     ivec: &mut Counter,
-                    gcm: &mut gcm::Context,
+                    gcm: &mut gcm::ContextInner,
                 ) -> c::size_t;
             }
             unsafe {
@@ -252,7 +252,7 @@ fn integrated_aes_gcm<'a>(
                     in_out.len(),
                     aes_key.inner_less_safe(),
                     ctr,
-                    gcm_ctx,
+                    gcm_ctx.inner(),
                 )
             }
         }

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -71,7 +71,6 @@ impl Key {
     }
 }
 
-#[repr(transparent)]
 pub struct Context {
     inner: ContextInner,
     cpu_features: cpu::Features,
@@ -95,6 +94,13 @@ impl Context {
         }
 
         ctx
+    }
+
+    /// Access to `inner` for the integrated AES-GCM implementations only.
+    #[cfg(target_arch = "x86_64")]
+    #[inline]
+    pub(super) fn inner(&mut self) -> &mut ContextInner {
+        &mut self.inner
     }
 
     pub fn update_blocks(&mut self, input: &[u8]) {
@@ -263,7 +269,7 @@ impl From<Xi> for Block {
 // Some assembly language code, in particular the MOVEBE+AVX2 X86-64
 // implementation, requires this exact layout.
 #[repr(C, align(16))]
-struct ContextInner {
+pub(super) struct ContextInner {
     Xi: Xi,
     _unused: Block,
     Htable: HTable,


### PR DESCRIPTION
Clarify some pointer aliasing in gcm.rs by removing the questionable `key_aliasing` pattern. It was much easier to remove it than to figure out if it is guaranteed to work. Clarify how keys and contexts are passed to the non-Rust GCM code. Although these changes are justified on their own, they also make merging upstream BoringSSL changes easier. The individual commit messages each contain more detailed explanation.