### PR TITLE
Make small arrays of `endian::Encoding` types a little easier to use.

### DIFF
--- a/src/aead/chacha20_poly1305_openssh.rs
+++ b/src/aead/chacha20_poly1305_openssh.rs
@@ -167,7 +167,7 @@ fn make_counter(sequence_number: u32) -> Counter {
         BigEndian::ZERO,
         BigEndian::from(sequence_number),
     ];
-    Counter::zero(Nonce::try_assume_unique_for_key(as_bytes(&nonce)).unwrap())
+    Counter::zero(Nonce::assume_unique_for_key(*(nonce.as_byte_array())))
 }
 
 /// The length of key.

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -24,7 +24,11 @@
 // The goal for this implementation is to drive the overhead as close to zero
 // as possible.
 
-use crate::{c, cpu, debug, endian::*, polyfill};
+use crate::{
+    c, cpu, debug,
+    endian::{self, BigEndian},
+    polyfill,
+};
 use core::num::Wrapping;
 
 mod sha1;
@@ -243,7 +247,8 @@ impl Digest {
 impl AsRef<[u8]> for Digest {
     #[inline(always)]
     fn as_ref(&self) -> &[u8] {
-        &as_bytes(unsafe { &self.value.as64 })[..self.algorithm.output_len]
+        let as64 = unsafe { &self.value.as64 };
+        &endian::as_byte_slice(as64)[..self.algorithm.output_len]
     }
 }
 


### PR DESCRIPTION
Also remove the unnecessary: `T: From<E>` bound.