### PR TITLE
ADDED: seed_to_pkcs8, deriving an Ed25519 key pair from a seed.

### DIFF
--- a/src/ec/curve25519/ed25519/signing.rs
+++ b/src/ec/curve25519/ed25519/signing.rs
@@ -59,6 +59,22 @@ impl Ed25519KeyPair {
         ))
     }
 
+    /// Like generate_pkcs8, except that it generates the key pair
+    /// from a given seed.
+    ///
+    /// This is useful for example to derive keys from passwords,
+    /// so that the key need not be stored at all.
+    pub fn seed_to_pkcs8(
+        seed: &Seed,
+    ) -> Result<pkcs8::Document, error::KeyRejected> {
+        let key_pair = Self::from_seed_(seed);
+        Ok(pkcs8::wrap_key(
+            &PKCS8_TEMPLATE,
+            &seed[..],
+            key_pair.public_key().as_ref(),
+        ))
+    }
+
     /// Constructs an Ed25519 key pair by parsing an unencrypted PKCS#8 v2
     /// Ed25519 private key.
     ///

--- a/tests/ed25519_tests.rs
+++ b/tests/ed25519_tests.rs
@@ -46,6 +46,14 @@ fn test_signature_ed25519() {
         let public_key = test_case.consume_bytes("PUB");
         assert_eq!(32, public_key.len());
 
+        // Test deterministic creation of key pair from seed.
+        let mut seed_bytes = [0;32];
+        seed_bytes.copy_from_slice(&seed);
+
+        let pkcs8_from_seed = Ed25519KeyPair::seed_to_pkcs8(&seed_bytes).unwrap();
+        let key_pair_from_seed = Ed25519KeyPair::from_pkcs8(pkcs8_from_seed.as_ref()).unwrap();
+        assert_eq!(key_pair_from_seed.public_key().as_ref(), &public_key[..]);
+
         let msg = test_case.consume_bytes("MESSAGE");
 
         let expected_sig = test_case.consume_bytes("SIG");


### PR DESCRIPTION
This is useful for example to generate keys from passwords, so
that data can be signed without having to store the key.

This addresses #1003.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.