### PR TITLE
WIP: Remove `Block` from AES modules

### DIFF
--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -15,7 +15,7 @@
 
 use super::{
     nonce::{self, Iv},
-    Block, BLOCK_LEN,
+    BLOCK_LEN,
 };
 use crate::{c, endian::*};
 
@@ -55,7 +55,7 @@ impl Key {
     }
 
     #[inline]
-    pub fn new_mask(&self, sample: Block) -> [u8; 5] {
+    pub fn new_mask(&self, sample: [u8; BLOCK_LEN]) -> [u8; 5] {
         let mut out: [u8; 5] = [0; 5];
         let iv = Iv::assume_unique_for_key(sample);
 

--- a/src/aead/gcm/gcm_nohw.rs
+++ b/src/aead/gcm/gcm_nohw.rs
@@ -22,8 +22,10 @@
 //
 // Unlike the BearSSL notes, we use u128 in the 64-bit implementation.
 
-use super::{super::Block, Xi};
-use crate::endian::BigEndian;
+use super::{
+    super::{ConvertEndian, BLOCK_LEN},
+    Xi,
+};
 use core::convert::TryInto;
 
 #[cfg(target_pointer_width = "64")]
@@ -238,5 +240,6 @@ fn with_swapped_xi(Xi(xi): &mut Xi, f: impl FnOnce(&mut [u64; 2])) {
     let unswapped = xi.u64s_be_to_native();
     let mut swapped: [u64; 2] = [unswapped[1], unswapped[0]];
     f(&mut swapped);
-    *xi = Block::from_u64_be(BigEndian::from(swapped[1]), BigEndian::from(swapped[0]))
+    swapped.reverse();
+    *xi = <[u8; BLOCK_LEN]>::from_be_u64s(swapped);
 }

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -19,8 +19,8 @@ use super::{
     block::{Block, BLOCK_LEN},
     Tag,
 };
-use core::convert::TryInto;
 use crate::{bssl, c, error};
+use core::convert::TryInto;
 
 /// A Poly1305 key.
 pub struct Key([u8; KEY_LEN]);
@@ -160,7 +160,7 @@ impl Funcs {
 
     #[inline]
     fn emit(&self, state: &mut Opaque, nonce: &Nonce) -> Tag {
-        let mut tag = Tag(Block::zero());
+        let mut tag = Tag([0u8; BLOCK_LEN]);
         unsafe {
             (self.emit_fn)(state, &mut tag, nonce);
         }

--- a/src/aead/shift.rs
+++ b/src/aead/shift.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::block::{Block, BLOCK_LEN};
+use super::block::BLOCK_LEN;
 
 #[cfg(target_arch = "x86")]
 pub fn shift_full_blocks<F>(in_out: &mut [u8], in_prefix_len: usize, mut transform: F)
@@ -36,7 +36,7 @@ where
 
 pub fn shift_partial<F>((in_prefix_len, in_out): (usize, &mut [u8]), transform: F)
 where
-    F: FnOnce(&[u8]) -> Block,
+    F: FnOnce(&[u8]) -> [u8; BLOCK_LEN],
 {
     let (block, in_out_len) = {
         let input = &in_out[in_prefix_len..];


### PR DESCRIPTION
Replace uses of `Block` in `aead/aes*` modules to eventually remove the `Block` type completely.

Related AEAD modules adapted to use new interfaces

Related to #1021