### PR TITLE
Fix linker errors when *ring* is incorporated into a (32-bit Android) ARM shared library.

### DIFF
--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -197,6 +197,8 @@ $code.=<<___;
 .Lone:
 .long	1,0,0,0
 #if __ARM_MAX_ARCH__>=7
+.extern GFp_armcap_P
+.hidden GFp_armcap_P
 .LOPENSSL_armcap:
 .word   GFp_armcap_P-.LChaCha20_ctr32
 #else

--- a/crypto/fipsmodule/bn/asm/armv4-mont.pl
+++ b/crypto/fipsmodule/bn/asm/armv4-mont.pl
@@ -112,6 +112,8 @@ $code=<<___;
 #endif
 
 #if __ARM_MAX_ARCH__>=7
+.extern GFp_armcap_P
+.hidden GFp_armcap_P
 .align	5
 .LOPENSSL_armcap:
 .word	GFp_armcap_P-.Lbn_mul_mont

--- a/crypto/fipsmodule/sha/asm/sha256-armv4.pl
+++ b/crypto/fipsmodule/sha/asm/sha256-armv4.pl
@@ -218,6 +218,8 @@ K256:
 .size	K256,.-K256
 .word	0				@ terminator
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
+.extern GFp_armcap_P
+.hidden GFp_armcap_P
 .LOPENSSL_armcap:
 .word	GFp_armcap_P-.Lsha256_block_data_order
 #endif

--- a/crypto/fipsmodule/sha/asm/sha512-armv4.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-armv4.pl
@@ -278,6 +278,8 @@ WORD64(0x4cc5d4be,0xcb3e42b6, 0x597f299c,0xfc657e2a)
 WORD64(0x5fcb6fab,0x3ad6faec, 0x6c44198c,0x4a475817)
 .size	K512,.-K512
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
+.extern GFp_armcap_P
+.hidden GFp_armcap_P
 .LOPENSSL_armcap:
 .word	GFp_armcap_P-.Lsha512_block_data_order
 .skip	32-4

--- a/crypto/fipsmodule/sha/asm/sha512-armv8.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-armv8.pl
@@ -179,6 +179,7 @@ $code.=<<___;
 .text
 
 .extern	GFp_armcap_P
+.hidden GFp_armcap_P
 .globl	$func
 .type	$func,%function
 .align	6


### PR DESCRIPTION
commit 8a90093cccf60bd2aaf582fe7e56c0b0eff9b002 regressed the ability to incorporate *ring* into a 32-bit ARM shared library, on 32-bit Android at least.

The symbol needs to be declared `.protected`. Not all assemblers (notably, Apple's) understand `.protected`, so use `.hidden`, which implies `.protected`.

Additionally explicitly declare them as `.extern` even though this isn't required by the assembler.