### PR TITLE
Move from `spin` to `conquer-once`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,7 +297,7 @@ name = "ring"
 untrusted = { version = "0.7.1" }
 
 [target.'cfg(all(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86", target_arch = "x86_64"), not(target_os = "ios")))'.dependencies]
-spin = { version = "0.5.2", default-features = false }
+conquer-once = { version = "0.2.1", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.69", default-features = false }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -36,8 +36,8 @@ pub(crate) fn features() -> Features {
         not(target_os = "ios")
     ))]
     {
-        static INIT: spin::Once<()> = spin::Once::new();
-        let () = INIT.call_once(|| {
+        static INIT: conquer_once::spin::Once = conquer_once::spin::Once::uninit();
+        let () = INIT.init_once(|| {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {
                 extern "C" {


### PR DESCRIPTION
This resolves [RUSTSEC-2019-0031][0].

[0]: https://rustsec.org/advisories/RUSTSEC-2019-0031.html

---

The advisory page suggests several alternatives to the now-deprecated `spin` crate. The reason I picked `conquer-once` was because it seemed to have the most similar (and limited) API to how `spin` was being used -- it seemed a good small dependency to trade for.