### PR TITLE
Fix: Hardfault on ARM targets using ChaCha

### DIFF
--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -16,7 +16,7 @@
 use super::{counter, iv::Iv, quic::Sample, BLOCK_LEN};
 use crate::{c, endian::*};
 
-#[repr(C)]
+#[repr(C, align(4))]
 pub struct Key([u8; KEY_LEN]);
 
 impl From<[u8; KEY_LEN]> for Key {


### PR DESCRIPTION
The assembly portion of the chacha code uses vector instructions to fetch the key, see chacha-armv4.pl line 240:

```asm
ldmia	r3,{r4-r11}		@ load key
```

The rust side uses a struct for the key, see chacha.rs line 19:

```rust
#[repr(C)]
pub struct Key([u8; KEY_LEN]);
```

This is a problem, since the vector instruction `ldmia` requires the data to be 4 byte aligned. But Rust does not guarantee this.
In my setup this lead to a processor Hardfault.
The fix is rather simple. Rust lets you align structs with repr(align()), so that's what I did.

Maybe this crash leads to security problems in some cases.