### PR TITLE
Fix another linker error for arm 32-bit Android

### DIFF
--- a/crypto/chacha/asm/chacha-armv8.pl
+++ b/crypto/chacha/asm/chacha-armv8.pl
@@ -123,6 +123,7 @@ $code.=<<___;
 #include <GFp/arm_arch.h>
 
 .extern	GFp_armcap_P
+.hidden	GFp_armcap_P
 
 .section .rodata
 


### PR DESCRIPTION
Similar error and fix as https://github.com/briansmith/ring/pull/1109
but for chacha-armv8.

Resolves error:
  = note: ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol GFp_armcap_P
; recompile with -fPIC
chacha-armv8-linux64.o:(GFp_ChaCha20_ctr32) in archive libring-core/android_arm64_armv8-a_static/libring-core.a