### PR TITLE
CI/CD: Test wasm32-unknown-unknown in GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           - i686-unknown-linux-gnu
           - i686-unknown-linux-musl
           - x86_64-unknown-linux-musl
+
     steps:
       - uses: actions/checkout@v2
 
@@ -106,7 +107,6 @@ jobs:
           - beta
           - nightly
         target:
-          - wasm32-unknown-unknown
           - aarch64-linux-android
           - armv7-linux-androideabi
     steps:
@@ -130,12 +130,12 @@ jobs:
           CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi18-clang \
           cargo test -vv --no-run --target=${{ matrix.target }} ${{ matrix.features }} ${{ matrix.mode }}
 
-  # Verify that the the "wasm32_c" configuration builds.
-  build-cross-wasm32-c:
+  test-cross-wasm32-c:
     runs-on: ${{ matrix.host_os }}
     strategy:
       matrix:
         features:
+          - # Default
           - --features=wasm32_c
         host_os:
           - ubuntu-18.04
@@ -148,7 +148,9 @@ jobs:
           - nightly
         target:
           - wasm32-unknown-unknown
-
+        webdriver:
+          - GECKODRIVER=geckodriver
+          - CHROMEDRIVER=chromedriver
     steps:
       - uses: actions/checkout@v2
 
@@ -165,9 +167,10 @@ jobs:
           # feature is enabled.
           CC_wasm32_unknown_unknown: clang-10
           AR_wasm32_unknown_unknown: llvm-ar-10
+          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
         # TODO: Collect the resultant artifacts and/or run the tests.
         run: |
-          cargo test -vv --no-run --target=${{ matrix.target }} ${{ matrix.features }} ${{ matrix.mode }}
+          ${{ matrix.webdriver }} cargo test -vv --target=${{ matrix.target }} ${{ matrix.features }} ${{ matrix.mode }}
 
   build-cross-apple:
     runs-on: ${{ matrix.host_os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ web-sys = { version = "0.3.37", default-features = false, features = ["Crypto", 
 winapi = { version = "0.3.8", default-features = false, features = ["ntsecapi", "wtypesbase"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.10", default-features = false }
+wasm-bindgen-test = { version = "0.3.18", default-features = false }
 
 [target.'cfg(any(unix, windows))'.dev-dependencies]
 libc = { version = "0.2.69", default-features = false }

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -55,6 +55,7 @@ case $target in
     libc6-dev-i386
   ;;
 --target=wasm32-unknown-unknown)
+  cargo install wasm-bindgen-cli --vers "0.2.68" --bin wasm-bindgen-test-runner
   case ${features-} in
     *wasm32_c*)
       # "wasm_c" has only been tested with clang-10 and llvm-ar-10. The build


### PR DESCRIPTION
Bump the wasm-bindgen-test dependency version to be compatible with
the latest wasm-bindgen-cli version.