### PR TITLE
AEAD: Reduce the amount of `unsafe` code in `Block`

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -165,13 +165,13 @@ fn aead(
     let remainder = &mut in_out[whole_len..];
     shift::shift_partial((in_prefix_len, remainder), |remainder| {
         let mut input = Block::zero();
-        input.partial_copy_from(remainder);
+        input.overwrite_part_at(0, remainder);
         if let Direction::Opening { .. } = direction {
             gcm_ctx.update_block(input);
         }
         let mut output = aes_key.encrypt_iv_xor_block(ctr.into(), input);
         if let Direction::Sealing = direction {
-            polyfill::slice::fill(&mut output.as_mut()[remainder.len()..], 0);
+            output.zero_from(remainder.len());
             gcm_ctx.update_block(output);
         }
         output

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -96,14 +96,6 @@ impl AsRef<[u8; BLOCK_LEN]> for Block {
     }
 }
 
-/// Like `AsMut`.
-impl<'a> From_<&'a mut [Block; 2]> for &'a mut [u8; 2 * BLOCK_LEN] {
-    #[inline]
-    fn from_(bytes: &'a mut [Block; 2]) -> &'a mut [u8; 2 * BLOCK_LEN] {
-        unsafe { core::mem::transmute(bytes) }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -17,12 +17,7 @@ use super::{
     nonce::Iv,
     poly1305, Aad, Block, Direction, Nonce, Tag, BLOCK_LEN,
 };
-use crate::{
-    aead, cpu,
-    endian::*,
-    error,
-    polyfill::{self, convert::*},
-};
+use crate::{aead, cpu, endian::*, error, polyfill};
 use core::convert::TryInto;
 
 /// ChaCha20-Poly1305 as described in [RFC 7539].
@@ -139,12 +134,9 @@ fn poly1305_update_padded_16(ctx: &mut poly1305::Context, input: &[u8]) {
 
 // Also used by chacha20_poly1305_openssh.
 pub(super) fn derive_poly1305_key(chacha_key: &chacha::Key, iv: Iv) -> poly1305::Key {
-    let mut blocks = [Block::zero(); poly1305::KEY_BLOCKS];
-    chacha_key.encrypt_iv_xor_blocks_in_place(
-        iv,
-        <&mut [u8; poly1305::KEY_BLOCKS * BLOCK_LEN]>::from_(&mut blocks),
-    );
-    poly1305::Key::from(blocks)
+    let mut key_bytes = [0u8; 2 * BLOCK_LEN];
+    chacha_key.encrypt_iv_xor_blocks_in_place(iv, &mut key_bytes);
+    poly1305::Key::from(key_bytes)
 }
 
 #[cfg(test)]

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -132,7 +132,7 @@ fn poly1305_update_padded_16(ctx: &mut poly1305::Context, input: &[u8]) {
     }
     if remainder_len > 0 {
         let mut block = Block::zero();
-        block.partial_copy_from(&input[whole_len..]);
+        block.overwrite_part_at(0, &input[whole_len..]);
         ctx.update_block(block, poly1305::Pad::Pad)
     }
 }

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -89,7 +89,7 @@ impl Context {
 
         for ad in aad.0.chunks(BLOCK_LEN) {
             let mut block = Block::zero();
-            block.partial_copy_from(ad);
+            block.overwrite_part_at(0, ad);
             ctx.update_block(block);
         }
 

--- a/src/aead/nonce.rs
+++ b/src/aead/nonce.rs
@@ -102,7 +102,7 @@ where
             block: Block::zero(),
         };
         let block = unsafe { &mut r.block };
-        block.as_mut()[U32::NONCE_BYTE_INDEX..][..NONCE_LEN].copy_from_slice(nonce.as_ref());
+        block.overwrite_part_at(U32::NONCE_BYTE_INDEX, nonce.as_ref());
         r.increment_by_less_safe(initial_counter);
 
         r


### PR DESCRIPTION
It seems like we have a couple of instances where we create multiple `&mut` references to the same object. Stop doing that to make it clearer that the Rust rules are being followed. The individual commits have more details.