### PR TITLE
Add support for aarch64-apple-darwin.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
 
         target:
           - aarch64-apple-ios
+          - aarch64-apple-darwin
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu
           - arm-unknown-linux-gnueabihf
@@ -110,10 +111,25 @@ jobs:
           - beta
           - nightly
 
+        exclude:
+          # The stable channel doesn't have aarch64-apple-darwin support yet.
+          - target: aarch64-apple-darwin
+            rust_channel: stable
+
+          # The beta channel doesn't have aarch64-apple-darwin support yet.
+          - target: aarch64-apple-darwin
+            rust_channel: beta
+
         include:
+          - target: aarch64-apple-darwin
+            # macos-latest didn't work.
+            host_os: macos-11.0
+            # GitHub Actions doesn't have a way to run this target yet.
+            cargo_options: --no-run
+
           - target: aarch64-apple-ios
             host_os: macos-latest
-            # GitHub Actions doesn't have a way to run aarch64-apple-ios.
+            # GitHub Actions doesn't have a way to run this target yet.
             cargo_options: --no-run
 
           - target: aarch64-linux-android
@@ -172,6 +188,9 @@ jobs:
           override: true
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust_channel }}
+
+      - if: ${{ matrix.target == 'aarch64-apple-darwin' }}
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_12.2.app/Contents/Developer" >> $GITHUB_ENV
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |

--- a/build.rs
+++ b/build.rs
@@ -237,6 +237,7 @@ const ASM_TARGETS: &[(&str, Option<&str>, Option<&str>)] = &[
     ("x86_64", Some(WINDOWS), Some("nasm")),
     ("x86_64", None, Some("elf")),
     ("aarch64", Some("ios"), Some("ios64")),
+    ("aarch64", Some("macos"), Some("ios64")),
     ("aarch64", None, Some("linux64")),
     ("x86", Some(WINDOWS), Some("win32n")),
     ("x86", Some("ios"), Some("macosx")),


### PR DESCRIPTION
Change the static CPU feature detection logic to assume all aarch64-apple-* targets
have the same capabilities as far as the features we use are concerned.

Use the "ios64" PerlAsm flavour for aarch64-apple-darwin, like OpenSSL upstream does.

Add (build-only) cross-compilation jobs to GitHub Actions.