### PR TITLE
Build: Move wasm32-unknown-unknown support to cargo.sh.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,12 +199,5 @@ jobs:
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust_channel }}
 
-      - env:
-          # The first two are only needed for for wasm32 targets only, only
-          # when the "wasm_c" feature is enabled.
-          CC_wasm32_unknown_unknown: clang-10
-          AR_wasm32_unknown_unknown: llvm-ar-10
-          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
-        # TODO: Collect the resultant artifacts and/or run the tests.
-        run: |
-          ${{ matrix.webdriver }} cargo test -vv --target=${{ matrix.target }} ${{ matrix.features }} ${{ matrix.mode }}
+      - run: |
+          ${{ matrix.webdriver }} mk/cargo.sh test -vv --target=${{ matrix.target }} ${{ matrix.features }} ${{ matrix.mode }}

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -43,4 +43,9 @@ export CARGO_TARGET_i686_UNKNOWN_LINUX_MUSL_LINKER=clang
 export CC_x86_64_unknown_linux_musl=clang
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=clang
 
+# The first two are only needed for when the "wasm_c" feature is enabled.
+export CC_wasm32_unknown_unknown=clang-10
+export AR_wasm32_unknown_unknown=llvm-ar-10
+export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner
+
 cargo "$@"


### PR DESCRIPTION
Make it easier to build and test the wasm32-unknown-unknown target locally.