### PR TITLE
Add doc/link-to-readme.md to the published crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ include = [
     "crypto/poly1305/asm/poly1305-armv8.pl",
     "crypto/poly1305/asm/poly1305-x86.pl",
     "crypto/poly1305/asm/poly1305-x86_64.pl",
+    "doc/link-to-readme.md",
     "examples/checkdigest.rs",
     "include/GFp/aes.h",
     "include/GFp/arm_arch.h",


### PR DESCRIPTION
Cargo may start requiring the readme to be in the published crate.