### PR TITLE
Added musl targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,16 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=stable
+      rust: stable
+      os: linux
+      dist: trusty
+
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=stable
+      rust: stable
+      os: linux
+      dist: trusty
+
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=stable
       rust: stable
       os: linux
@@ -204,6 +214,30 @@ matrix:
             - gcc-7
             - gcc-7-multilib
             - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=stable
+      rust: stable
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - libc6-dev-i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=stable
+      rust: stable
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - libc6-dev-i386
           sources:
             - ubuntu-toolchain-r-test
 
@@ -331,6 +365,16 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=nightly
+      rust: nightly
+      os: linux
+      dist: trusty
+
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=nightly
+      rust: nightly
+      os: linux
+      dist: trusty
+
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=nightly
       rust: nightly
       os: linux
@@ -435,6 +479,30 @@ matrix:
             - gcc-7
             - gcc-7-multilib
             - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=nightly
+      rust: nightly
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - libc6-dev-i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=nightly
+      rust: nightly
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - libc6-dev-i386
           sources:
             - ubuntu-toolchain-r-test
 
@@ -556,6 +624,16 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=beta
+      rust: beta
+      os: linux
+      dist: trusty
+
+    - env: TARGET_X=x86_64-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=beta
+      rust: beta
+      os: linux
+      dist: trusty
+
     - env: TARGET_X=aarch64-unknown-linux-gnu CC_X=aarch64-linux-gnu-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=beta
       rust: beta
       os: linux
@@ -651,6 +729,30 @@ matrix:
             - gcc-7
             - gcc-7-multilib
             - linux-libc-dev:i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=beta
+      rust: beta
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - libc6-dev-i386
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=beta
+      rust: beta
+      os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - libc6-dev-i386
           sources:
             - ubuntu-toolchain-r-test
 

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -73,6 +73,12 @@ if [[ ! "$TARGET_X" =~ "x86_64-" ]]; then
   fi
 fi
 
+# This stanza is separate from the above because MUSL requires a target install,
+# but does *not* require special linking / multilib.
+if [[ "$TARGET_X" =~ .*"-unknown-linux-musl" ]]; then
+  rustup target add "$TARGET_X"
+fi
+
 if [[ ! -z "${CC_X-}" ]]; then
   export CC=$CC_X
   $CC --version

--- a/mk/travis.sh
+++ b/mk/travis.sh
@@ -59,8 +59,6 @@ if [[ "$TARGET_X" =~ ^(arm|aarch64) && ! "$TARGET_X" =~ android ]]; then
 fi
 
 if [[ ! "$TARGET_X" =~ "x86_64-" ]]; then
-  rustup target add "$TARGET_X"
-
   # By default cargo/rustc seems to use cc for linking, We installed the
   # multilib support that corresponds to $CC_X but unless cc happens to match
   # $CC_X, that's not the right version. The symptom is a linker error
@@ -73,9 +71,7 @@ if [[ ! "$TARGET_X" =~ "x86_64-" ]]; then
   fi
 fi
 
-# This stanza is separate from the above because MUSL requires a target install,
-# but does *not* require special linking / multilib.
-if [[ "$TARGET_X" =~ .*"-unknown-linux-musl" ]]; then
+if [[ "$TARGET_X" =~ .*"-unknown-linux-musl" || ! "$TARGET_X" =~ "x86_64" ]]; then
   rustup target add "$TARGET_X"
 fi
 

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -47,7 +47,9 @@ compilers = {
     "armv7-linux-androideabi" : [ "armv7a-linux-androideabi18-clang" ],
     "arm-unknown-linux-gnueabihf" : [ "arm-linux-gnueabihf-gcc" ],
     "i686-unknown-linux-gnu" : linux_compilers,
+    "i686-unknown-linux-musl" : [clang],
     "x86_64-unknown-linux-gnu" : linux_compilers,
+    "x86_64-unknown-linux-musl" : [clang],
     "x86_64-apple-darwin" : osx_compilers,
 }
 
@@ -75,8 +77,10 @@ targets = {
         "aarch64-linux-android",
         "armv7-linux-androideabi",
         "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-gnu",
         "i686-unknown-linux-gnu",
+        "i686-unknown-linux-musl",
         "arm-unknown-linux-gnueabihf",
     ],
 }


### PR DESCRIPTION
Building off of #935, I added musl targets for i686 and x86_64 using clang as the compiler. Addresses #713 