### PR TITLE
Initial ppc64le Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
           - i686-pc-windows-msvc
           - i686-unknown-linux-gnu
           - i686-unknown-linux-musl
+          - powerpc64le-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
@@ -246,6 +247,9 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: i686-unknown-linux-musl
+            host_os: ubuntu-22.04
+
+          - target: powerpc64le-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu
@@ -337,6 +341,7 @@ jobs:
         target:
           - aarch64-unknown-linux-musl
           - i686-pc-windows-msvc
+          - powerpc64le-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
 
         mode:
@@ -353,6 +358,9 @@ jobs:
 
           - target: i686-pc-windows-msvc
             host_os: windows-latest
+
+          - target: powerpc64le-unknown-linux-gnu
+            host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
             host_os: ubuntu-22.04
@@ -487,6 +495,7 @@ jobs:
         target:
           - aarch64-unknown-linux-gnu
           - i686-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
           - x86_64-unknown-linux-musl
 
@@ -509,6 +518,9 @@ jobs:
           # https://github.com/rust-lang/rust/issues/79556 and
           # https://github.com/rust-lang/rust/issues/79555 are fixed.
           - target: i686-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: powerpc64le-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -40,6 +40,9 @@
 #elif defined(__MIPSEL__) && defined(__LP64__)
 #define OPENSSL_64_BIT
 #define OPENSSL_MIPS64
+#elif (defined(__PPC64__) || defined(__powerpc64__)) && defined(_LITTLE_ENDIAN)
+#define OPENSSL_64_BIT
+#define OPENSSL_PPC64LE
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 8
 #define OPENSSL_64_BIT
 #define OPENSSL_RISCV64

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -21,6 +21,7 @@ rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
 qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
 qemu_mipsel="qemu-mipsel -L /usr/mipsel-linux-gnu"
+qemu_powerpc64le="qemu-ppc64le -L /usr/powerpc64le-linux-gnu"
 qemu_riscv64="qemu-riscv64 -L /usr/riscv64-linux-gnu"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
@@ -99,6 +100,13 @@ case $target in
     export AR_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc-ar
     export CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc
     export CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER="$qemu_mipsel"
+    ;;
+  powerpc64le-unknown-linux-gnu)
+    export CC_powerpc64le_unknown_linux_gnu=clang-$llvm_version
+    export AR_powerpc64le_unknown_linux_gnu=llvm-ar-$llvm_version
+    export CFLAGS_powerpc64le_unknown_linux_gnu="--sysroot=/usr/powerpc64le-linux-gnu"
+    export CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc
+    export CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER="$qemu_powerpc64le"
     ;;
   riscv64gc-unknown-linux-gnu)
     export CC_riscv64gc_unknown_linux_gnu=clang-$llvm_version

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -91,6 +91,13 @@ case $target in
     libc6-dev-mipsel-cross \
     qemu-user
   ;;
+--target=powerpc64le-unknown-linux-gnu)
+  use_clang=1
+  install_packages \
+    gcc-powerpc64le-linux-gnu \
+    libc6-dev-ppc64el-cross \
+    qemu-user
+  ;;
 --target=riscv64gc-unknown-linux-gnu)
   use_clang=1
   install_packages \

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -12,6 +12,11 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+#![cfg_attr(
+    not(any(target_arch = "aarch64", target_arch = "arm")),
+    allow(dead_code)
+)]
+
 #[cfg(all(
     any(target_os = "android", target_os = "linux"),
     any(target_arch = "aarch64", target_arch = "arm")


### PR DESCRIPTION
Revive PR #819 (by q66) in reduced-scope by implementing powerpc64le support in ring. This effort supports only little endian machines using POWER8 and later processors for now. The goal is to enable ring to target modern powerpc64le machines.

Only the bare minimum needed to build ring and pass ring tests is included; there is no new optimized code for algorithms already implemented in C/Rust. This has been tested on a POWER9 Blackbird, and on a POWER8 machine.