### PR TITLE
Improve support for *-*-linux-musl* targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,10 @@ jobs:
           - aarch64-apple-darwin
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
           - arm-unknown-linux-gnueabihf
           - armv7-linux-androideabi
+          - armv7-unknown-linux-musleabihf
           - i686-pc-windows-msvc
           - i686-unknown-linux-gnu
           - i686-unknown-linux-musl
@@ -140,12 +142,20 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             host_os: ubuntu-18.04
 
+          - target: aarch64-unknown-linux-musl
+            host_os: ubuntu-18.04
+
           - target: arm-unknown-linux-gnueabihf
             host_os: ubuntu-18.04
 
           - target: armv7-linux-androideabi
             host_os: ubuntu-18.04
             # TODO: https://github.com/briansmith/ring/issues/838
+            cargo_options: --no-run
+
+          - target: armv7-unknown-linux-musleabihf
+            host_os: ubuntu-18.04
+            # TODO: https://github.com/briansmith/ring/issues/1115
             cargo_options: --no-run
 
           - target: i686-pc-windows-msvc

--- a/README.md
+++ b/README.md
@@ -204,24 +204,25 @@ and release configurations, for the current release of each Rust channel
 parts of *ring*; *ring* should be compatible with GCC 4.8+, Clang 10+, and MSVC
 2019+, at least.
 
-| Target                       | Notes |
-| -----------------------------| ----- |
-| aarch64-apple-darwin         | Build-only (GitHub Actions doesn't have a way to run the tests)
-| aarch64-apple-ios            | Build-only (GitHub Actions doesn't have a way to run the tests)
-| aarch64-unknown-linux-gnu    | Tested on 64-bit Linux using QEMU user emulation
-| aarch64-linux-android        | API level 21 (Android 5.0+); [Build-only; issue 486](https://github.com/briansmith/ring/issues/486)
-| arm-unknown-linux-gnueabihf  | Tested on 64-bit Linux using QEMU user emulation
-| armv7-linux-androideabi      | API level 18 (Android 4.3+); [Build-only; issue 838](https://github.com/briansmith/ring/issues/838)
-| i686-pc-windows-msvc         | Tested on 64-bit Windows Server 2019 Datacenter
-| i686-unknown-linux-gnu       | Tested on 64-bit Linux using multilib support
-| i686-unknown-linux-musl      | [Needs more work; issue 713](https://github.com/briansmith/ring/issues/713)
-| x86_64-apple-darwin          |
-| x86_64-pc-windows-gnu        |
-| x86_64-pc-windows-msvc       | Tested on 64-bit Windows Server 2019 Datacenter
-| x86_64-unknown-linux-gnu     |
-| x86_64-unknown-linux-musl    | [Needs more work; issue 713](https://github.com/briansmith/ring/issues/713)
-| wasm32-unknown-unknown       | Tested using wasm-bindgen-test-runner on Linux in Chrome and Firefox.
-
+| Target                         | Notes |
+| -------------------------------| ----- |
+| aarch64-apple-darwin           | Build-only (GitHub Actions doesn't have a way to run the tests)
+| aarch64-apple-ios              | Build-only (GitHub Actions doesn't have a way to run the tests)
+| aarch64-unknown-linux-gnu      | Tested on 64-bit Linux using QEMU user emulation
+| aarch64-unknown-linux-musl     | Tested on 64-bit Linux using QEMU user emulation. [Needs more work; issue 713](https://github.com/briansmith/ring/issues/713)
+| aarch64-linux-android          | API level 21 (Android 5.0+); [Build-only; issue 486](https://github.com/briansmith/ring/issues/486)
+| arm-unknown-linux-gnueabihf    | Tested on 64-bit Linux using QEMU user emulation
+| armv7-linux-androideabi        | API level 18 (Android 4.3+); [Build-only; issue 838](https://github.com/briansmith/ring/issues/838)
+| armv7-unknown-linux-musleabihf | Tested on 64-bit Linux using QEMU user emulation. [Needs more work; issue 713](https://github.com/briansmith/ring/issues/713)
+| i686-pc-windows-msvc           | Tested on 64-bit Windows Server 2019 Datacenter
+| i686-unknown-linux-gnu         | Tested on 64-bit Linux using multilib support
+| i686-unknown-linux-musl        | Tested on 64-bit Linux using multilib support. [Needs more work; issue 713](https://github.com/briansmith/ring/issues/713)
+| x86_64-apple-darwin            |
+| x86_64-pc-windows-gnu          |
+| x86_64-pc-windows-msvc         | Tested on 64-bit Windows Server 2019 Datacenter
+| x86_64-unknown-linux-gnu       |
+| x86_64-unknown-linux-musl      | [Needs more work; issue 713](https://github.com/briansmith/ring/issues/713)
+| wasm32-unknown-unknown         | Tested using wasm-bindgen-test-runner on Linux in Chrome and Firefox.
 
 License
 -------

--- a/build.rs
+++ b/build.rs
@@ -603,6 +603,7 @@ fn cc(
             // TODO: Expand this to non-clang compilers in 0.17.0 if practical.
             if compiler.is_like_clang() {
                 let _ = c.flag("-nostdlibinc");
+                let _ = c.define("GFp_NOSTDLIBINC", "1");
             }
         }
     }

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -259,22 +259,12 @@ static inline uint32_t CRYPTO_bswap4(uint32_t x) {
 }
 #endif
 
-// Assume we have <string.h> unless we can detect otherwise. The
-// targets that don't have string.h do have `__has_include`.
-#define GFp_HAS_STRING_H
-
-#if defined(__has_include)
-# if !__has_include(<string.h>)
-#  undef GFp_HAS_STRING_H
-# endif
-#endif
-
-#if defined(GFp_HAS_STRING_H)
+#if !defined(GFp_NOSTDLIBINC)
 #include <string.h>
 #endif
 
 static inline void *GFp_memcpy(void *dst, const void *src, size_t n) {
-#if defined(GFp_HAS_STRING_H)
+#if !defined(GFp_NOSTDLIBINC)
   if (n == 0) {
     return dst;
   }
@@ -290,7 +280,7 @@ static inline void *GFp_memcpy(void *dst, const void *src, size_t n) {
 }
 
 static inline void *GFp_memset(void *dst, int c, size_t n) {
-#if defined(GFp_HAS_STRING_H)
+#if !defined(GFp_NOSTDLIBINC)
   if (n == 0) {
     return dst;
   }

--- a/include/GFp/check.h
+++ b/include/GFp/check.h
@@ -17,12 +17,20 @@
 
 // |debug_assert_nonsecret| is like |assert| and should be used (only) when the
 // assertion does not have any potential to leak a secret. |NDEBUG| controls this
-// exactly like |assert|. It is emulated for WebAssembly so that <assert.h> is
-// not required for it.
+// exactly like |assert|. It is emulated when there is no assert.h to make
+// cross-building easier.
 //
 // When reviewing uses of |debug_assert_nonsecret|, verify that the check
 // really does not have potential to leak a secret.
-#if !defined(__wasm__)
+#define GFp_HAS_ASSERT_H
+
+#if defined(__has_include)
+# if !__has_include(<assert.h>)
+#  undef GFp_HAS_ASSERT_H
+# endif
+#endif
+
+#if defined(GFp_HAS_ASSERT_H)
 # include <assert.h>
 # define debug_assert_nonsecret(x) assert(x)
 #else

--- a/include/GFp/check.h
+++ b/include/GFp/check.h
@@ -22,15 +22,8 @@
 //
 // When reviewing uses of |debug_assert_nonsecret|, verify that the check
 // really does not have potential to leak a secret.
-#define GFp_HAS_ASSERT_H
 
-#if defined(__has_include)
-# if !__has_include(<assert.h>)
-#  undef GFp_HAS_ASSERT_H
-# endif
-#endif
-
-#if defined(GFp_HAS_ASSERT_H)
+#if !defined(GFp_NOSTDLIBINC)
 # include <assert.h>
 # define debug_assert_nonsecret(x) assert(x)
 #else

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -17,6 +17,10 @@
 set -eux -o pipefail
 IFS=$'\n\t'
 
+rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
+qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
+qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
+
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may
 # be needed to compile the build script, or to compile for other targets.
@@ -37,6 +41,12 @@ for arg in $*; do
       export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
       export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-aarch64 -L /usr/aarch64-linux-gnu"
       ;;
+    --target=aarch64-unknown-linux-musl)
+      export CC_aarch64_unknown_linux_musl=clang-10
+      export AR_aarch64_unknown_linux_musl=llvm-ar-10
+      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="$rustflags_self_contained"
+      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="$qemu_aarch64"
+      ;;
     --target=arm-unknown-linux-gnueabihf)
       export CC_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc
       export AR_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc-ar
@@ -47,6 +57,12 @@ for arg in $*; do
       export CC_armv7_linux_androideabi=$android_tools/armv7a-linux-androideabi18-clang
       export AR_armv7_linux_androideabi=$android_tools/arm-linux-androideabi-ar
       export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$android_tools/armv7a-linux-androideabi18-clang
+      ;;
+    --target=armv7-unknown-linux-musleabihf)
+      export CC_armv7_unknown_linux_musleabihf=clang-10
+      export AR_armv7_unknown_linux_musleabihf=llvm-ar-10
+      export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS="$rustflags_self_contained"
+      export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="$qemu_arm"
       ;;
     --target=i686-unknown-linux-gnu)
       export CC_i686_unknown_linux_gnu=clang-10

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -43,20 +43,24 @@ case $target in
     gcc-aarch64-linux-gnu \
     libc6-dev-arm64-cross
   ;;
+--target=aarch64-unknown-linux-musl|--target=armv7-unknown-linux-musleabihf)
+  use_clang=1
+  install_packages \
+    qemu-user
+  ;;
 --target=arm-unknown-linux-gnueabihf)
   install_packages \
     qemu-user \
     gcc-arm-linux-gnueabihf \
     libc6-dev-armhf-cross
   ;;
---target=i686-unknown-linux-gnu|--target=i686-unknown-linux-musl)
-  # TODO: musl i686 shouldn't be using gcc-multilib or libc6-dev-i386.
+--target=i686-unknown-linux-gnu)
   use_clang=1
   install_packages \
     gcc-multilib \
     libc6-dev-i386
   ;;
---target=x86_64-unknown-linux-musl)
+--target=i686-unknown-linux-musl|--target=x86_64-unknown-linux-musl)
   use_clang=1
   ;;
 --target=wasm32-unknown-unknown)


### PR DESCRIPTION
Allow building for *-*-linux-musl* targets without having the musl C sysroot (headers, etc.) available, and without abusing the glibc sysroot, except temporarily for X86_64.

Add aarch64-linux-musl and armv7-unknown-linux-musleabihf targets to GitHub Actions.

More discussion about remaining work will be in issue #713.  See the individual commit messages and contents for more details.