### PR TITLE
ChaCha: use `slice::copy_within` instead of `core::ptr::copy`.

### DIFF
--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -78,11 +78,7 @@ impl Key {
         // https://rt.openssl.org/Ticket/Display.html?id=4362
         let len = in_out.len() - in_prefix_len;
         if cfg!(any(target_arch = "arm", target_arch = "x86")) && in_prefix_len != 0 {
-            // TODO: replace with `in_out.copy_within(in_prefix_len.., 0)`
-            // See https://github.com/rust-lang/rust/issues/54236.
-            unsafe {
-                core::ptr::copy(in_out[in_prefix_len..].as_ptr(), in_out.as_mut_ptr(), len);
-            }
+            in_out.copy_within(in_prefix_len.., 0);
             self.encrypt_in_place(counter, &mut in_out[..len]);
         } else {
             unsafe {


### PR DESCRIPTION
Use less `unsafe`.