### PR TITLE
CI/CD: Don't install glibc stuff for musl targets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -205,7 +205,6 @@ matrix:
         apt:
           packages:
             - gcc-multilib
-            - libc6-dev-i386
 
     - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=stable
       rust: stable
@@ -215,7 +214,6 @@ matrix:
         apt:
           packages:
             - gcc-multilib
-            - libc6-dev-i386
 
     - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=stable
       rust: stable
@@ -437,7 +435,6 @@ matrix:
         apt:
           packages:
             - gcc-multilib
-            - libc6-dev-i386
 
     - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=nightly
       rust: nightly
@@ -447,7 +444,6 @@ matrix:
         apt:
           packages:
             - gcc-multilib
-            - libc6-dev-i386
 
     - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=nightly
       rust: nightly
@@ -667,7 +663,6 @@ matrix:
         apt:
           packages:
             - gcc-multilib
-            - libc6-dev-i386
 
     - env: TARGET_X=i686-unknown-linux-musl CC_X=clang FEATURES_X= MODE_X=RELWITHDEBINFO KCOV=0 RUST_X=beta
       rust: beta
@@ -677,7 +672,6 @@ matrix:
         apt:
           packages:
             - gcc-multilib
-            - libc6-dev-i386
 
     - env: TARGET_X=arm-unknown-linux-gnueabihf CC_X=arm-linux-gnueabihf-gcc FEATURES_X= MODE_X=DEBUG KCOV=0 RUST_X=beta
       rust: beta

--- a/mk/update-travis-yml.py
+++ b/mk/update-travis-yml.py
@@ -164,7 +164,7 @@ def format_entry(os, target, compiler, rust, mode, features):
         return [prefix + x for x in xs]
 
     if sys == "linux":
-        packages = sorted(get_linux_packages_to_install(target, compiler, arch, kcov))
+        packages = sorted(get_linux_packages_to_install(target, compiler, arch, abi, kcov))
         template += """
       dist: %s""" % linux_dist
 
@@ -195,7 +195,7 @@ def format_entry(os, target, compiler, rust, mode, features):
             "os" : os,
             }
 
-def get_linux_packages_to_install(target, compiler, arch, kcov):
+def get_linux_packages_to_install(target, compiler, arch, abi, kcov):
     if compiler.startswith("clang-") or compiler.startswith("gcc-"):
         packages = [compiler]
     else:
@@ -221,11 +221,13 @@ def get_linux_packages_to_install(target, compiler, arch, kcov):
 
     if arch == "i686":
         if compiler.startswith("clang") or compiler == "":
-            packages += ["libc6-dev-i386",
-                         "gcc-multilib"]
+            packages += ["gcc-multilib"]
+            if abi == "gnu":
+                packages += ["libc6-dev-i386"]
         elif compiler.startswith("gcc-"):
-            packages += [compiler + "-multilib",
-                         "linux-libc-dev:i386"]
+            packages += [compiler + "-multilib"]
+            if abi == "gnu":
+                packages += ["linux-libc-dev:i386"]
         else:
             raise ValueError("unexpected compiler: %s" % compiler)
 


### PR DESCRIPTION
We shouldn't be using system libaries when using musl libc so don't
install them.