### PR TITLE
Remove definitions of deprecated `Error::description()` and `Error::cause()`.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -76,30 +76,15 @@ extern crate std;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Unspecified;
 
-impl Unspecified {
-    fn description_() -> &'static str {
-        "ring::error::Unspecified"
-    }
-}
-
 // This is required for the implementation of `std::error::Error`.
 impl core::fmt::Display for Unspecified {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.write_str(Self::description_())
+        f.write_str("ring::error::Unspecified")
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Unspecified {
-    #[inline]
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        Self::description_()
-    }
-}
+impl std::error::Error for Unspecified {}
 
 impl From<untrusted::EndOfInput> for Unspecified {
     fn from(_: untrusted::EndOfInput) -> Self {
@@ -115,10 +100,10 @@ impl From<core::array::TryFromSliceError> for Unspecified {
 
 /// An error parsing or validating a key.
 ///
-/// The `Display` implementation and `<KeyRejected as Error>::description()`
-/// will return a string that will help you better understand why a key was
-/// rejected change which errors are reported in which situations while
-/// minimizing the likelihood that any applications will be broken.
+/// The `Display` implementation will return a string that will help you better
+/// understand why a key was rejected change which errors are reported in which
+/// situations while minimizing the likelihood that any applications will be
+/// broken.
 ///
 /// Here is an incomplete list of reasons a key may be unsupported:
 ///
@@ -147,11 +132,6 @@ impl From<core::array::TryFromSliceError> for Unspecified {
 pub struct KeyRejected(&'static str);
 
 impl KeyRejected {
-    /// The value returned from <Self as std::error::Error>::description()
-    pub fn description_(&self) -> &'static str {
-        self.0
-    }
-
     pub(crate) fn inconsistent_components() -> Self {
         KeyRejected("InconsistentComponents")
     }
@@ -203,19 +183,11 @@ impl KeyRejected {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for KeyRejected {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        self.description_()
-    }
-}
+impl std::error::Error for KeyRejected {}
 
 impl core::fmt::Display for KeyRejected {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.write_str(self.description_())
+        f.write_str(self.0)
     }
 }
 

--- a/tests/ed25519_tests.rs
+++ b/tests/ed25519_tests.rs
@@ -126,7 +126,7 @@ fn test_ed25519_from_pkcs8_unchecked() {
                 (Ok(_), None) => (),
                 (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),
                 (Ok(_), Some(e)) => panic!("Succeeded, but expected error \"{}\"", e),
-                (Err(actual), Some(expected)) => assert_eq!(actual.description_(), expected),
+                (Err(actual), Some(expected)) => assert_eq!(format!("{}", actual), expected),
             };
 
             Ok(())
@@ -148,7 +148,7 @@ fn test_ed25519_from_pkcs8() {
                 (Ok(_), None) => (),
                 (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),
                 (Ok(_), Some(e)) => panic!("Succeeded, but expected error \"{}\"", e),
-                (Err(actual), Some(expected)) => assert_eq!(actual.description_(), expected),
+                (Err(actual), Some(expected)) => assert_eq!(format!("{}", actual), expected),
             };
 
             Ok(())


### PR DESCRIPTION
This was reverted in PR #1108 because it broke backward compatibility.