### PR TITLE
CI/CD: Cache the cargo-deny binary to speed up the `deny` job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,12 @@ jobs:
           toolchain: stable
           profile: minimal
 
-      - run: cargo install cargo-deny
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cargo/bin/cargo-deny
+          key: ${{ runner.os }}-cargo-deny-0.8.4
+
+      - run: cargo install cargo-deny --vers "0.8.4"
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
`cargo install cargo-deny` takes 7 minutes, while running it takes 2 seconds.