### PR TITLE
Clean up and fix .gitattributes files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,7 @@
 * text=auto !eol
-*.sln eol=crlf
-*.vcxproj eol=crlf
-*.vcxproj.filters eol=crlf
-*.props eol=crlf
-*.bat eol=crlf
-*.rc eol=crlf
-*.pl linguist-language=Assembly
+crypto/**/*.pl linguist-language=Assembly
+crypto/perlasm/*.pl linguist-language=Perl
 *.bin binary
 *.der binary
+**/*.h linguist-language=C
+**/*.inl linguist-language=C

--- a/crypto/.gitattributes
+++ b/crypto/.gitattributes
@@ -1,1 +1,0 @@
-*.h linguist-language=C

--- a/crypto/fipsmodule/.gitattributes
+++ b/crypto/fipsmodule/.gitattributes
@@ -1,1 +1,0 @@
-*.inl linguist-language=C

--- a/crypto/perlasm/.gitattributes
+++ b/crypto/perlasm/.gitattributes
@@ -1,2 +1,0 @@
-*.pl linguist-language=Perl
-

--- a/include/GFp/.gitattributes
+++ b/include/GFp/.gitattributes
@@ -1,1 +1,0 @@
-*.h linguist-language=C


### PR DESCRIPTION
GitHub is reporting some include files as C++ instead of C, and it is reporting
some .pl files as Perl instead of Assembly. Attempt to fix that.

Remove superfluous entries in ./.gitattributes and consolidate some of the
.gitattributes files into ./.gitattributes.