### PR TITLE
Fix alignment of ChaCha20 keys.

### DIFF
--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -16,13 +16,13 @@
 use super::{counter, iv::Iv, quic::Sample, BLOCK_LEN};
 use crate::{c, endian::*};
 
-#[repr(C)]
-pub struct Key([u8; KEY_LEN]);
+#[repr(transparent)]
+pub struct Key([LittleEndian<u32>; KEY_LEN / 4]);
 
 impl From<[u8; KEY_LEN]> for Key {
     #[inline]
     fn from(value: [u8; KEY_LEN]) -> Self {
-        Self(value)
+        Self(FromByteArray::from_byte_array(&value))
     }
 }
 


### PR DESCRIPTION
When we removed the use of `Block` from ChaCha20, we didn't preserve the alignment. Fix that.

BoringSSL uses this declaration of `ChaCha20_ctr32`:

```
void ChaCha20_ctr32(uint8_t *out, const uint8_t *in, size_t in_len,
                    const uint32_t key[8], const uint32_t counter[4]);
```
