### PR TITLE
Remove the use of `Block` from `aead::Tag`.

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -635,7 +635,7 @@ impl Eq for Algorithm {}
 /// An authentication tag.
 #[must_use]
 #[repr(C)]
-pub struct Tag(Block);
+pub struct Tag([u8; TAG_LEN]);
 
 impl AsRef<[u8]> for Tag {
     fn as_ref(&self) -> &[u8] {

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -190,7 +190,7 @@ fn aead(
         let bytes = tag_iv.into_bytes_less_safe();
         let mut tag = aes_key.encrypt_block(Block::from(&bytes));
         tag.bitxor_assign(pre_tag.into());
-        Tag(tag)
+        Tag(*tag.as_ref())
     })
 }
 

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -17,7 +17,7 @@
 
 use super::{
     block::{Block, BLOCK_LEN},
-    Tag,
+    Tag, TAG_LEN,
 };
 use crate::{bssl, c, error};
 use core::convert::TryInto;
@@ -160,7 +160,7 @@ impl Funcs {
 
     #[inline]
     fn emit(&self, state: &mut Opaque, nonce: &Nonce) -> Tag {
-        let mut tag = Tag(Block::zero());
+        let mut tag = Tag([0u8; TAG_LEN]);
         unsafe {
             (self.emit_fn)(state, &mut tag, nonce);
         }


### PR DESCRIPTION
Related to #1021