### PR TITLE
Fix BSD `--no-default-features` build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,9 +304,10 @@ spin = { version = "0.5.2", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.69", default-features = false }
-
-[target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris", target_os = "illumos"))'.dependencies]
 once_cell = { version = "1.5.2", default-features = false, features=["std"], optional = true }
+
+[target.'cfg(any(target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
+once_cell = { version = "1.5.2", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
 web-sys = { version = "0.3.37", default-features = false, features = ["Crypto", "Window"] }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -181,10 +181,10 @@ use self::sysrand_or_urandom::fill as fill_impl;
 
 #[cfg(any(
     target_os = "freebsd",
+    target_os = "illumos",
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris",
-    target_os = "illumos"
 ))]
 use self::urandom::fill as fill_impl;
 


### PR DESCRIPTION
`once_cell` is a required, not optional, dependency, on these platforms.