### PR TITLE
Upgrade to spin 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,7 +300,7 @@ name = "ring"
 untrusted = { version = "0.7.1" }
 
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux"))))'.dependencies]
-spin = { version = "0.5.2", default-features = false }
+spin = { version = "0.7.0", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.69", default-features = false }


### PR DESCRIPTION
This moves *ring* to the most up-to-date, maintained, version of `spin-rs`. 

Closes https://github.com/briansmith/ring/issues/1076 and https://github.com/briansmith/ring/issues/921