### PR TITLE
cpu.rs: Clarify conditions under which runtime CPU feature detection is done.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,7 +300,7 @@ name = "ring"
 [dependencies]
 untrusted = { version = "0.7.1" }
 
-[target.'cfg(all(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86", target_arch = "x86_64"), not(target_os = "ios")))'.dependencies]
+[target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux"))))'.dependencies]
 spin = { version = "0.5.2", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]


### PR DESCRIPTION
Clarify that, on ARM/Aarch64, runtime feature detection is done only for Linux (including Android) and Fuchsia. Reduce some of the duplication between Linux and Fuchsia; probably we should do more later.