### PR TITLE
add support for illumos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ spin = { version = "0.5.2", default-features = false }
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.69", default-features = false }
 
-[target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "solaris"))'.dependencies]
 once_cell = { version = "1.3.1", default-features = false, features=["std"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]

--- a/crypto/perlasm/x86asm.pl
+++ b/crypto/perlasm/x86asm.pl
@@ -311,7 +311,7 @@ sub ::asm_init
     else
     {	print STDERR <<"EOF";
 Pick one target type from
-	elf	- Linux, FreeBSD, Solaris x86, etc.
+	elf	- Linux, FreeBSD, illumos, Solaris x86, etc.
 	a.out	- DJGPP, elder OpenBSD, etc.
 	coff	- GAS/COFF such as Win32 targets
 	win32n	- Windows 95/Windows NT NASM format

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -183,6 +183,7 @@ use self::sysrand_or_urandom::fill as fill_impl;
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "illumos",
     target_os = "solaris"
 ))]
 use self::urandom::fill as fill_impl;
@@ -354,6 +355,7 @@ mod sysrand_or_urandom {
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "illumos",
     target_os = "solaris"
 ))]
 mod urandom {

--- a/util/make_prefix_headers.go
+++ b/util/make_prefix_headers.go
@@ -23,7 +23,7 @@
 // instead of a custom macro. This avoids the need for a custom macro, but also
 // ensures that our renaming won't conflict with symbols defined and used by our
 // consumers (the "HMAC" problem). An example of this approach can be seen in
-// IllumOS' fork of OpenSSL:
+// the SmartOS fork of OpenSSL:
 // https://github.com/joyent/illumos-extra/blob/master/openssl1x/sunw_prefix.h
 
 package main


### PR DESCRIPTION
We recently added support for an illumos host triple to the Rust toolchain, and would like to be able to build ring there.  This patch adds support for that.  We are sufficiently similar to Solaris that we just needed some extra conditional compilation directives.

The tests don't currently pass:

```
$ cargo test --all -- --test-threads=1
    Finished test [unoptimized + debuginfo] target(s) in 0.06s
     Running target/debug/deps/ring-2e180370d30c697d

running 88 tests
test aead::aes::tests::test_aes ... ok
test aead::aes_gcm::tests::max_input_len_test ... ok
test aead::block::tests::test_bitxor_assign ... ok
test aead::chacha20_poly1305::tests::max_input_len_test ... ok
test aead::chacha::tests::chacha20_tests ... ok
test aead::poly1305::tests::test_poly1305 ... ok
test aead::poly1305::tests::test_state_layout ... ok
test arithmetic::bigint::tests::test_elem_exp_consttime ... ok
test arithmetic::bigint::tests::test_elem_mul ... ok
test arithmetic::bigint::tests::test_elem_reduced ... ok
test arithmetic::bigint::tests::test_elem_reduced_once ... ok
test arithmetic::bigint::tests::test_elem_squared ... ok
test arithmetic::bigint::tests::test_modulus_debug ... ok
test arithmetic::bigint::tests::test_mul_add_words ... ok
test arithmetic::bigint::tests::test_public_exponent_debug ... ok
test bssl::tests::result::semantics ... ok
test bssl::tests::result::size_and_alignment ... ok
test c::tests::test_libc_compatible ... ok
test constant_time::tests::test_constant_time ... ok
test cpu::intel::x86_64_tests::test_avx_movbe_mask ... ok
test digest::tests::max_input::SHA1_FOR_LEGACY_USE_ONLY::max_input_test ... ok
test digest::tests::max_input::SHA1_FOR_LEGACY_USE_ONLY::too_long_input_test_block ... fatal runtime error: failed to initiate panic, error 5
error: test failed, to rerun pass '--lib'

Caused by:
  process didn't exit successfully: `/ws/safari/ring/target/debug/deps/ring-2e180370d30c697d --test-threads=1` (signal: 6, SIGABRT: process abort signal)
```

The reason for this is a somewhat complicated artefact of the unwinding machinery and dynamic linker dependencies, and my plan is to go and fix this directly in the Rust toolchain.  The issue is in the order of `NEEDED` entries in the resultant executable:

```
$ elfdump -d /ws/safari/ring/target/debug/deps/ring-2e180370d30c697d  | awk '/index.*tag/ || /Section/ || /NEEDED/'
Dynamic Section:  .dynamic
     index  tag                value
       [0]  NEEDED            0x86d36             libc.so.1
       [1]  NEEDED            0x86daf             libm.so.2
       [2]  NEEDED            0x86db9             libsocket.so.1
       [3]  NEEDED            0x86e19             libumem.so.1
       [4]  NEEDED            0x86dda             libgcc_s.so.1
       [5]  NEEDED            0x86e02             libssp.so.0
```

Because `libc.so.1` is before `libgcc_s.so.1` in the list, we will use the unwinding symbols that are provided as part of the system ABI.  Unfortunately for our purposes, there are some additional symbols in the GCC unwinder that are not in the base platform library -- these symbols fall through and are bound to the GCC version, and thus we have two totally separate implementations trying to work on one another's data structures and the result is a crash (or worse).  I intend to fix this in the Rust toolchain, to make sure the correct ordering of NEEDED entries is always present in built binaries.  Once that's fixed there I expect better behaviour here, as we see with unwinding in binaries that don't have as much custom/FFI stuff.

I expect the same issue afflicts the Solaris stuff today, though they might have added the additional symbols to their base libc unwinder.