### PR TITLE
Re-enable debug = true in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,11 +334,9 @@ std = ["alloc"]
 test_logging = []
 wasm32_c = []
 
-# XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
-
 [profile.bench]
 opt-level = 3
-debug = false
+debug = true
 rpath = false
 lto = true
 debug-assertions = false
@@ -346,7 +344,7 @@ codegen-units = 1
 
 [profile.release]
 opt-level = 3
-debug = false
+debug = true
 rpath = false
 lto = true
 debug-assertions = false


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/28233 seems to have been fixed for a while now, and I could not re-produce the original build fails that caused this to be disabled.