### PR TITLE
Fix a PBKDF2 documentation comment typo

### DIFF
--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -122,7 +122,7 @@ pub struct Algorithm(hmac::Algorithm);
 /// PBKDF2 using HMAC-SHA1.
 pub static PBKDF2_HMAC_SHA1: Algorithm = Algorithm(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY);
 
-/// PBKDF2 using HMAC-h.
+/// PBKDF2 using HMAC-SHA256.
 pub static PBKDF2_HMAC_SHA256: Algorithm = Algorithm(hmac::HMAC_SHA256);
 
 /// PBKDF2 using HMAC-SHA384.


### PR DESCRIPTION
One of the documentation comments for the predefined PBKDF2 algorithms (HMAC-SHA256) was incomplete so this fixes it to be like the others.

This is a very small change, so feel free to take care of this as part of a bigger fix later.