### PR TITLE
CI/CD: Enable building of aarch64-apple-darwin targets on Rust Beta.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,6 @@ jobs:
           - target: aarch64-apple-darwin
             rust_channel: stable
 
-          # The beta channel doesn't have aarch64-apple-darwin support yet.
-          - target: aarch64-apple-darwin
-            rust_channel: beta
-
         include:
           - target: aarch64-apple-darwin
             # macos-latest didn't work.


### PR DESCRIPTION
https://blog.rust-lang.org/2020/11/27/Rustup-1.23.0.html#support-for-apple-m1-devices
says that the beta channel supports M1 targets now.