### PR TITLE
Remove `Block` from `aead::{aes,chacha}::new_mask`

### DIFF
--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{counter, iv::Iv, Block, Direction, BLOCK_LEN};
+use super::{counter, iv::Iv, quic::Sample, Block, Direction, BLOCK_LEN};
 use crate::{bits::BitLength, c, cpu, endian::*, error, polyfill};
 
 pub(crate) struct Key {
@@ -291,8 +291,8 @@ impl Key {
         }
     }
 
-    pub fn new_mask(&self, sample: Block) -> [u8; 5] {
-        let block = self.encrypt_block(sample);
+    pub fn new_mask(&self, sample: Sample) -> [u8; 5] {
+        let block = self.encrypt_block(Block::from(&sample));
 
         let mut out: [u8; 5] = [0; 5];
         out.copy_from_slice(&block.as_ref()[..5]);

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -13,7 +13,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{counter, iv::Iv, Block, BLOCK_LEN};
+use super::{counter, iv::Iv, quic::Sample, BLOCK_LEN};
 use crate::{c, endian::*};
 
 #[repr(C)]
@@ -52,9 +52,9 @@ impl Key {
     }
 
     #[inline]
-    pub fn new_mask(&self, sample: Block) -> [u8; 5] {
+    pub fn new_mask(&self, sample: Sample) -> [u8; 5] {
         let mut out: [u8; 5] = [0; 5];
-        let iv = Iv::assume_unique_for_key(*sample.as_ref());
+        let iv = Iv::assume_unique_for_key(sample);
 
         unsafe {
             self.encrypt(

--- a/src/aead/quic.rs
+++ b/src/aead/quic.rs
@@ -17,7 +17,7 @@
 //! See draft-ietf-quic-tls.
 
 use crate::{
-    aead::{aes, block::Block, chacha},
+    aead::{aes, chacha},
     cpu, error, hkdf,
 };
 use core::convert::{TryFrom, TryInto};
@@ -63,9 +63,8 @@ impl HeaderProtectionKey {
     /// `sample` must be exactly `self.algorithm().sample_len()` bytes long.
     pub fn new_mask(&self, sample: &[u8]) -> Result<[u8; 5], error::Unspecified> {
         let sample = <&[u8; SAMPLE_LEN]>::try_from(sample)?;
-        let sample = Block::from(sample);
 
-        let out = (self.algorithm.new_mask)(&self.inner, sample);
+        let out = (self.algorithm.new_mask)(&self.inner, *sample);
         Ok(out)
     }
 
@@ -78,11 +77,14 @@ impl HeaderProtectionKey {
 
 const SAMPLE_LEN: usize = super::TAG_LEN;
 
+/// QUIC sample for new key masks
+pub type Sample = [u8; SAMPLE_LEN];
+
 /// A QUIC Header Protection Algorithm.
 pub struct Algorithm {
     init: fn(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, error::Unspecified>,
 
-    new_mask: fn(key: &KeyInner, sample: Block) -> [u8; 5],
+    new_mask: fn(key: &KeyInner, sample: Sample) -> [u8; 5],
 
     key_len: usize,
     id: AlgorithmID,
@@ -152,7 +154,7 @@ fn aes_init_256(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, err
     Ok(KeyInner::Aes(aes_key))
 }
 
-fn aes_new_mask(key: &KeyInner, sample: Block) -> [u8; 5] {
+fn aes_new_mask(key: &KeyInner, sample: Sample) -> [u8; 5] {
     let aes_key = match key {
         KeyInner::Aes(key) => key,
         _ => unreachable!(),
@@ -174,7 +176,7 @@ fn chacha20_init(key: &[u8], _todo: cpu::Features) -> Result<KeyInner, error::Un
     Ok(KeyInner::ChaCha20(chacha::Key::from(chacha20_key)))
 }
 
-fn chacha20_new_mask(key: &KeyInner, sample: Block) -> [u8; 5] {
+fn chacha20_new_mask(key: &KeyInner, sample: Sample) -> [u8; 5] {
     let chacha20_key = match key {
         KeyInner::ChaCha20(key) => key,
         _ => unreachable!(),


### PR DESCRIPTION
Remove use of `Block` from `aead::{aes,chacha}::new_mask` API.

Leave internal use of `Block` in `aead::aes::new_mask`