### PR TITLE
Bump some minimum required dependency versions to better support aarch64-apple-darwin.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,7 @@ winapi = { version = "0.3.8", default-features = false, features = ["ntsecapi", 
 wasm-bindgen-test = { version = "0.3.18", default-features = false }
 
 [target.'cfg(any(unix, windows))'.dev-dependencies]
-libc = { version = "0.2.69", default-features = false }
+libc = { version = "0.2.80", default-features = false }
 
 # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,7 +322,7 @@ libc = { version = "0.2.69", default-features = false }
 
 # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
 [build-dependencies]
-cc = { version = "1.0.52", default-features = false }
+cc = { version = "1.0.62", default-features = false }
 
 [features]
 # These features are documented in the top-level module's documentation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ spin = { version = "0.5.2", default-features = false }
 libc = { version = "0.2.69", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris", target_os = "illumos"))'.dependencies]
-once_cell = { version = "1.3.1", default-features = false, features=["std"], optional = true }
+once_cell = { version = "1.5.2", default-features = false, features=["std"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
 web-sys = { version = "0.3.37", default-features = false, features = ["Crypto", "Window"] }


### PR DESCRIPTION
According to https://github.com/shepmaster/rust/blob/silicon/silicon/README.md#porting-notes, newever versions of `libc` and `cc` in particular have better support for aarch64-apple-darwin.