### PR TITLE
CI/CD: Run `sudo apt-get update` before using `apt-get`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,9 @@ jobs:
             host_os: ubuntu-18.04
 
     steps:
+      - if: ${{ contains(matrix.host_os, 'ubuntu') }}
+        run: sudo apt-get update -y
+
       - uses: actions/checkout@v2
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
@@ -297,9 +300,13 @@ jobs:
           - CHROMEDRIVER=chromedriver
 
     steps:
+      - if: ${{ contains(matrix.host_os, 'ubuntu') }}
+        run: sudo apt-get update -y
+
       - uses: actions/checkout@v2
 
       - run: cargo generate-lockfile
+
       - run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
 
       - uses: actions-rs/toolchain@v1
@@ -358,6 +365,9 @@ jobs:
           # too.
 
     steps:
+      - if: ${{ contains(matrix.host_os, 'ubuntu') }}
+        run: sudo apt-get update -y
+
       - uses: actions/checkout@v2
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}


### PR DESCRIPTION
See https://github.com/actions/virtual-environments/issues/2155. This fixes
CI/CD jobs failing due to `apt-get` failing to download packages.