### PR TITLE
Chacha20: Move AAarch64 NEON dispatching logic to Rust.

### DIFF
--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -37,10 +37,13 @@ pub static CHACHA20_POLY1305: aead::Algorithm = aead::Algorithm {
 /// Copies |key| into |ctx_buf|.
 fn chacha20_poly1305_init(
     key: &[u8],
-    _todo: cpu::Features,
+    cpu_features: cpu::Features,
 ) -> Result<aead::KeyInner, error::Unspecified> {
     let key: [u8; chacha::KEY_LEN] = key.try_into()?;
-    Ok(aead::KeyInner::ChaCha20Poly1305(chacha::Key::from(key)))
+    Ok(aead::KeyInner::ChaCha20Poly1305(chacha::Key::new(
+        key,
+        cpu_features,
+    )))
 }
 
 fn chacha20_poly1305_seal(
@@ -71,7 +74,7 @@ fn chacha20_poly1305_open(
     )
 }
 
-pub type Key = chacha::Key;
+pub(super) type Key = chacha::Key;
 
 #[inline(always)] // Statically eliminate branches on `direction`.
 fn aead(

--- a/src/aead/chacha20_poly1305_openssh.rs
+++ b/src/aead/chacha20_poly1305_openssh.rs
@@ -158,8 +158,8 @@ impl Key {
         let k_1: [u8; chacha::KEY_LEN] = k_1.try_into().unwrap();
         let k_2: [u8; chacha::KEY_LEN] = k_2.try_into().unwrap();
         Key {
-            k_1: chacha::Key::from(k_1),
-            k_2: chacha::Key::from(k_2),
+            k_1: chacha::Key::new(k_1, cpu_features),
+            k_2: chacha::Key::new(k_2, cpu_features),
             cpu_features,
         }
     }

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -60,13 +60,13 @@ macro_rules! dispatch {
         match () {
             // Apple's 32-bit ARM ABI is incompatible with the assembly code.
             #[cfg(all(target_arch = "arm", not(target_vendor = "apple")))]
-            () if cpu::arm::NEON.available($features) => {
+            _ if cpu::arm::NEON.available($features) => {
                 extern "C" {
                     fn $neon_f( $( $p : $t ),+ );
                 }
                 unsafe { $neon_f( $( $a ),+ ) }
             }
-            () => {
+            _ => {
                 extern "C" {
                     fn $f( $( $p : $t ),+ );
                 }

--- a/src/aead/quic.rs
+++ b/src/aead/quic.rs
@@ -171,9 +171,12 @@ pub static CHACHA20: Algorithm = Algorithm {
     id: AlgorithmID::CHACHA20,
 };
 
-fn chacha20_init(key: &[u8], _todo: cpu::Features) -> Result<KeyInner, error::Unspecified> {
+fn chacha20_init(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, error::Unspecified> {
     let chacha20_key: [u8; chacha::KEY_LEN] = key.try_into()?;
-    Ok(KeyInner::ChaCha20(chacha::Key::from(chacha20_key)))
+    Ok(KeyInner::ChaCha20(chacha::Key::new(
+        chacha20_key,
+        cpu_features,
+    )))
 }
 
 fn chacha20_new_mask(key: &KeyInner, sample: Sample) -> [u8; 5] {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -209,9 +209,9 @@ pub(crate) mod arm {
     }
 
     // Keep in sync with `ARMV7_NEON`.
-    #[cfg(all(
-        any(target_arch = "aarch64", target_arch = "arm"),
-        not(target_os = "ios")
+    #[cfg(any(
+        target_arch = "aarch64",
+        all(target_arch = "arm", not(target_vendor = "apple"))
     ))]
     pub(crate) const NEON: Feature = Feature {
         mask: 1 << 0,


### PR DESCRIPTION
Move away from using `GFp_armcap_P`, starting with the AAarch64 code. A similar change has already been made to the Poly1305 code for AAarch64.

After AAarch64 is done, the dispatching logic for other targets will likely be changed similarly.