### PR TITLE
Update doc links to use correct branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Users of *ring* should always use the latest released version, and users
 should upgrade to the latest released version as soon as it is released.
 *ring* has a linear release model that favors users of the latest released
 version. We have never backported fixes to earlier releases and we don't
-maintain branches other than the master branch. Further, for some obscure
+maintain branches other than the main branch. Further, for some obscure
 technical reasons it's currently not possible to link two different versions
 of *ring* into the same program; for policy reasons we don't bother to try
 to work around that. Thus it is important that libraries using *ring* update
@@ -169,8 +169,8 @@ source libraries use. The idea behind *our* model is to encourage all users to
 work together to ensure that the latest version is good *as it is being
 developed*. In particular, because users know that correctness/security fixes
 (if any) aren't going to get backported, they have a strong incentive to help
-review pull requests before they are merged and/or review commits on the master
-branch after they've landed to ensure that code quality on the master branch
+review pull requests before they are merged and/or review commits on the main
+branch after they've landed to ensure that code quality on the main branch
 stays high.
 
 The more common model, where there are stable versions that have important
@@ -228,7 +228,7 @@ the table below. The C compilers listed are used for compiling the C portions.
 <tr><td>Windows</td>
     <td>x86, x86_64</td>
     <td>MSVC 2015 Update 3 (14.0)</td>
-    <td><a href=https://ci.appveyor.com/project/briansmith/ring/branch/master>Build Status</a></td>
+    <td><a href=https://ci.appveyor.com/project/briansmith/ring/branch/main>Build Status</a></td>
 </tr>
 </table>
 

--- a/src/ec/suite_b/curve.rs
+++ b/src/ec/suite_b/curve.rs
@@ -31,7 +31,7 @@ macro_rules! suite_b_curve {
         /// [NIST Special Publication 800-56A, revision 2]:
         ///     http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf
         /// [Suite B Implementer's Guide to NIST SP 800-56A]:
-        ///     https://github.com/briansmith/ring/blob/master/doc/ecdh.pdf
+        ///     https://github.com/briansmith/ring/blob/main/doc/ecdh.pdf
         pub static $NAME: ec::Curve = ec::Curve {
             public_key_len: 1 + (2 * (($bits + 7) / 8)),
             elem_scalar_seed_len: ($bits + 7) / 8,

--- a/src/ec/suite_b/ecdh.rs
+++ b/src/ec/suite_b/ecdh.rs
@@ -38,7 +38,7 @@ macro_rules! ecdh {
         /// [NIST Special Publication 800-56A, revision 2]:
         ///     http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf
         /// [Suite B Implementer's Guide to NIST SP 800-56A]:
-        ///     https://github.com/briansmith/ring/blob/master/doc/ecdh.pdf
+        ///     https://github.com/briansmith/ring/blob/main/doc/ecdh.pdf
         pub static $NAME: agreement::Algorithm = agreement::Algorithm {
             curve: $curve,
             ecdh: $ecdh,

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -105,9 +105,9 @@
 //!
 //! [RFC 2104]: https://tools.ietf.org/html/rfc2104
 //! [code for `ring::pbkdf2`]:
-//!     https://github.com/briansmith/ring/blob/master/src/pbkdf2.rs
+//!     https://github.com/briansmith/ring/blob/main/src/pbkdf2.rs
 //! [code for `ring::hkdf`]:
-//!     https://github.com/briansmith/ring/blob/master/src/hkdf.rs
+//!     https://github.com/briansmith/ring/blob/main/src/hkdf.rs
 
 use crate::{constant_time, digest, error, hkdf, rand};
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -111,7 +111,7 @@
 //! [NIST Special Publication 800-56A, revision 2]:
 //!     http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf
 //! [Suite B implementer's guide to FIPS 186-3]:
-//!     https://github.com/briansmith/ring/blob/master/doc/ecdsa.pdf
+//!     https://github.com/briansmith/ring/blob/main/doc/ecdsa.pdf
 //! [RFC 3279 Section 2.2.3]:
 //!     https://tools.ietf.org/html/rfc3279#section-2.2.3
 //! [RFC 3447 Section 8.2]:


### PR DESCRIPTION
It looks like *ring* is using `main` now.

Signed-off-by: Joe Richey <joerichey@google.com>