### PR TITLE
Added build configuration for Apple Silicon based Macs.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -235,6 +235,7 @@ const ASM_TARGETS: &[(&str, Option<&str>, Option<&str>)] = &[
     ("x86_64", Some(WINDOWS), Some("nasm")),
     ("x86_64", None, Some("elf")),
     ("aarch64", Some("ios"), Some("ios64")),
+    ("aarch64", Some("macos"), Some("ios64")),
     ("aarch64", None, Some("linux64")),
     ("x86", Some(WINDOWS), Some("win32n")),
     ("x86", Some("ios"), Some("macosx")),

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -33,7 +33,9 @@ pub(crate) fn features() -> Features {
             target_arch = "x86",
             target_arch = "x86_64"
         ),
-        not(target_os = "ios")
+        not(
+            any(target_os = "ios",
+                target_os = "macos"))
     ))]
     {
         static INIT: spin::Once<()> = spin::Once::new();
@@ -173,13 +175,14 @@ pub(crate) mod arm {
         #[cfg_attr(
             any(
                 target_os = "ios",
+                target_os = "macos",
                 not(any(target_arch = "arm", target_arch = "aarch64"))
             ),
             allow(dead_code)
         )]
         mask: u32,
 
-        #[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+        #[cfg_attr(not(any(target_os = "ios", target_os = "macos")), allow(dead_code))]
         ios: bool,
     }
 
@@ -187,7 +190,7 @@ pub(crate) mod arm {
     impl Feature {
         #[inline(always)]
         pub fn available(&self, _: super::Features) -> bool {
-            #[cfg(all(target_os = "ios", any(target_arch = "arm", target_arch = "aarch64")))]
+            #[cfg(all(any(target_os = "ios", target_os = "macos"), any(target_arch = "arm", target_arch = "aarch64")))]
             {
                 return self.ios;
             }


### PR DESCRIPTION
Added the required build configuration changes to support compilation on Apple Silicon Macs. 

Tested on a Developer Transition Kit Mac.

> cargo build
> cargo test

For now, the flavor portion of the ASM_TARGETS triple is left as ios64. With some additional changes to arm-xlate.pl, we could insert a custom string here (e.g. macArm64).