### PR TITLE
Vlad/chapoly aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ include = [
     "crypto/poly1305/poly1305_arm.c",
     "crypto/poly1305/poly1305_arm_asm.S",
     "crypto/poly1305/poly1305_vec.c",
+    "crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl",
     "doc/link-to-readme.md",
     "examples/checkdigest.rs",
     "include/GFp/aes.h",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ include = [
     "crypto/poly1305/poly1305_arm_asm.S",
     "crypto/poly1305/poly1305_vec.c",
     "crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl",
+    "crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl",
     "doc/link-to-readme.md",
     "examples/checkdigest.rs",
     "include/GFp/aes.h",

--- a/build.rs
+++ b/build.rs
@@ -85,6 +85,7 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[X86_64], "crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl"),
     (&[X86_64], "crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl"),
     (&[X86_64], "crypto/fipsmodule/modes/asm/ghash-x86_64.pl"),
+    (&[X86_64], "crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl"),
     (&[X86_64], "crypto/poly1305/poly1305_vec.c"),
     (&[X86_64], SHA512_X86_64),
 

--- a/build.rs
+++ b/build.rs
@@ -109,6 +109,7 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[AARCH64], "crypto/chacha/asm/chacha-armv8.pl"),
     (&[AARCH64], "crypto/fipsmodule/ec/asm/ecp_nistz256-armv8.pl"),
     (&[AARCH64], "crypto/fipsmodule/modes/asm/ghash-neon-armv8.pl"),
+    (&[AARCH64], "crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl"),
     (&[AARCH64], SHA512_ARMV8),
 ];
 

--- a/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
@@ -1,0 +1,1497 @@
+#!/usr/bin/env perl
+
+# Copyright (c) 2020, CloudFlare Ltd.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+# OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+
+##############################################################################
+#                                                                            #
+# Author:  Vlad Krasnov                                                      #
+#                                                                            #
+##############################################################################
+
+$flavour = shift;
+while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+
+$0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
+( $xlate="${dir}arm-xlate.pl" and -f $xlate ) or
+( $xlate="${dir}../../perlasm/arm-xlate.pl" and -f $xlate) or
+die "can't locate arm-xlate.pl";
+
+open OUT,"| \"$^X\" $xlate $flavour $output";
+*STDOUT=*OUT;
+
+my ($oup,$inl,$adp,$adl,$keyp,$itr1,$itr2,$inp) = ("x0","x1","x2","x3","x4","x5","x6","x7");
+my ($acc0,$acc1,$acc2) = map("x$_",(8..10));
+my ($t0,$t1,$t2,$t3) = map("x$_",(11..14));
+my ($one, $r0, $r1) = ("x15","x16","x17");
+my ($t0w) = $t0 =~ s/x/w/r;
+
+my ($A0,$A1,$A2,$A3,$A4,$B0,$B1,$B2,$B3,$B4,$C0,$C1,$C2,$C3,$C4,$D0,$D1,$D2,$D3,$D4) = map("v$_",(0..19));
+my ($T0,$T1,$T2,$T3) = map("v$_",(20..23));
+
+my $CONSTS = "v24";
+my $INC = "v25";
+my $ROL8 = "v26";
+my $CLAMP = "v27";
+
+my ($B_STORE, $C_STORE, $D_STORE) = map("v$_",(28..30));
+
+my $S_STORE = $CLAMP;
+my $LEN_STORE = "v31";
+
+sub chacha_qr {
+my ($a,$b,$c,$d,$t,$dir)=@_;
+my ($shift_b,$shift_d) = $dir =~ /left/ ? ("#4","#12") : ("#12","#4");
+$code.=<<___;
+    add   $a.4s, $a.4s, $b.4s
+    eor   $d.16b, $d.16b, $a.16b
+    rev32 $d.8h, $d.8h
+
+    add   $c.4s, $c.4s, $d.4s
+    eor   $b.16b, $b.16b, $c.16b
+    ushr  $t.4s, $b.4s, #20
+    sli   $t.4s, $b.4s, #12
+___
+    ($t,$b) = ($b,$t);
+$code.=<<___;
+    add   $a.4s, $a.4s, $b.4s
+    eor   $d.16b, $d.16b, $a.16b
+    tbl   $d.16b, {$d.16b}, $ROL8.16b
+
+    add   $c.4s, $c.4s, $d.4s
+    eor   $b.16b, $b.16b, $c.16b
+    ushr  $t.4s, $b.4s, #25
+    sli   $t.4s, $b.4s, #7
+___
+    ($t,$b) = ($b,$t);
+$code.=<<___;
+    ext $b.16b, $b.16b, $b.16b, $shift_b
+    ext $c.16b, $c.16b, $c.16b, #8
+    ext $d.16b, $d.16b, $d.16b, $shift_d
+___
+}
+
+
+sub poly_add {
+my ($src)=@_;
+$code.="ldp  $t0, $t1, [$src], 16
+        adds $acc0, $acc0, $t0
+        adcs $acc1, $acc1, $t1
+        adc  $acc2, $acc2, $one\n";
+}
+
+sub poly_add_vec {
+my ($src)=@_;
+$code.="mov  $t0, $src.d[0]
+        mov  $t1, $src.d[1]
+        adds $acc0, $acc0, $t0
+        adcs $acc1, $acc1, $t1
+        adc  $acc2, $acc2, $one\n";
+}
+
+sub poly_stage1 {
+$code.="mul   $t0, $acc0, $r0     // [t2:t1:t0] = [acc2:acc1:acc0] * r0
+        umulh $t1, $acc0, $r0
+        mul   $t2, $acc1, $r0
+        umulh $t3, $acc1, $r0
+        adds  $t1, $t1, $t2
+        mul   $t2, $acc2, $r0
+        adc   $t2, $t2, $t3\n";
+}
+
+sub poly_stage2 {
+$code.="mul   $t3, $acc0, $r1       // [t3:t2:t1:t0] = [acc2:acc1:acc0] * [r1:r0]
+        umulh $acc0, $acc0, $r1
+        adds  $t1, $t1, $t3
+        mul   $t3, $acc1, $r1
+        umulh $acc1, $acc1, $r1
+        adcs  $t3, $t3, $acc0
+        mul   $acc2, $acc2, $r1
+        adc   $acc2, $acc2, $acc1
+        adds  $t2, $t2, $t3
+        adc   $t3, $acc2, xzr\n";
+}
+
+
+sub poly_reduce_stage {
+$code.="and  $acc2, $t2, #3
+        and  $acc0, $t2, #-4
+        extr $t2, $t3, $t2, #2
+        adds $acc0, $acc0, $t0
+        adcs $acc1, $t1, $t3
+        lsr  $t3, $t3, #2
+        adc  $acc2, $acc2, xzr
+        adds $acc0, $acc0, $t2
+        adcs $acc1, $acc1, $t3
+        adc  $acc2, $acc2, xzr\n";
+}
+
+sub poly_mul {
+    &poly_stage1();
+    &poly_stage2();
+    &poly_reduce_stage();
+}
+
+sub chacha_qr_x3 {
+my ($dir)=@_;
+my ($shift_b,$shift_d) = $dir =~ /left/ ? ("#4","#12") : ("#12","#4");
+$code.=<<___;
+    add   $A0.4s, $A0.4s, $B0.4s
+    add   $A1.4s, $A1.4s, $B1.4s
+    add   $A2.4s, $A2.4s, $B2.4s
+    eor   $D0.16b, $D0.16b, $A0.16b
+    eor   $D1.16b, $D1.16b, $A1.16b
+    eor   $D2.16b, $D2.16b, $A2.16b
+    rev32 $D0.8h, $D0.8h
+    rev32 $D1.8h, $D1.8h
+    rev32 $D2.8h, $D2.8h
+
+    add   $C0.4s, $C0.4s, $D0.4s
+    add   $C1.4s, $C1.4s, $D1.4s
+    add   $C2.4s, $C2.4s, $D2.4s
+    eor   $B0.16b, $B0.16b, $C0.16b
+    eor   $B1.16b, $B1.16b, $C1.16b
+    eor   $B2.16b, $B2.16b, $C2.16b
+    ushr  $T0.4s, $B0.4s, #20
+    sli   $T0.4s, $B0.4s, #12
+    ushr  $B0.4s, $B1.4s, #20
+    sli   $B0.4s, $B1.4s, #12
+    ushr  $B1.4s, $B2.4s, #20
+    sli   $B1.4s, $B2.4s, #12
+
+    add   $A0.4s, $A0.4s, $T0.4s
+    add   $A1.4s, $A1.4s, $B0.4s
+    add   $A2.4s, $A2.4s, $B1.4s
+    eor   $D0.16b, $D0.16b, $A0.16b
+    eor   $D1.16b, $D1.16b, $A1.16b
+    eor   $D2.16b, $D2.16b, $A2.16b
+    tbl   $D0.16b, {$D0.16b}, $ROL8.16b
+    tbl   $D1.16b, {$D1.16b}, $ROL8.16b
+    tbl   $D2.16b, {$D2.16b}, $ROL8.16b
+
+    add   $C0.4s, $C0.4s, $D0.4s
+    add   $C1.4s, $C1.4s, $D1.4s
+    add   $C2.4s, $C2.4s, $D2.4s
+    eor   $T0.16b, $T0.16b, $C0.16b
+    eor   $B0.16b, $B0.16b, $C1.16b
+    eor   $B1.16b, $B1.16b, $C2.16b
+    ushr  $B2.4s, $B1.4s, #25
+    sli   $B2.4s, $B1.4s, #7
+    ushr  $B1.4s, $B0.4s, #25
+    sli   $B1.4s, $B0.4s, #7
+    ushr  $B0.4s, $T0.4s, #25
+    sli   $B0.4s, $T0.4s, #7
+
+    ext $B0.16b, $B0.16b, $B0.16b, $shift_b
+    ext $B1.16b, $B1.16b, $B1.16b, $shift_b
+    ext $B2.16b, $B2.16b, $B2.16b, $shift_b
+
+    ext $C0.16b, $C0.16b, $C0.16b, #8
+    ext $C1.16b, $C1.16b, $C1.16b, #8
+    ext $C2.16b, $C2.16b, $C2.16b, #8
+
+    ext $D0.16b, $D0.16b, $D0.16b, $shift_d
+    ext $D1.16b, $D1.16b, $D1.16b, $shift_d
+    ext $D2.16b, $D2.16b, $D2.16b, $shift_d
+___
+}
+
+# When preparing 5 ChaCha20 blocks in parallel, we operate on 4 blocks vertically as introduced by Andrew Moon
+# the fifth block is done horizontally
+sub chacha_qr_x5 {
+my ($dir)=@_;
+my ($a0,$a1,$a2,$a3) = $dir =~ /left/ ? ($A0,$A1,$A2,$A3) : ($A0,$A1,$A2,$A3);
+my ($b0,$b1,$b2,$b3) = $dir =~ /left/ ? ($B0,$B1,$B2,$B3) : ($B1,$B2,$B3,$B0);
+my ($c0,$c1,$c2,$c3) = $dir =~ /left/ ? ($C0,$C1,$C2,$C3) : ($C2,$C3,$C0,$C1);
+my ($d0,$d1,$d2,$d3) = $dir =~ /left/ ? ($D0,$D1,$D2,$D3) : ($D3,$D0,$D1,$D2);
+my ($shift_b,$shift_d) = $dir =~ /left/ ? ("#4","#12") : ("#12","#4");
+$code.=<<___;
+    add   $a0.4s, $a0.4s, $b0.4s
+    add   $a1.4s, $a1.4s, $b1.4s
+    add   $a2.4s, $a2.4s, $b2.4s
+    add   $a3.4s, $a3.4s, $b3.4s
+    add   $A4.4s, $A4.4s, $B4.4s
+
+    eor   $d0.16b, $d0.16b, $a0.16b
+    eor   $d1.16b, $d1.16b, $a1.16b
+    eor   $d2.16b, $d2.16b, $a2.16b
+    eor   $d3.16b, $d3.16b, $a3.16b
+    eor   $D4.16b, $D4.16b, $A4.16b
+
+    rev32 $d0.8h, $d0.8h
+    rev32 $d1.8h, $d1.8h
+    rev32 $d2.8h, $d2.8h
+    rev32 $d3.8h, $d3.8h
+    rev32 $D4.8h, $D4.8h
+
+    add   $c0.4s, $c0.4s, $d0.4s
+    add   $c1.4s, $c1.4s, $d1.4s
+    add   $c2.4s, $c2.4s, $d2.4s
+    add   $c3.4s, $c3.4s, $d3.4s
+    add   $C4.4s, $C4.4s, $D4.4s
+
+    eor   $b0.16b, $b0.16b, $c0.16b
+    eor   $b1.16b, $b1.16b, $c1.16b
+    eor   $b2.16b, $b2.16b, $c2.16b
+    eor   $b3.16b, $b3.16b, $c3.16b
+    eor   $B4.16b, $B4.16b, $C4.16b
+
+    ushr  $T0.4s, $b0.4s, #20
+    sli   $T0.4s, $b0.4s, #12
+    ushr  $b0.4s, $b1.4s, #20
+    sli   $b0.4s, $b1.4s, #12
+    ushr  $b1.4s, $b2.4s, #20
+    sli   $b1.4s, $b2.4s, #12
+    ushr  $b2.4s, $b3.4s, #20
+    sli   $b2.4s, $b3.4s, #12
+    ushr  $b3.4s, $B4.4s, #20
+    sli   $b3.4s, $B4.4s, #12
+
+    add   $a0.4s, $a0.4s, $T0.4s
+    add   $a1.4s, $a1.4s, $b0.4s
+    add   $a2.4s, $a2.4s, $b1.4s
+    add   $a3.4s, $a3.4s, $b2.4s
+    add   $A4.4s, $A4.4s, $b3.4s
+
+    eor   $d0.16b, $d0.16b, $a0.16b
+    eor   $d1.16b, $d1.16b, $a1.16b
+    eor   $d2.16b, $d2.16b, $a2.16b
+    eor   $d3.16b, $d3.16b, $a3.16b
+    eor   $D4.16b, $D4.16b, $A4.16b
+
+    tbl   $d0.16b, {$d0.16b}, $ROL8.16b
+    tbl   $d1.16b, {$d1.16b}, $ROL8.16b
+    tbl   $d2.16b, {$d2.16b}, $ROL8.16b
+    tbl   $d3.16b, {$d3.16b}, $ROL8.16b
+    tbl   $D4.16b, {$D4.16b}, $ROL8.16b
+
+    add   $c0.4s, $c0.4s, $d0.4s
+    add   $c1.4s, $c1.4s, $d1.4s
+    add   $c2.4s, $c2.4s, $d2.4s
+    add   $c3.4s, $c3.4s, $d3.4s
+    add   $C4.4s, $C4.4s, $D4.4s
+
+    eor   $T0.16b, $T0.16b, $c0.16b
+    eor   $b0.16b, $b0.16b, $c1.16b
+    eor   $b1.16b, $b1.16b, $c2.16b
+    eor   $b2.16b, $b2.16b, $c3.16b
+    eor   $b3.16b, $b3.16b, $C4.16b
+
+    ushr  $B4.4s, $b3.4s, #25
+    sli   $B4.4s, $b3.4s, #7
+    ushr  $b3.4s, $b2.4s, #25
+    sli   $b3.4s, $b2.4s, #7
+    ushr  $b2.4s, $b1.4s, #25
+    sli   $b2.4s, $b1.4s, #7
+    ushr  $b1.4s, $b0.4s, #25
+    sli   $b1.4s, $b0.4s, #7
+    ushr  $b0.4s, $T0.4s, #25
+    sli   $b0.4s, $T0.4s, #7
+
+    ext $B4.16b, $B4.16b, $B4.16b, $shift_b
+    ext $C4.16b, $C4.16b, $C4.16b, #8
+    ext $D4.16b, $D4.16b, $D4.16b, $shift_d
+___
+}
+
+{
+$code.=<<___;
+.align 4
+.Lchacha20_consts:
+.byte 'e','x','p','a','n','d',' ','3','2','-','b','y','t','e',' ','k'
+.Linc:
+.long 1,2,3,4
+.Lrol8:
+.byte 3,0,1,2, 7,4,5,6, 11,8,9,10, 15,12,13,14
+.Lclamp:
+.quad 0x0FFFFFFC0FFFFFFF, 0x0FFFFFFC0FFFFFFC
+
+.type	.Lpoly_hash_ad_internal,%function
+.align	6
+.Lpoly_hash_ad_internal:
+    cmp $adl, #16
+    b.lt .Lpoly_hash_ad_tail
+___
+        &poly_add($adp);
+        &poly_mul();
+$code.=<<___;
+        sub $adl, $adl, #16
+        b .Lpoly_hash_ad_internal
+
+.Lpoly_hash_ad_tail:
+    cbz $adl, .Lpoly_hash_ad_ret
+
+    eor $T0.16b, $T0.16b, $T0.16b // Use T0 to load the AAD
+    subs $adl, $adl, #1
+
+.Lpoly_hash_tail_16_compose:
+        ext  $T0.16b, $T0.16b, $T0.16b, #15
+        ldrb $t0w, [$adp, $adl]
+        mov  $T0.b[0], $t0w
+        subs $adl, $adl, #1
+        b.ge .Lpoly_hash_tail_16_compose
+___
+    &poly_add_vec($T0);
+    &poly_mul();
+$code.=<<___;
+
+.Lpoly_hash_ad_ret:
+    ret $itr2
+.size .Lpoly_hash_ad_internal, .-.Lpoly_hash_ad_internal
+
+/////////////////////////////////
+//
+// void GFp_chacha20_poly1305_seal(uint8_t *in_out, size_t len_in, uint8_t *ad, size_t len_ad, uint8_t keyp[48]);
+//
+.globl	GFp_chacha20_poly1305_seal
+.type	GFp_chacha20_poly1305_seal,%function
+.align	6
+GFp_chacha20_poly1305_seal:
+
+    adr $t0, .Lchacha20_consts
+    ld1 {$CONSTS.16b - $CLAMP.16b}, [$t0] // Load the CONSTS, INC, ROL8 and CLAMP values
+    ld1 {$B_STORE.16b - $D_STORE.16b}, [$keyp]
+
+    mov $one, #1 // Prepare the Poly1305 state
+    mov $acc0, #0
+    mov $acc1, #0
+    mov $acc2, #0
+
+    mov $LEN_STORE.d[0], $adl  // Store the input and aad lengths
+    mov $LEN_STORE.d[1], $inl
+
+    cmp $inl, #128
+    b.le .Lseal_128 // Optimization for smaller buffers
+
+    // Initially we prepare 5 ChaCha20 blocks. One for the Poly1305 R and S keys
+    // and four to encrypt up to 4 blocks (256 bytes) of plaintext
+    // The first four blocks (A0-A3..D0-D3) are computed vertically, the fifth block (A4-D4) horizontally
+    ld4r {$A0.4s-$A3.4s}, [$t0]
+    mov $A4.16b, $CONSTS.16b
+
+    ld4r {$B0.4s-$B3.4s}, [$keyp], #16
+    mov $B4.16b, $B_STORE.16b
+
+    ld4r {$C0.4s-$C3.4s}, [$keyp], #16
+    mov $C4.16b, $C_STORE.16b
+
+    ld4r {$D0.4s-$D3.4s}, [$keyp], #16
+    add $D0.4s, $D0.4s, $INC.4s
+    mov $D4.16b, $D_STORE.16b
+
+    sub $keyp, $keyp, #48
+
+    mov  $itr1, #10
+
+.align 5
+.Lseal_init_rounds:
+___
+        &chacha_qr_x5("left");
+        &chacha_qr_x5("right");
+$code.=<<___;
+        subs $itr1, $itr1, #1
+    b.hi .Lseal_init_rounds
+
+    add $D0.4s, $D0.4s, $INC.4s
+    mov $t0, #4
+    dup $T0.4s, $t0w
+    add $INC.4s, $INC.4s, $T0.4s
+
+    zip1 $T0.4s, $A0.4s, $A1.4s
+    zip2 $T1.4s, $A0.4s, $A1.4s
+    zip1 $T2.4s, $A2.4s, $A3.4s
+    zip2 $T3.4s, $A2.4s, $A3.4s
+
+    zip1 $A0.2d, $T0.2d, $T2.2d
+    zip2 $A1.2d, $T0.2d, $T2.2d
+    zip1 $A2.2d, $T1.2d, $T3.2d
+    zip2 $A3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $B0.4s, $B1.4s
+    zip2 $T1.4s, $B0.4s, $B1.4s
+    zip1 $T2.4s, $B2.4s, $B3.4s
+    zip2 $T3.4s, $B2.4s, $B3.4s
+
+    zip1 $B0.2d, $T0.2d, $T2.2d
+    zip2 $B1.2d, $T0.2d, $T2.2d
+    zip1 $B2.2d, $T1.2d, $T3.2d
+    zip2 $B3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $C0.4s, $C1.4s
+    zip2 $T1.4s, $C0.4s, $C1.4s
+    zip1 $T2.4s, $C2.4s, $C3.4s
+    zip2 $T3.4s, $C2.4s, $C3.4s
+
+    zip1 $C0.2d, $T0.2d, $T2.2d
+    zip2 $C1.2d, $T0.2d, $T2.2d
+    zip1 $C2.2d, $T1.2d, $T3.2d
+    zip2 $C3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $D0.4s, $D1.4s
+    zip2 $T1.4s, $D0.4s, $D1.4s
+    zip1 $T2.4s, $D2.4s, $D3.4s
+    zip2 $T3.4s, $D2.4s, $D3.4s
+
+    zip1 $D0.2d, $T0.2d, $T2.2d
+    zip2 $D1.2d, $T0.2d, $T2.2d
+    zip1 $D2.2d, $T1.2d, $T3.2d
+    zip2 $D3.2d, $T1.2d, $T3.2d
+
+    add $A4.4s, $A4.4s, $CONSTS.4s
+    add $B4.4s, $B4.4s, $B_STORE.4s
+    and $A4.16b, $A4.16b, $CLAMP.16b
+
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $B0.4s, $B0.4s, $B_STORE.4s
+    add $C0.4s, $C0.4s, $C_STORE.4s
+    add $D0.4s, $D0.4s, $D_STORE.4s
+
+    add $A1.4s, $A1.4s, $CONSTS.4s
+    add $B1.4s, $B1.4s, $B_STORE.4s
+    add $C1.4s, $C1.4s, $C_STORE.4s
+    add $D1.4s, $D1.4s, $D_STORE.4s
+
+    add $A2.4s, $A2.4s, $CONSTS.4s
+    add $B2.4s, $B2.4s, $B_STORE.4s
+    add $C2.4s, $C2.4s, $C_STORE.4s
+    add $D2.4s, $D2.4s, $D_STORE.4s
+
+    add $A3.4s, $A3.4s, $CONSTS.4s
+    add $B3.4s, $B3.4s, $B_STORE.4s
+    add $C3.4s, $C3.4s, $C_STORE.4s
+    add $D3.4s, $D3.4s, $D_STORE.4s
+
+    mov $r0, $A4.d[0] // Move the R key to GPRs
+    mov $r1, $A4.d[1]
+    mov $S_STORE.16b, $B4.16b // Store the S key
+    mov $inp, $oup
+
+    adr  $itr2, .Lseal_ad_done
+    cbnz $adl, .Lpoly_hash_ad_internal
+.Lseal_ad_done:
+
+    cmp $inl, #256
+    b.le .Lseal_tail
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A0.16b
+    eor $T1.16b, $T1.16b, $B0.16b
+    eor $T2.16b, $T2.16b, $C0.16b
+    eor $T3.16b, $T3.16b, $D0.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A1.16b
+    eor $T1.16b, $T1.16b, $B1.16b
+    eor $T2.16b, $T2.16b, $C1.16b
+    eor $T3.16b, $T3.16b, $D1.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A2.16b
+    eor $T1.16b, $T1.16b, $B2.16b
+    eor $T2.16b, $T2.16b, $C2.16b
+    eor $T3.16b, $T3.16b, $D2.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A3.16b
+    eor $T1.16b, $T1.16b, $B3.16b
+    eor $T2.16b, $T2.16b, $C3.16b
+    eor $T3.16b, $T3.16b, $D3.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    sub $inl, $inl, #256
+
+    mov $itr1, #4 // In the first run of the loop we need to hash 256 bytes, therefore we hash one block for the first 4 rounds
+    mov $itr2, #6 // and two blocks for the remaining 6, for a total of (1 * 4 + 2 * 6) * 16 = 256
+
+.Lseal_main_loop:
+    adr $t0, .Lchacha20_consts
+
+    ld4r {$A0.4s-$A3.4s}, [$t0]
+    mov $A4.16b, $CONSTS.16b
+
+    ld4r {$B0.4s-$B3.4s}, [$keyp], #16
+    mov $B4.16b, $B_STORE.16b
+
+    ld4r {$C0.4s-$C3.4s}, [$keyp], #16
+    mov $C4.16b, $C_STORE.16b
+
+    ld4r {$D0.4s-$D3.4s}, [$keyp], #16
+    add $D0.4s, $D0.4s, $INC.4s
+    mov $D4.16b, $D_STORE.16b
+
+    eor $T0.16b, $T0.16b, $T0.16b //zero
+    not $T1.16b, $T0.16b // -1
+    sub $T1.4s, $INC.4s, $T1.4s // Add +1
+    ext $T0.16b, $T1.16b, $T0.16b, #12 // Get the last element (counter)
+    add $D4.4s, $D4.4s, $T0.4s
+
+    sub $keyp, $keyp, #48
+.align 5
+.Lseal_main_loop_rounds:
+___
+        &chacha_qr_x5("left");
+        &poly_add($oup);
+        &poly_mul();
+        &chacha_qr_x5("right");
+$code.=<<___;
+        subs $itr1, $itr1, #1
+        b.ge .Lseal_main_loop_rounds
+___
+        &poly_add($oup);
+        &poly_mul();
+$code.=<<___;
+        subs $itr2, $itr2, #1
+        b.gt .Lseal_main_loop_rounds
+
+    eor $T0.16b, $T0.16b, $T0.16b //zero
+    not $T1.16b, $T0.16b // -1
+    sub $T1.4s, $INC.4s, $T1.4s // Add +1
+    ext $T0.16b, $T1.16b, $T0.16b, #12 // Get the last element (counter)
+    add $D4.4s, $D4.4s, $T0.4s
+
+    add $D0.4s, $D0.4s, $INC.4s
+    mov $t0, #5
+    dup $T0.4s, $t0w
+    add $INC.4s, $INC.4s, $T0.4s
+
+    zip1 $T0.4s, $A0.4s, $A1.4s
+    zip2 $T1.4s, $A0.4s, $A1.4s
+    zip1 $T2.4s, $A2.4s, $A3.4s
+    zip2 $T3.4s, $A2.4s, $A3.4s
+
+    zip1 $A0.2d, $T0.2d, $T2.2d
+    zip2 $A1.2d, $T0.2d, $T2.2d
+    zip1 $A2.2d, $T1.2d, $T3.2d
+    zip2 $A3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $B0.4s, $B1.4s
+    zip2 $T1.4s, $B0.4s, $B1.4s
+    zip1 $T2.4s, $B2.4s, $B3.4s
+    zip2 $T3.4s, $B2.4s, $B3.4s
+
+    zip1 $B0.2d, $T0.2d, $T2.2d
+    zip2 $B1.2d, $T0.2d, $T2.2d
+    zip1 $B2.2d, $T1.2d, $T3.2d
+    zip2 $B3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $C0.4s, $C1.4s
+    zip2 $T1.4s, $C0.4s, $C1.4s
+    zip1 $T2.4s, $C2.4s, $C3.4s
+    zip2 $T3.4s, $C2.4s, $C3.4s
+
+    zip1 $C0.2d, $T0.2d, $T2.2d
+    zip2 $C1.2d, $T0.2d, $T2.2d
+    zip1 $C2.2d, $T1.2d, $T3.2d
+    zip2 $C3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $D0.4s, $D1.4s
+    zip2 $T1.4s, $D0.4s, $D1.4s
+    zip1 $T2.4s, $D2.4s, $D3.4s
+    zip2 $T3.4s, $D2.4s, $D3.4s
+
+    zip1 $D0.2d, $T0.2d, $T2.2d
+    zip2 $D1.2d, $T0.2d, $T2.2d
+    zip1 $D2.2d, $T1.2d, $T3.2d
+    zip2 $D3.2d, $T1.2d, $T3.2d
+
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $B0.4s, $B0.4s, $B_STORE.4s
+    add $C0.4s, $C0.4s, $C_STORE.4s
+    add $D0.4s, $D0.4s, $D_STORE.4s
+
+    add $A1.4s, $A1.4s, $CONSTS.4s
+    add $B1.4s, $B1.4s, $B_STORE.4s
+    add $C1.4s, $C1.4s, $C_STORE.4s
+    add $D1.4s, $D1.4s, $D_STORE.4s
+
+    add $A2.4s, $A2.4s, $CONSTS.4s
+    add $B2.4s, $B2.4s, $B_STORE.4s
+    add $C2.4s, $C2.4s, $C_STORE.4s
+    add $D2.4s, $D2.4s, $D_STORE.4s
+
+    add $A3.4s, $A3.4s, $CONSTS.4s
+    add $B3.4s, $B3.4s, $B_STORE.4s
+    add $C3.4s, $C3.4s, $C_STORE.4s
+    add $D3.4s, $D3.4s, $D_STORE.4s
+
+    add $A4.4s, $A4.4s, $CONSTS.4s
+    add $B4.4s, $B4.4s, $B_STORE.4s
+    add $C4.4s, $C4.4s, $C_STORE.4s
+    add $D4.4s, $D4.4s, $D_STORE.4s
+
+    cmp $inl, #320
+    b.le .Lseal_tail
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A0.16b
+    eor $T1.16b, $T1.16b, $B0.16b
+    eor $T2.16b, $T2.16b, $C0.16b
+    eor $T3.16b, $T3.16b, $D0.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A1.16b
+    eor $T1.16b, $T1.16b, $B1.16b
+    eor $T2.16b, $T2.16b, $C1.16b
+    eor $T3.16b, $T3.16b, $D1.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A2.16b
+    eor $T1.16b, $T1.16b, $B2.16b
+    eor $T2.16b, $T2.16b, $C2.16b
+    eor $T3.16b, $T3.16b, $D2.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A3.16b
+    eor $T1.16b, $T1.16b, $B3.16b
+    eor $T2.16b, $T2.16b, $C3.16b
+    eor $T3.16b, $T3.16b, $D3.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A4.16b
+    eor $T1.16b, $T1.16b, $B4.16b
+    eor $T2.16b, $T2.16b, $C4.16b
+    eor $T3.16b, $T3.16b, $D4.16b
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    sub $inl, $inl, #320
+
+    mov $itr1, #0
+    mov $itr2, #10 // For the remainder of the loop we always hash and encrypt 320 bytes per iteration
+
+    b .Lseal_main_loop
+
+.Lseal_tail:
+    // This part of the function handles the storate and authentication of the last [0,320) bytes
+    // We assume A0-A4 ... D0-D4 hold the 320 bytes of stream data
+    cmp $inl, #64
+    b.lt .Lseal_tail_64
+
+    // Store and authenticate 64B blocks per iteration
+    ld1 {$T0.16b - $T3.16b}, [$inp]
+
+    eor $T0.16b, $T0.16b, $A0.16b
+    eor $T1.16b, $T1.16b, $B0.16b
+    eor $T2.16b, $T2.16b, $C0.16b
+    eor $T3.16b, $T3.16b, $D0.16b
+___
+    &poly_add_vec($T0);
+    &poly_mul();
+    &poly_add_vec($T1);
+    &poly_mul();
+    &poly_add_vec($T2);
+    &poly_mul();
+    &poly_add_vec($T3);
+    &poly_mul();
+$code.=<<___;
+    st1 {$T0.16b - $T3.16b}, [$inp], #64
+    sub $inl, $inl, #64
+
+    // Shift the state left by 64 bytes for the next interation of the loop
+    mov $A0.16b, $A1.16b
+    mov $B0.16b, $B1.16b
+    mov $C0.16b, $C1.16b
+    mov $D0.16b, $D1.16b
+
+    mov $A1.16b, $A2.16b
+    mov $B1.16b, $B2.16b
+    mov $C1.16b, $C2.16b
+    mov $D1.16b, $D2.16b
+
+    mov $A2.16b, $A3.16b
+    mov $B2.16b, $B3.16b
+    mov $C2.16b, $C3.16b
+    mov $D2.16b, $D3.16b
+
+    mov $A3.16b, $A4.16b
+    mov $B3.16b, $B4.16b
+    mov $C3.16b, $C4.16b
+    mov $D3.16b, $D4.16b
+
+    b .Lseal_tail
+
+.Lseal_tail_64:
+    // Here we handle the last [0,64) bytes of plaintext
+    cmp $inl, #16
+    b.lt .Lseal_tail_16
+    // Each iteration encrypt and authenticate a 16B block
+    ld1 {$T0.16b}, [$inp]
+    eor $T0.16b, $T0.16b, $A0.16b
+___
+    &poly_add_vec($T0);
+    &poly_mul();
+$code.=<<___;
+    st1 {$T0.16b}, [$inp], #16
+
+    sub $inl, $inl, #16
+
+    // Shift the state left by 16 bytes for the next interation of the loop
+    mov $A0.16b, $B0.16b
+    mov $B0.16b, $C0.16b
+    mov $C0.16b, $D0.16b
+
+    b .Lseal_tail_64
+
+.Lseal_tail_16:
+    // Here we handle the last [0,16) bytes that require a padded block
+    cbz $inl, .Lseal_finalize
+
+    eor $T0.16b, $T0.16b, $T0.16b // Use T0 to load the plaintext
+    eor $T1.16b, $T1.16b, $T1.16b // Use T1 to generate an AND mask
+    not $T2.16b, $T0.16b
+
+    add $oup, $inp, $inl
+    mov $itr1, $inl
+
+.Lseal_tail_16_compose:
+    ext  $T0.16b, $T0.16b, $T0.16b, #15
+    ldrb $t0w, [$oup, #-1]!
+    mov  $T0.b[0], $t0w
+    ext  $T1.16b, $T2.16b, $T1.16b, #15
+    subs $inl, $inl, #1
+    b.gt .Lseal_tail_16_compose
+
+    and $A0.16b, $A0.16b, $T1.16b
+    eor $T0.16b, $T0.16b, $A0.16b
+    // Hash in the final padded block
+___
+    &poly_add_vec($T0);
+    &poly_mul();
+$code.=<<___;
+
+.Lseal_tail_16_store:
+    umov $t0w, $T0.b[0]
+    strb $t0w, [$inp], #1
+    ext  $T0.16b, $T0.16b, $T0.16b, #1
+    subs $itr1, $itr1, #1
+    b.gt .Lseal_tail_16_store
+
+.Lseal_finalize:
+___
+    &poly_add_vec($LEN_STORE);
+    &poly_mul();
+$code.=<<___;
+    # Final reduction step
+    sub  $t1, xzr, $one
+    orr  $t2, xzr, #3
+    subs $t0, $acc0, #-5
+    sbcs $t1, $acc1, $t1
+    sbcs $t2, $acc2, $t2
+    csel $acc0, $t0, $acc0, eq
+    csel $acc1, $t1, $acc1, eq
+    csel $acc2, $t2, $acc2, eq
+___
+    &poly_add_vec($S_STORE);
+$code.=<<___;
+
+    stp  $acc0, $acc1, [$keyp, #32]!
+    mov x0, $keyp
+
+	ret
+
+.Lseal_128:
+    // On some architectures preparing 5 blocks for small buffers is wasteful
+    eor $INC.16b, $INC.16b, $INC.16b
+    mov $t0, #1
+    mov $INC.s[0], $t0w
+    mov $A0.16b, $CONSTS.16b
+    mov $A1.16b, $CONSTS.16b
+    mov $A2.16b, $CONSTS.16b
+    mov $B0.16b, $B_STORE.16b
+    mov $B1.16b, $B_STORE.16b
+    mov $B2.16b, $B_STORE.16b
+    mov $C0.16b, $C_STORE.16b
+    mov $C1.16b, $C_STORE.16b
+    mov $C2.16b, $C_STORE.16b
+    mov $D2.16b, $D_STORE.16b
+    add $D0.4s, $D2.4s, $INC.4s
+    add $D1.4s, $D0.4s, $INC.4s
+
+    mov  $itr1, #10
+
+.Lseal_128_rounds:
+___
+        &chacha_qr_x3("left");
+        &chacha_qr_x3("right");
+$code.=<<___;
+        subs $itr1, $itr1, #1
+    b.hi .Lseal_128_rounds
+
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $A1.4s, $A1.4s, $CONSTS.4s
+    add $A2.4s, $A2.4s, $CONSTS.4s
+
+    add $B0.4s, $B0.4s, $B_STORE.4s
+    add $B1.4s, $B1.4s, $B_STORE.4s
+    add $B2.4s, $B2.4s, $B_STORE.4s
+
+    add $C0.4s, $C0.4s, $C_STORE.4s
+    add $C1.4s, $C1.4s, $C_STORE.4s
+
+    add $D_STORE.4s, $D_STORE.4s, $INC.4s
+    add $D0.4s, $D0.4s, $D_STORE.4s
+    add $D_STORE.4s, $D_STORE.4s, $INC.4s
+    add $D1.4s, $D1.4s, $D_STORE.4s
+
+    and $A2.16b, $A2.16b, $CLAMP.16b
+    mov $r0, $A2.d[0] // Move the R key to GPRs
+    mov $r1, $A2.d[1]
+    mov $S_STORE.16b, $B2.16b // Store the S key
+    mov $inp, $oup
+
+    adr $itr2, .Lseal_tail
+    cbnz $adl, .Lpoly_hash_ad_internal
+    b   .Lseal_tail
+.size	GFp_chacha20_poly1305_seal,.-GFp_chacha20_poly1305_seal
+
+
+/////////////////////////////////
+//
+// void GFp_chacha20_poly1305_open(uint8_t *in_out, size_t len_in, uint8_t *ad, size_t len_ad, uint8_t keyp[48], size_t out_offset);
+//
+.globl	GFp_chacha20_poly1305_open
+.type	GFp_chacha20_poly1305_open,%function
+.align	6
+GFp_chacha20_poly1305_open:
+
+    add $inp, $oup, x5
+
+    adr $t0, .Lchacha20_consts
+    ld1 {$CONSTS.16b - $CLAMP.16b}, [$t0] // Load the CONSTS, INC, ROL8 and CLAMP values
+    ld1 {$B_STORE.16b - $D_STORE.16b}, [$keyp]
+
+    mov $one, #1 // Prepare the Poly1305 state
+    mov $acc0, #0
+    mov $acc1, #0
+    mov $acc2, #0
+
+    mov $LEN_STORE.d[0], $adl  // Store the input and aad lengths
+    mov $LEN_STORE.d[1], $inl
+
+    cmp $inl, #128
+    b.le .Lopen_128 // Optimization for smaller buffers
+
+    // Initially we prepare a single ChaCha20 block for the Poly1305 R and S keys
+    mov $A0.16b, $CONSTS.16b
+    mov $B0.16b, $B_STORE.16b
+    mov $C0.16b, $C_STORE.16b
+    mov $D0.16b, $D_STORE.16b
+
+    mov  $itr1, #10
+
+.align 5
+.Lopen_init_rounds:
+___
+        &chacha_qr($A0, $B0, $C0, $D0, $T0, "left");
+        &chacha_qr($A0, $B0, $C0, $D0, $T0, "right");
+$code.=<<___;
+        subs $itr1, $itr1, #1
+    b.hi .Lopen_init_rounds
+
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $B0.4s, $B0.4s, $B_STORE.4s
+
+    and $A0.16b, $A0.16b, $CLAMP.16b
+    mov $r0, $A0.d[0] // Move the R key to GPRs
+    mov $r1, $A0.d[1]
+    mov $S_STORE.16b, $B0.16b // Store the S key
+
+    adr  $itr2, .Lopen_ad_done
+    cbnz $adl, .Lpoly_hash_ad_internal
+
+.Lopen_ad_done:
+    mov $adp, $inp
+
+// Each iteration of the loop hash 320 bytes, and prepare stream for 320 bytes
+.Lopen_main_loop:
+
+    cmp $inl, #192
+    b.lt .Lopen_tail
+
+    adr $t0, .Lchacha20_consts
+    ld4r {$A0.4s-$A3.4s}, [$t0]
+    mov $A4.16b, $CONSTS.16b
+
+    ld4r {$B0.4s-$B3.4s}, [$keyp], #16
+    mov $B4.16b, $B_STORE.16b
+
+    ld4r {$C0.4s-$C3.4s}, [$keyp], #16
+    mov $C4.16b, $C_STORE.16b
+
+    ld4r {$D0.4s-$D3.4s}, [$keyp]
+    sub $keyp, $keyp, #32
+    add $D0.4s, $D0.4s, $INC.4s
+    mov $D4.16b, $D_STORE.16b
+
+    eor $T0.16b, $T0.16b, $T0.16b //zero
+    not $T1.16b, $T0.16b // -1
+    sub $T1.4s, $INC.4s, $T1.4s // Add +1
+    ext $T0.16b, $T1.16b, $T0.16b, #12 // Get the last element (counter)
+    add $D4.4s, $D4.4s, $T0.4s
+
+    lsr $adl, $inl, #4 // How many whole blocks we have to hash, will always be at least 12
+    sub $adl, $adl, #10
+
+    mov $itr2, #10
+    subs $itr1, $itr2, $adl
+    subs $itr1, $itr2, $adl // itr1 can be negative if we have more than 320 bytes to hash
+    csel $itr2, $itr2, $adl, le // if itr1 is zero or less, itr2 should be 10 to indicate all 10 rounds are full
+
+    cbz $itr2, .Lopen_main_loop_rounds_short
+
+.align 5
+.Lopen_main_loop_rounds:
+___
+        &poly_add($adp);
+        &poly_mul();
+$code.=<<___;
+.Lopen_main_loop_rounds_short:
+___
+        &chacha_qr_x5("left");
+        &poly_add($adp);
+        &poly_mul();
+        &chacha_qr_x5("right");
+$code.=<<___;
+        subs $itr2, $itr2, #1
+        b.gt .Lopen_main_loop_rounds
+        subs $itr1, $itr1, #1
+        b.ge .Lopen_main_loop_rounds_short
+___
+$code.=<<___;
+
+    eor $T0.16b, $T0.16b, $T0.16b //zero
+    not $T1.16b, $T0.16b // -1
+    sub $T1.4s, $INC.4s, $T1.4s // Add +1
+    ext $T0.16b, $T1.16b, $T0.16b, #12 // Get the last element (counter)
+    add $D4.4s, $D4.4s, $T0.4s
+
+    add $D0.4s, $D0.4s, $INC.4s
+    mov $t0, #5
+    dup $T0.4s, $t0w
+    add $INC.4s, $INC.4s, $T0.4s
+
+    zip1 $T0.4s, $A0.4s, $A1.4s
+    zip2 $T1.4s, $A0.4s, $A1.4s
+    zip1 $T2.4s, $A2.4s, $A3.4s
+    zip2 $T3.4s, $A2.4s, $A3.4s
+
+    zip1 $A0.2d, $T0.2d, $T2.2d
+    zip2 $A1.2d, $T0.2d, $T2.2d
+    zip1 $A2.2d, $T1.2d, $T3.2d
+    zip2 $A3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $B0.4s, $B1.4s
+    zip2 $T1.4s, $B0.4s, $B1.4s
+    zip1 $T2.4s, $B2.4s, $B3.4s
+    zip2 $T3.4s, $B2.4s, $B3.4s
+
+    zip1 $B0.2d, $T0.2d, $T2.2d
+    zip2 $B1.2d, $T0.2d, $T2.2d
+    zip1 $B2.2d, $T1.2d, $T3.2d
+    zip2 $B3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $C0.4s, $C1.4s
+    zip2 $T1.4s, $C0.4s, $C1.4s
+    zip1 $T2.4s, $C2.4s, $C3.4s
+    zip2 $T3.4s, $C2.4s, $C3.4s
+
+    zip1 $C0.2d, $T0.2d, $T2.2d
+    zip2 $C1.2d, $T0.2d, $T2.2d
+    zip1 $C2.2d, $T1.2d, $T3.2d
+    zip2 $C3.2d, $T1.2d, $T3.2d
+
+    zip1 $T0.4s, $D0.4s, $D1.4s
+    zip2 $T1.4s, $D0.4s, $D1.4s
+    zip1 $T2.4s, $D2.4s, $D3.4s
+    zip2 $T3.4s, $D2.4s, $D3.4s
+
+    zip1 $D0.2d, $T0.2d, $T2.2d
+    zip2 $D1.2d, $T0.2d, $T2.2d
+    zip1 $D2.2d, $T1.2d, $T3.2d
+    zip2 $D3.2d, $T1.2d, $T3.2d
+
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $B0.4s, $B0.4s, $B_STORE.4s
+    add $C0.4s, $C0.4s, $C_STORE.4s
+    add $D0.4s, $D0.4s, $D_STORE.4s
+
+    add $A1.4s, $A1.4s, $CONSTS.4s
+    add $B1.4s, $B1.4s, $B_STORE.4s
+    add $C1.4s, $C1.4s, $C_STORE.4s
+    add $D1.4s, $D1.4s, $D_STORE.4s
+
+    add $A2.4s, $A2.4s, $CONSTS.4s
+    add $B2.4s, $B2.4s, $B_STORE.4s
+    add $C2.4s, $C2.4s, $C_STORE.4s
+    add $D2.4s, $D2.4s, $D_STORE.4s
+
+    add $A3.4s, $A3.4s, $CONSTS.4s
+    add $B3.4s, $B3.4s, $B_STORE.4s
+    add $C3.4s, $C3.4s, $C_STORE.4s
+    add $D3.4s, $D3.4s, $D_STORE.4s
+
+    add $A4.4s, $A4.4s, $CONSTS.4s
+    add $B4.4s, $B4.4s, $B_STORE.4s
+    add $C4.4s, $C4.4s, $C_STORE.4s
+    add $D4.4s, $D4.4s, $D_STORE.4s
+
+    // We can always safely store 192 bytes
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+    eor $T0.16b, $T0.16b, $A0.16b
+    eor $T1.16b, $T1.16b, $B0.16b
+    eor $T2.16b, $T2.16b, $C0.16b
+    eor $T3.16b, $T3.16b, $D0.16b
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+    eor $T0.16b, $T0.16b, $A1.16b
+    eor $T1.16b, $T1.16b, $B1.16b
+    eor $T2.16b, $T2.16b, $C1.16b
+    eor $T3.16b, $T3.16b, $D1.16b
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+    eor $T0.16b, $T0.16b, $A2.16b
+    eor $T1.16b, $T1.16b, $B2.16b
+    eor $T2.16b, $T2.16b, $C2.16b
+    eor $T3.16b, $T3.16b, $D2.16b
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+
+    sub $inl, $inl, #192
+
+    mov $A0.16b, $A3.16b
+    mov $B0.16b, $B3.16b
+    mov $C0.16b, $C3.16b
+    mov $D0.16b, $D3.16b
+
+    cmp $inl, #64
+    b.lt .Lopen_tail_64_store
+
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+    eor $T0.16b, $T0.16b, $A3.16b
+    eor $T1.16b, $T1.16b, $B3.16b
+    eor $T2.16b, $T2.16b, $C3.16b
+    eor $T3.16b, $T3.16b, $D3.16b
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+
+    sub $inl, $inl, #64
+
+    mov $A0.16b, $A4.16b
+    mov $B0.16b, $B4.16b
+    mov $C0.16b, $C4.16b
+    mov $D0.16b, $D4.16b
+
+    cmp $inl, #64
+    b.lt .Lopen_tail_64_store
+
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+    eor $T0.16b, $T0.16b, $A4.16b
+    eor $T1.16b, $T1.16b, $B4.16b
+    eor $T2.16b, $T2.16b, $C4.16b
+    eor $T3.16b, $T3.16b, $D4.16b
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+
+    sub $inl, $inl, #64
+    b .Lopen_main_loop
+
+.Lopen_tail:
+
+    cbz $inl, .Lopen_finalize
+
+    lsr $adl, $inl, #4 // How many whole blocks we have to hash
+
+    cmp $inl, #64
+    b.le .Lopen_tail_64
+    cmp $inl, #128
+    b.le .Lopen_tail_128
+
+.Lopen_tail_192:
+     // We need three more blocks
+    mov $A0.16b, $CONSTS.16b
+    mov $A1.16b, $CONSTS.16b
+    mov $A2.16b, $CONSTS.16b
+    mov $B0.16b, $B_STORE.16b
+    mov $B1.16b, $B_STORE.16b
+    mov $B2.16b, $B_STORE.16b
+    mov $C0.16b, $C_STORE.16b
+    mov $C1.16b, $C_STORE.16b
+    mov $C2.16b, $C_STORE.16b
+    mov $D0.16b, $D_STORE.16b
+    mov $D1.16b, $D_STORE.16b
+    mov $D2.16b, $D_STORE.16b
+    eor $T3.16b, $T3.16b, $T3.16b
+    eor $T1.16b, $T1.16b, $T1.16b
+    ins $T3.s[0], $INC.s[0]
+    ins $T1.d[0], $one
+
+    add $T2.4s, $T3.4s, $T1.4s
+    add $T1.4s, $T2.4s, $T1.4s
+
+    add $D0.4s, $D0.4s, $T1.4s
+    add $D1.4s, $D1.4s, $T3.4s
+    add $D2.4s, $D2.4s, $T2.4s
+
+    mov $itr2, #10
+    subs $itr1, $itr2, $adl // itr1 can be negative if we have more than 160 bytes to hash
+    csel $itr2, $itr2, $adl, le // if itr1 is zero or less, itr2 should be 10 to indicate all 10 rounds are hashing
+    sub $adl, $adl, $itr2
+
+    cbz $itr2, .Lopen_tail_192_rounds_no_hash
+
+.Lopen_tail_192_rounds:
+___
+        &poly_add($adp);
+        &poly_mul();
+$code.=<<___;
+.Lopen_tail_192_rounds_no_hash:
+___
+        &chacha_qr_x3("left");
+        &chacha_qr_x3("right");
+$code.=<<___;
+        subs $itr2, $itr2, #1
+        b.gt .Lopen_tail_192_rounds
+        subs $itr1, $itr1, #1
+        b.ge .Lopen_tail_192_rounds_no_hash
+
+    // We hashed 160 bytes at most, may still have 32 bytes left
+.Lopen_tail_192_hash:
+    cbz $adl, .Lopen_tail_192_hash_done
+___
+        &poly_add($adp);
+        &poly_mul();
+$code.=<<___;
+    sub $adl, $adl, #1
+    b .Lopen_tail_192_hash
+
+.Lopen_tail_192_hash_done:
+
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $A1.4s, $A1.4s, $CONSTS.4s
+    add $A2.4s, $A2.4s, $CONSTS.4s
+    add $B0.4s, $B0.4s, $B_STORE.4s
+    add $B1.4s, $B1.4s, $B_STORE.4s
+    add $B2.4s, $B2.4s, $B_STORE.4s
+    add $C0.4s, $C0.4s, $C_STORE.4s
+    add $C1.4s, $C1.4s, $C_STORE.4s
+    add $C2.4s, $C2.4s, $C_STORE.4s
+    add $D0.4s, $D0.4s, $D_STORE.4s
+    add $D1.4s, $D1.4s, $D_STORE.4s
+    add $D2.4s, $D2.4s, $D_STORE.4s
+
+    add $D0.4s, $D0.4s, $T1.4s
+    add $D1.4s, $D1.4s, $T3.4s
+    add $D2.4s, $D2.4s, $T2.4s
+
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    eor $T0.16b, $T0.16b, $A1.16b
+    eor $T1.16b, $T1.16b, $B1.16b
+    eor $T2.16b, $T2.16b, $C1.16b
+    eor $T3.16b, $T3.16b, $D1.16b
+
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    eor $T0.16b, $T0.16b, $A2.16b
+    eor $T1.16b, $T1.16b, $B2.16b
+    eor $T2.16b, $T2.16b, $C2.16b
+    eor $T3.16b, $T3.16b, $D2.16b
+
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+
+    sub $inl, $inl, #128
+    b .Lopen_tail_64_store
+
+.Lopen_tail_128:
+     // We need two more blocks
+    mov $A0.16b, $CONSTS.16b
+    mov $A1.16b, $CONSTS.16b
+    mov $B0.16b, $B_STORE.16b
+    mov $B1.16b, $B_STORE.16b
+    mov $C0.16b, $C_STORE.16b
+    mov $C1.16b, $C_STORE.16b
+    mov $D0.16b, $D_STORE.16b
+    mov $D1.16b, $D_STORE.16b
+    eor $T3.16b, $T3.16b, $T3.16b
+    eor $T2.16b, $T2.16b, $T2.16b
+    ins $T3.s[0], $INC.s[0]
+    ins $T2.d[0], $one
+    add $T2.4s, $T2.4s, $T3.4s
+
+    add $D0.4s, $D0.4s, $T2.4s
+    add $D1.4s, $D1.4s, $T3.4s
+
+    mov $itr1, #10
+    sub $itr1, $itr1, $adl
+
+.Lopen_tail_128_rounds:
+___
+        &chacha_qr($A0, $B0, $C0, $D0, $T0, "left");
+        &chacha_qr($A1, $B1, $C1, $D1, $T0, "left");
+        &chacha_qr($A0, $B0, $C0, $D0, $T0, "right");
+        &chacha_qr($A1, $B1, $C1, $D1, $T0, "right");
+$code.=<<___;
+        subs $itr1, $itr1, #1
+        b.gt .Lopen_tail_128_rounds
+        cbz $adl, .Lopen_tail_128_rounds_done
+        subs $adl, $adl, #1
+___
+        &poly_add($adp);
+        &poly_mul();
+$code.=<<___;
+    b .Lopen_tail_128_rounds
+
+.Lopen_tail_128_rounds_done:
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $A1.4s, $A1.4s, $CONSTS.4s
+    add $B0.4s, $B0.4s, $B_STORE.4s
+    add $B1.4s, $B1.4s, $B_STORE.4s
+    add $C0.4s, $C0.4s, $C_STORE.4s
+    add $C1.4s, $C1.4s, $C_STORE.4s
+    add $D0.4s, $D0.4s, $D_STORE.4s
+    add $D1.4s, $D1.4s, $D_STORE.4s
+    add $D0.4s, $D0.4s, $T2.4s
+    add $D1.4s, $D1.4s, $T3.4s
+
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+
+    eor $T0.16b, $T0.16b, $A1.16b
+    eor $T1.16b, $T1.16b, $B1.16b
+    eor $T2.16b, $T2.16b, $C1.16b
+    eor $T3.16b, $T3.16b, $D1.16b
+
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+    sub $inl, $inl, #64
+
+    b .Lopen_tail_64_store
+
+.Lopen_tail_64:
+    // We just need a single block
+    mov $A0.16b, $CONSTS.16b
+    mov $B0.16b, $B_STORE.16b
+    mov $C0.16b, $C_STORE.16b
+    mov $D0.16b, $D_STORE.16b
+    eor $T3.16b, $T3.16b, $T3.16b
+    ins $T3.s[0], $INC.s[0]
+    add $D0.4s, $D0.4s, $T3.4s
+
+    mov $itr1, #10
+    sub $itr1, $itr1, $adl
+
+.Lopen_tail_64_rounds:
+___
+        &chacha_qr($A0, $B0, $C0, $D0, $T0, "left");
+        &chacha_qr($A0, $B0, $C0, $D0, $T0, "right");
+$code.=<<___;
+        subs $itr1, $itr1, #1
+        b.gt .Lopen_tail_64_rounds
+        cbz $adl, .Lopen_tail_64_rounds_done
+        subs $adl, $adl, #1
+___
+        &poly_add($adp);
+        &poly_mul();
+$code.=<<___;
+    b .Lopen_tail_64_rounds
+
+.Lopen_tail_64_rounds_done:
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $B0.4s, $B0.4s, $B_STORE.4s
+    add $C0.4s, $C0.4s, $C_STORE.4s
+    add $D0.4s, $D0.4s, $D_STORE.4s
+    add $D0.4s, $D0.4s, $T3.4s
+
+.Lopen_tail_64_store:
+    cmp $inl, #16
+    b.lt .Lopen_tail_16
+
+    ld1 {$T0.16b}, [$inp], #16
+    eor $T0.16b, $T0.16b, $A0.16b
+    st1 {$T0.16b}, [$oup], #16
+    mov $A0.16b, $B0.16b
+    mov $B0.16b, $C0.16b
+    mov $C0.16b, $D0.16b
+    sub $inl, $inl, #16
+    b .Lopen_tail_64_store
+
+.Lopen_tail_16:
+    // Here we handle the last [0,16) bytes that require a padded block
+    cbz $inl, .Lopen_finalize
+
+    eor $T0.16b, $T0.16b, $T0.16b // Use T0 to load the ciphertext
+    eor $T1.16b, $T1.16b, $T1.16b // Use T1 to generate an AND mask
+    not $T2.16b, $T0.16b
+
+    add $itr2, $inp, $inl
+    mov $itr1, $inl
+
+.Lopen_tail_16_compose:
+    ext  $T0.16b, $T0.16b, $T0.16b, #15
+    ldrb $t0w, [$itr2, #-1]!
+    mov  $T0.b[0], $t0w
+    ext  $T1.16b, $T2.16b, $T1.16b, #15
+    subs $inl, $inl, #1
+    b.gt .Lopen_tail_16_compose
+
+    and $T0.16b, $T0.16b, $T1.16b
+    // Hash in the final padded block
+___
+    &poly_add_vec($T0);
+    &poly_mul();
+$code.=<<___;
+    eor $T0.16b, $T0.16b, $A0.16b
+
+.Lopen_tail_16_store:
+    umov $t0w, $T0.b[0]
+    strb $t0w, [$oup], #1
+    ext  $T0.16b, $T0.16b, $T0.16b, #1
+    subs $itr1, $itr1, #1
+    b.gt .Lopen_tail_16_store
+
+.Lopen_finalize:
+___
+    &poly_add_vec($LEN_STORE);
+    &poly_mul();
+$code.=<<___;
+    # Final reduction step
+    sub  $t1, xzr, $one
+    orr  $t2, xzr, #3
+    subs $t0, $acc0, #-5
+    sbcs $t1, $acc1, $t1
+    sbcs $t2, $acc2, $t2
+    csel $acc0, $t0, $acc0, eq
+    csel $acc1, $t1, $acc1, eq
+    csel $acc2, $t2, $acc2, eq
+___
+    &poly_add_vec($S_STORE);
+$code.=<<___;
+
+    stp  $acc0, $acc1, [$keyp, #32]!
+    mov x0, $keyp
+
+    ret
+
+.Lopen_128:
+    // On some architectures preparing 5 blocks for small buffers is wasteful
+    eor $INC.16b, $INC.16b, $INC.16b
+    mov $t0, #1
+    mov $INC.s[0], $t0w
+    mov $A0.16b, $CONSTS.16b
+    mov $A1.16b, $CONSTS.16b
+    mov $A2.16b, $CONSTS.16b
+    mov $B0.16b, $B_STORE.16b
+    mov $B1.16b, $B_STORE.16b
+    mov $B2.16b, $B_STORE.16b
+    mov $C0.16b, $C_STORE.16b
+    mov $C1.16b, $C_STORE.16b
+    mov $C2.16b, $C_STORE.16b
+    mov $D2.16b, $D_STORE.16b
+    add $D0.4s, $D2.4s, $INC.4s
+    add $D1.4s, $D0.4s, $INC.4s
+
+    mov  $itr1, #10
+
+.Lopen_128_rounds:
+___
+        &chacha_qr_x3("left");
+        &chacha_qr_x3("right");
+$code.=<<___;
+        subs $itr1, $itr1, #1
+    b.hi .Lopen_128_rounds
+
+    add $A0.4s, $A0.4s, $CONSTS.4s
+    add $A1.4s, $A1.4s, $CONSTS.4s
+    add $A2.4s, $A2.4s, $CONSTS.4s
+
+    add $B0.4s, $B0.4s, $B_STORE.4s
+    add $B1.4s, $B1.4s, $B_STORE.4s
+    add $B2.4s, $B2.4s, $B_STORE.4s
+
+    add $C0.4s, $C0.4s, $C_STORE.4s
+    add $C1.4s, $C1.4s, $C_STORE.4s
+
+    add $D_STORE.4s, $D_STORE.4s, $INC.4s
+    add $D0.4s, $D0.4s, $D_STORE.4s
+    add $D_STORE.4s, $D_STORE.4s, $INC.4s
+    add $D1.4s, $D1.4s, $D_STORE.4s
+
+    and $A2.16b, $A2.16b, $CLAMP.16b
+    mov $r0, $A2.d[0] // Move the R key to GPRs
+    mov $r1, $A2.d[1]
+    mov $S_STORE.16b, $B2.16b // Store the S key
+
+    adr $itr2, .Lopen_128_store
+    cbnz $adl, .Lpoly_hash_ad_internal
+
+.Lopen_128_store:
+    cmp $inl, #64
+    b.lt .Lopen_128_store_64
+
+    ld1 {$T0.16b - $T3.16b}, [$inp], #64
+
+___
+    &poly_add_vec($T0);
+    &poly_mul();
+    &poly_add_vec($T1);
+    &poly_mul();
+    &poly_add_vec($T2);
+    &poly_mul();
+    &poly_add_vec($T3);
+    &poly_mul();
+$code.=<<___;
+
+    eor $T0.16b, $T0.16b, $A0.16b
+    eor $T1.16b, $T1.16b, $B0.16b
+    eor $T2.16b, $T2.16b, $C0.16b
+    eor $T3.16b, $T3.16b, $D0.16b
+
+    st1 {$T0.16b - $T3.16b}, [$oup], #64
+
+    sub $inl, $inl, #64
+
+    mov $A0.16b, $A1.16b
+    mov $B0.16b, $B1.16b
+    mov $C0.16b, $C1.16b
+    mov $D0.16b, $D1.16b
+
+.Lopen_128_store_64:
+
+    lsr $adl, $inl, #4
+    mov $adp, $inp
+
+.Lopen_128_hash_64:
+    cbz $adl, .Lopen_tail_64_store
+___
+    &poly_add($adp);
+    &poly_mul();
+$code.=<<___;
+    sub $adl, $adl, #1
+    b .Lopen_128_hash_64
+
+.size	GFp_chacha20_poly1305_open,.-GFp_chacha20_poly1305_open
+___
+}
+
+foreach (split("\n",$code)) {
+	s/\`([^\`]*)\`/eval $1/ge;
+
+	print $_,"\n";
+}
+close STDOUT or die "error closing STDOUT";

--- a/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl
@@ -1,0 +1,2489 @@
+#!/usr/bin/env perl
+
+# Copyright (c) 2015, CloudFlare Ltd.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+# OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+
+##############################################################################
+#                                                                            #
+# Author:  Vlad Krasnov                                                      #
+#                                                                            #
+##############################################################################
+
+$flavour = shift;
+$output  = shift;
+if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
+
+$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+
+$0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
+( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or
+( $xlate="${dir}../../perlasm/x86_64-xlate.pl" and -f $xlate) or
+die "can't locate x86_64-xlate.pl";
+
+open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
+*STDOUT=*OUT;
+
+$avx = 2;
+
+$code.=<<___;
+.text
+.extern OPENSSL_ia32cap_P
+
+chacha20_poly1305_constants:
+
+.align 64
+.chacha20_consts:
+.byte 'e','x','p','a','n','d',' ','3','2','-','b','y','t','e',' ','k'
+.byte 'e','x','p','a','n','d',' ','3','2','-','b','y','t','e',' ','k'
+.rol8:
+.byte 3,0,1,2, 7,4,5,6, 11,8,9,10, 15,12,13,14
+.byte 3,0,1,2, 7,4,5,6, 11,8,9,10, 15,12,13,14
+.rol16:
+.byte 2,3,0,1, 6,7,4,5, 10,11,8,9, 14,15,12,13
+.byte 2,3,0,1, 6,7,4,5, 10,11,8,9, 14,15,12,13
+.avx2_init:
+.long 0,0,0,0
+.sse_inc:
+.long 1,0,0,0
+.avx2_inc:
+.long 2,0,0,0,2,0,0,0
+.clamp:
+.quad 0x0FFFFFFC0FFFFFFF, 0x0FFFFFFC0FFFFFFC
+.quad 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF
+.align 16
+.and_masks:
+.byte 0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00
+.byte 0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff
+___
+
+my ($oup,$inp,$inl,$adp,$keyp,$itr1,$itr2)=("%rdi","%rsi","%rbx","%rcx","%r9","%rcx","%r8");
+my ($acc0,$acc1,$acc2)=map("%r$_",(10..12));
+my ($t0,$t1,$t2,$t3)=("%r13","%r14","%r15","%r9");
+my ($A0,$A1,$A2,$A3,$B0,$B1,$B2,$B3,$C0,$C1,$C2,$C3,$D0,$D1,$D2,$D3)=map("%xmm$_",(0..15));
+my ($T0,$T1,$T2,$T3)=($A3,$B3,$C3,$D3);
+my $r_store="0*16(%rbp)";
+my $s_store="1*16(%rbp)";
+my $len_store="2*16(%rbp)";
+my $state1_store="3*16(%rbp)";
+my $state2_store="4*16(%rbp)";
+my $tmp_store="5*16(%rbp)";
+my $ctr0_store="6*16(%rbp)";
+my $ctr1_store="7*16(%rbp)";
+my $ctr2_store="8*16(%rbp)";
+my $ctr3_store="9*16(%rbp)";
+
+sub chacha_qr {
+my ($a,$b,$c,$d,$t,$dir)=@_;
+$code.="movdqa $t, $tmp_store\n" if ($dir =~ /store/);
+$code.="paddd $b, $a
+        pxor $a, $d
+        pshufb .rol16(%rip), $d
+        paddd $d, $c
+        pxor $c, $b
+        movdqa $b, $t
+        pslld \$12, $t
+        psrld \$20, $b
+        pxor $t, $b
+        paddd $b, $a
+        pxor $a, $d
+        pshufb .rol8(%rip), $d
+        paddd $d, $c
+        pxor $c, $b
+        movdqa $b, $t
+        pslld \$7, $t
+        psrld \$25, $b
+        pxor $t, $b\n";
+$code.="palignr \$4, $b, $b
+        palignr \$8, $c, $c
+        palignr \$12, $d, $d\n" if ($dir =~ /left/);
+$code.="palignr \$12, $b, $b
+        palignr \$8, $c, $c
+        palignr \$4, $d, $d\n" if ($dir =~ /right/);
+$code.="movdqa $tmp_store, $t\n" if ($dir =~ /load/);
+}
+
+sub poly_add {
+my ($src)=@_;
+$code.="add $src, $acc0
+        adc 8+$src, $acc1
+        adc \$1, $acc2\n";
+}
+
+sub poly_stage1 {
+$code.="mov 0+$r_store, %rax
+        mov %rax, $t2
+        mul $acc0
+        mov %rax, $t0
+        mov %rdx, $t1
+        mov 0+$r_store, %rax
+        mul $acc1
+        imulq $acc2, $t2
+        add %rax, $t1
+        adc %rdx, $t2\n";
+}
+
+sub poly_stage2 {
+$code.="mov 8+$r_store, %rax
+        mov %rax, $t3
+        mul $acc0
+        add %rax, $t1
+        adc \$0, %rdx
+        mov %rdx, $acc0
+        mov 8+$r_store, %rax
+        mul $acc1
+        add %rax, $t2
+        adc \$0, %rdx\n";
+}
+
+sub poly_stage3 {
+$code.="imulq $acc2, $t3
+        add $acc0, $t2
+        adc %rdx, $t3\n";
+}
+
+sub poly_reduce_stage {
+$code.="mov $t0, $acc0
+        mov $t1, $acc1
+        mov $t2, $acc2
+        and \$3, $acc2
+        mov $t2, $t0
+        and \$-4, $t0
+        mov $t3, $t1
+        shrd \$2, $t3, $t2
+        shr \$2, $t3
+        add $t0, $acc0
+        adc $t1, $acc1
+        adc \$0, $acc2
+        add $t2, $acc0
+        adc $t3, $acc1
+        adc \$0, $acc2\n";
+}
+
+sub poly_mul {
+    &poly_stage1();
+    &poly_stage2();
+    &poly_stage3();
+    &poly_reduce_stage();
+}
+
+sub prep_state {
+my ($n)=@_;
+$code.="movdqa .chacha20_consts(%rip), $A0
+        movdqa $state1_store, $B0
+        movdqa $state2_store, $C0\n";
+$code.="movdqa $A0, $A1
+        movdqa $B0, $B1
+        movdqa $C0, $C1\n" if ($n ge 2);
+$code.="movdqa $A0, $A2
+        movdqa $B0, $B2
+        movdqa $C0, $C2\n" if ($n ge 3);
+$code.="movdqa $A0, $A3
+        movdqa $B0, $B3
+        movdqa $C0, $C3\n" if ($n ge 4);
+$code.="movdqa $ctr0_store, $D0
+        paddd .sse_inc(%rip), $D0
+        movdqa $D0, $ctr0_store\n" if ($n eq 1);
+$code.="movdqa $ctr0_store, $D1
+        paddd .sse_inc(%rip), $D1
+        movdqa $D1, $D0
+        paddd .sse_inc(%rip), $D0
+        movdqa $D0, $ctr0_store
+        movdqa $D1, $ctr1_store\n" if ($n eq 2);
+$code.="movdqa $ctr0_store, $D2
+        paddd .sse_inc(%rip), $D2
+        movdqa $D2, $D1
+        paddd .sse_inc(%rip), $D1
+        movdqa $D1, $D0
+        paddd .sse_inc(%rip), $D0
+        movdqa $D0, $ctr0_store
+        movdqa $D1, $ctr1_store
+        movdqa $D2, $ctr2_store\n" if ($n eq 3);
+$code.="movdqa $ctr0_store, $D3
+        paddd .sse_inc(%rip), $D3
+        movdqa $D3, $D2
+        paddd .sse_inc(%rip), $D2
+        movdqa $D2, $D1
+        paddd .sse_inc(%rip), $D1
+        movdqa $D1, $D0
+        paddd .sse_inc(%rip), $D0
+        movdqa $D0, $ctr0_store
+        movdqa $D1, $ctr1_store
+        movdqa $D2, $ctr2_store
+        movdqa $D3, $ctr3_store\n" if ($n eq 4);
+}
+
+sub finalize_state {
+my ($n)=@_;
+$code.="paddd .chacha20_consts(%rip), $A3
+        paddd $state1_store, $B3
+        paddd $state2_store, $C3
+        paddd $ctr3_store, $D3\n" if ($n eq 4);
+$code.="paddd .chacha20_consts(%rip), $A2
+        paddd $state1_store, $B2
+        paddd $state2_store, $C2
+        paddd $ctr2_store, $D2\n" if ($n ge 3);
+$code.="paddd .chacha20_consts(%rip), $A1
+        paddd $state1_store, $B1
+        paddd $state2_store, $C1
+        paddd $ctr1_store, $D1\n" if ($n ge 2);
+$code.="paddd .chacha20_consts(%rip), $A0
+        paddd $state1_store, $B0
+        paddd $state2_store, $C0
+        paddd $ctr0_store, $D0\n";
+}
+
+sub xor_stream {
+my ($A, $B, $C, $D, $offset)=@_;
+$code.="movdqu 0*16 + $offset($inp), $A3
+        movdqu 1*16 + $offset($inp), $B3
+        movdqu 2*16 + $offset($inp), $C3
+        movdqu 3*16 + $offset($inp), $D3
+        pxor $A3, $A
+        pxor $B3, $B
+        pxor $C3, $C
+        pxor $D, $D3
+        movdqu $A, 0*16 + $offset($oup)
+        movdqu $B, 1*16 + $offset($oup)
+        movdqu $C, 2*16 + $offset($oup)
+        movdqu $D3, 3*16 + $offset($oup)\n";
+}
+
+sub xor_stream_using_temp {
+my ($A, $B, $C, $D, $offset, $temp)=@_;
+$code.="movdqa $temp, $tmp_store
+        movdqu 0*16 + $offset($inp), $temp
+        pxor $A, $temp
+        movdqu $temp, 0*16 + $offset($oup)
+        movdqu 1*16 + $offset($inp), $temp
+        pxor $B, $temp
+        movdqu $temp, 1*16 + $offset($oup)
+        movdqu 2*16 + $offset($inp), $temp
+        pxor $C, $temp
+        movdqu $temp, 2*16 + $offset($oup)
+        movdqu 3*16 + $offset($inp), $temp
+        pxor $D, $temp
+        movdqu $temp, 3*16 + $offset($oup)\n";
+}
+
+sub gen_chacha_round {
+my ($rot1, $rot2, $shift)=@_;
+my $round="";
+$round.="movdqa $C0, $tmp_store\n" if ($rot1 eq 20);
+$round.="movdqa $rot2, $C0
+         paddd $B3, $A3
+         paddd $B2, $A2
+         paddd $B1, $A1
+         paddd $B0, $A0
+         pxor $A3, $D3
+         pxor $A2, $D2
+         pxor $A1, $D1
+         pxor $A0, $D0
+         pshufb $C0, $D3
+         pshufb $C0, $D2
+         pshufb $C0, $D1
+         pshufb $C0, $D0
+         movdqa $tmp_store, $C0
+         paddd $D3, $C3
+         paddd $D2, $C2
+         paddd $D1, $C1
+         paddd $D0, $C0
+         pxor $C3, $B3
+         pxor $C2, $B2
+         pxor $C1, $B1
+         pxor $C0, $B0
+         movdqa $C0, $tmp_store
+         movdqa $B3, $C0
+         psrld \$$rot1, $C0
+         pslld \$32-$rot1, $B3
+         pxor $C0, $B3
+         movdqa $B2, $C0
+         psrld \$$rot1, $C0
+         pslld \$32-$rot1, $B2
+         pxor $C0, $B2
+         movdqa $B1, $C0
+         psrld \$$rot1, $C0
+         pslld \$32-$rot1, $B1
+         pxor $C0, $B1
+         movdqa $B0, $C0
+         psrld \$$rot1, $C0
+         pslld \$32-$rot1, $B0
+         pxor $C0, $B0\n";
+($s1,$s2,$s3)=(4,8,12) if ($shift =~ /left/);
+($s1,$s2,$s3)=(12,8,4) if ($shift =~ /right/);
+$round.="movdqa $tmp_store, $C0
+         palignr \$$s1, $B3, $B3
+         palignr \$$s2, $C3, $C3
+         palignr \$$s3, $D3, $D3
+         palignr \$$s1, $B2, $B2
+         palignr \$$s2, $C2, $C2
+         palignr \$$s3, $D2, $D2
+         palignr \$$s1, $B1, $B1
+         palignr \$$s2, $C1, $C1
+         palignr \$$s3, $D1, $D1
+         palignr \$$s1, $B0, $B0
+         palignr \$$s2, $C0, $C0
+         palignr \$$s3, $D0, $D0\n"
+if (($shift =~ /left/) || ($shift =~ /right/));
+return $round;
+};
+
+$chacha_body = &gen_chacha_round(20, ".rol16(%rip)") .
+               &gen_chacha_round(25, ".rol8(%rip)", "left") .
+               &gen_chacha_round(20, ".rol16(%rip)") .
+               &gen_chacha_round(25, ".rol8(%rip)", "right");
+
+my @loop_body = split /\n/, $chacha_body;
+
+sub emit_body {
+my ($n)=@_;
+    for (my $i=0; $i < $n; $i++) {
+        $code=$code.shift(@loop_body)."\n";
+    };
+}
+
+{
+################################################################################
+# void poly_hash_ad_internal();
+$code.="
+.type poly_hash_ad_internal,\@function,2
+.align 64
+poly_hash_ad_internal:
+.cfi_startproc
+    xor $acc0, $acc0
+    xor $acc1, $acc1
+    xor $acc2, $acc2
+    cmp \$13,  $itr2
+    jne hash_ad_loop
+poly_fast_tls_ad:
+    # Special treatment for the TLS case of 13 bytes
+    mov ($adp), $acc0
+    mov 5($adp), $acc1
+    shr \$24, $acc1
+    mov \$1, $acc2\n";
+    &poly_mul(); $code.="
+    ret
+hash_ad_loop:
+        # Hash in 16 byte chunk
+        cmp \$16, $itr2
+        jb hash_ad_tail\n";
+        &poly_add("0($adp)");
+        &poly_mul(); $code.="
+        lea 1*16($adp), $adp
+        sub \$16, $itr2
+    jmp hash_ad_loop
+hash_ad_tail:
+    cmp \$0, $itr2
+    je 1f
+    # Hash last < 16 byte tail
+    xor $t0, $t0
+    xor $t1, $t1
+    xor $t2, $t2
+    add $itr2, $adp
+hash_ad_tail_loop:
+        shld \$8, $t0, $t1
+        shl \$8, $t0
+        movzxb -1($adp), $t2
+        xor $t2, $t0
+        dec $adp
+        dec $itr2
+    jne hash_ad_tail_loop
+
+    add $t0, $acc0
+    adc $t1, $acc1
+    adc \$1, $acc2\n";
+    &poly_mul(); $code.="
+    # Finished AD
+1:
+    ret
+.cfi_endproc
+.size poly_hash_ad_internal, .-poly_hash_ad_internal\n";
+}
+
+{
+################################################################################
+# void chacha20_poly1305_open(uint8_t *pt, uint8_t *ct, size_t len_in, uint8_t *ad, size_t len_ad, uint8_t *keyp);
+$code.="
+.globl chacha20_poly1305_open
+.type chacha20_poly1305_open,\@function,2
+.align 64
+chacha20_poly1305_open:
+.cfi_startproc
+    push %rbp
+.cfi_adjust_cfa_offset 8
+    push %rbx
+.cfi_adjust_cfa_offset 8
+    push %r12
+.cfi_adjust_cfa_offset 8
+    push %r13
+.cfi_adjust_cfa_offset 8
+    push %r14
+.cfi_adjust_cfa_offset 8
+    push %r15
+.cfi_adjust_cfa_offset 8
+    # We write the calculated authenticator back to keyp at the end, so save
+    # the pointer on the stack too.
+    push $keyp
+.cfi_adjust_cfa_offset 8
+    sub \$288 + 32, %rsp
+.cfi_adjust_cfa_offset 288 + 32
+.cfi_offset rbp, -16
+.cfi_offset rbx, -24
+.cfi_offset r12, -32
+.cfi_offset r13, -40
+.cfi_offset r14, -48
+.cfi_offset r15, -56
+    lea 32(%rsp), %rbp
+    and \$-32, %rbp
+    mov %rdx, 8+$len_store
+    mov %r8, 0+$len_store
+    mov %rdx, $inl\n"; $code.="
+    mov OPENSSL_ia32cap_P+8(%rip), %eax
+    and \$`(1<<5) + (1<<8)`, %eax # Check both BMI2 and AVX2 are present
+    xor \$`(1<<5) + (1<<8)`, %eax
+    jz  chacha20_poly1305_open_avx2\n" if ($avx>1);
+$code.="
+1:
+    cmp \$128, $inl
+    jbe open_sse_128
+    # For long buffers, prepare the poly key first
+    movdqa .chacha20_consts(%rip), $A0
+    movdqu 0*16($keyp), $B0
+    movdqu 1*16($keyp), $C0
+    movdqu 2*16($keyp), $D0
+    movdqa $D0, $T1
+    # Store on stack, to free keyp
+    movdqa $B0, $state1_store
+    movdqa $C0, $state2_store
+    movdqa $D0, $ctr0_store
+    mov \$10, $acc0
+1:  \n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right"); $code.="
+        dec $acc0
+    jne 1b
+    # A0|B0 hold the Poly1305 32-byte key, C0,D0 can be discarded
+    paddd .chacha20_consts(%rip), $A0
+    paddd $state1_store, $B0
+    # Clamp and store the key
+    pand .clamp(%rip), $A0
+    movdqa $A0, $r_store
+    movdqa $B0, $s_store
+    # Hash
+    mov %r8, $itr2
+    call poly_hash_ad_internal
+open_sse_main_loop:
+        cmp \$16*16, $inl
+        jb 2f
+        # Load state, increment counter blocks\n";
+        &prep_state(4); $code.="
+        # There are 10 ChaCha20 iterations of 2QR each, so for 6 iterations we
+        # hash 2 blocks, and for the remaining 4 only 1 block - for a total of 16
+        mov \$4, $itr1
+        mov $inp, $itr2
+1:  \n";
+            &emit_body(20);
+            &poly_add("0($itr2)"); $code.="
+            lea 2*8($itr2), $itr2\n";
+            &emit_body(20);
+            &poly_stage1();
+            &emit_body(20);
+            &poly_stage2();
+            &emit_body(20);
+            &poly_stage3();
+            &emit_body(20);
+            &poly_reduce_stage();
+            foreach $l (@loop_body) {$code.=$l."\n";}
+            @loop_body = split /\n/, $chacha_body; $code.="
+            dec $itr1
+        jge 1b\n";
+            &poly_add("0($itr2)");
+            &poly_mul(); $code.="
+            lea 2*8($itr2), $itr2
+            cmp \$-6, $itr1
+        jg 1b\n";
+        &finalize_state(4);
+        &xor_stream_using_temp($A3, $B3, $C3, $D3, "0*16", $D0);
+        &xor_stream($A2, $B2, $C2, $D2, "4*16");
+        &xor_stream($A1, $B1, $C1, $D1, "8*16");
+        &xor_stream($A0, $B0, $C0, $tmp_store, "12*16"); $code.="
+        lea 16*16($inp), $inp
+        lea 16*16($oup), $oup
+        sub \$16*16, $inl
+    jmp open_sse_main_loop
+2:
+    # Handle the various tail sizes efficiently
+    test $inl, $inl
+    jz open_sse_finalize
+    cmp \$4*16, $inl
+    ja 3f\n";
+###############################################################################
+    # At most 64 bytes are left
+    &prep_state(1); $code.="
+    xor $itr2, $itr2
+    mov $inl, $itr1
+    cmp \$16, $itr1
+    jb 2f
+1:  \n";
+        &poly_add("0($inp, $itr2)");
+        &poly_mul(); $code.="
+        sub \$16, $itr1
+2:
+        add \$16, $itr2\n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right"); $code.="
+        cmp \$16, $itr1
+    jae 1b
+        cmp \$10*16, $itr2
+    jne 2b\n";
+    &finalize_state(1); $code.="
+    jmp open_sse_tail_64_dec_loop
+3:
+    cmp \$8*16, $inl
+    ja 3f\n";
+###############################################################################
+    # 65 - 128 bytes are left
+    &prep_state(2); $code.="
+    mov $inl, $itr1
+    and \$-16, $itr1
+    xor $itr2, $itr2
+1:  \n";
+        &poly_add("0($inp, $itr2)");
+        &poly_mul(); $code.="
+2:
+        add \$16, $itr2\n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"right");$code.="
+        cmp $itr1, $itr2
+    jb 1b
+        cmp \$10*16, $itr2
+    jne 2b\n";
+    &finalize_state(2);
+    &xor_stream($A1, $B1, $C1, $D1, "0*16"); $code.="
+    sub \$4*16, $inl
+    lea 4*16($inp), $inp
+    lea 4*16($oup), $oup
+    jmp open_sse_tail_64_dec_loop
+3:
+    cmp \$12*16, $inl
+    ja 3f\n";
+###############################################################################
+    # 129 - 192 bytes are left
+    &prep_state(3); $code.="
+    mov $inl, $itr1
+    mov \$10*16, $itr2
+    cmp \$10*16, $itr1
+    cmovg $itr2, $itr1
+    and \$-16, $itr1
+    xor $itr2, $itr2
+1:  \n";
+        &poly_add("0($inp, $itr2)");
+        &poly_mul(); $code.="
+2:
+        add \$16, $itr2\n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr($A2,$B2,$C2,$D2,$T0,"left");
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr($A2,$B2,$C2,$D2,$T0,"right"); $code.="
+        cmp $itr1, $itr2
+    jb 1b
+        cmp \$10*16, $itr2
+    jne 2b
+    cmp \$11*16, $inl
+    jb 1f\n";
+    &poly_add("10*16($inp)");
+    &poly_mul(); $code.="
+    cmp \$12*16, $inl
+    jb 1f\n";
+    &poly_add("11*16($inp)");
+    &poly_mul(); $code.="
+1:  \n";
+    &finalize_state(3);
+    &xor_stream($A2, $B2, $C2, $D2, "0*16");
+    &xor_stream($A1, $B1, $C1, $D1, "4*16"); $code.="
+    sub \$8*16, $inl
+    lea 8*16($inp), $inp
+    lea 8*16($oup), $oup
+    jmp open_sse_tail_64_dec_loop
+3:
+###############################################################################\n";
+    # 193 - 255 bytes are left
+    &prep_state(4); $code.="
+    xor $itr2, $itr2
+1:  \n";
+        &poly_add("0($inp, $itr2)");
+        &chacha_qr($A0,$B0,$C0,$D0,$C3,"store_left");
+        &chacha_qr($A1,$B1,$C1,$D1,$C3,"left");
+        &chacha_qr($A2,$B2,$C2,$D2,$C3,"left_load");
+        &poly_stage1();
+        &chacha_qr($A3,$B3,$C3,$D3,$C1,"store_left_load");
+        &poly_stage2();
+        &chacha_qr($A0,$B0,$C0,$D0,$C3,"store_right");
+        &chacha_qr($A1,$B1,$C1,$D1,$C3,"right");
+        &poly_stage3();
+        &chacha_qr($A2,$B2,$C2,$D2,$C3,"right_load");
+        &poly_reduce_stage();
+        &chacha_qr($A3,$B3,$C3,$D3,$C1,"store_right_load"); $code.="
+        add \$16, $itr2
+        cmp \$10*16, $itr2
+    jb 1b
+    mov $inl, $itr1
+    and \$-16, $itr1
+1:  \n";
+        &poly_add("0($inp, $itr2)");
+        &poly_mul(); $code.="
+        add \$16, $itr2
+        cmp $itr1, $itr2
+    jb 1b\n";
+    &finalize_state(4);
+    &xor_stream_using_temp($A3, $B3, $C3, $D3, "0*16", $D0);
+    &xor_stream($A2, $B2, $C2, $D2, "4*16");
+    &xor_stream($A1, $B1, $C1, $D1, "8*16"); $code.="
+    movdqa $tmp_store, $D0
+    sub \$12*16, $inl
+    lea 12*16($inp), $inp
+    lea 12*16($oup), $oup
+###############################################################################
+    # Decrypt the remaining data, 16B at a time, using existing stream
+open_sse_tail_64_dec_loop:
+    cmp \$16, $inl
+    jb 1f
+        sub \$16, $inl
+        movdqu ($inp), $T0
+        pxor $T0, $A0
+        movdqu $A0, ($oup)
+        lea 16($inp), $inp
+        lea 16($oup), $oup
+        movdqa $B0, $A0
+        movdqa $C0, $B0
+        movdqa $D0, $C0
+    jmp open_sse_tail_64_dec_loop
+1:
+    movdqa $A0, $A1
+
+    # Decrypt up to 16 bytes at the end.
+open_sse_tail_16:
+    test $inl, $inl
+    jz open_sse_finalize
+
+    # Read the final bytes into $T0. They need to be read in reverse order so
+    # that they end up in the correct order in $T0.
+    pxor $T0, $T0
+    lea -1($inp, $inl), $inp
+    movq $inl, $itr2
+2:
+        pslldq \$1, $T0
+        pinsrb \$0, ($inp), $T0
+        sub \$1, $inp
+        sub \$1, $itr2
+        jnz 2b
+
+3:
+    movq $T0, $t0
+    pextrq \$1, $T0, $t1
+    # The final bytes of keystream are in $A1.
+    pxor $A1, $T0
+
+    # Copy the plaintext bytes out.
+2:
+        pextrb \$0, $T0, ($oup)
+        psrldq \$1, $T0
+        add \$1, $oup
+        sub \$1, $inl
+    jne 2b
+
+    add $t0, $acc0
+    adc $t1, $acc1
+    adc \$1, $acc2\n";
+    &poly_mul(); $code.="
+
+open_sse_finalize:\n";
+    &poly_add($len_store);
+    &poly_mul(); $code.="
+    # Final reduce
+    mov $acc0, $t0
+    mov $acc1, $t1
+    mov $acc2, $t2
+    sub \$-5, $acc0
+    sbb \$-1, $acc1
+    sbb \$3, $acc2
+    cmovc $t0, $acc0
+    cmovc $t1, $acc1
+    cmovc $t2, $acc2
+    # Add in s part of the key
+    add 0+$s_store, $acc0
+    adc 8+$s_store, $acc1
+
+    add \$288 + 32, %rsp
+.cfi_adjust_cfa_offset -(288 + 32)
+    pop $keyp
+.cfi_adjust_cfa_offset -8
+    movq $acc0, ($keyp)
+    movq $acc1, 8($keyp)
+
+    pop %r15
+.cfi_adjust_cfa_offset -8
+    pop %r14
+.cfi_adjust_cfa_offset -8
+    pop %r13
+.cfi_adjust_cfa_offset -8
+    pop %r12
+.cfi_adjust_cfa_offset -8
+    pop %rbx
+.cfi_adjust_cfa_offset -8
+    pop %rbp
+.cfi_adjust_cfa_offset -8
+    ret
+.cfi_adjust_cfa_offset (8 * 6) + 288 + 32
+###############################################################################
+open_sse_128:
+    movdqu .chacha20_consts(%rip), $A0\nmovdqa $A0, $A1\nmovdqa $A0, $A2
+    movdqu 0*16($keyp), $B0\nmovdqa $B0, $B1\nmovdqa $B0, $B2
+    movdqu 1*16($keyp), $C0\nmovdqa $C0, $C1\nmovdqa $C0, $C2
+    movdqu 2*16($keyp), $D0
+    movdqa $D0, $D1\npaddd .sse_inc(%rip), $D1
+    movdqa $D1, $D2\npaddd .sse_inc(%rip), $D2
+    movdqa $B0, $T1\nmovdqa $C0, $T2\nmovdqa $D1, $T3
+    mov \$10, $acc0
+1:  \n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr($A2,$B2,$C2,$D2,$T0,"left");
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr($A2,$B2,$C2,$D2,$T0,"right"); $code.="
+    dec $acc0
+    jnz 1b
+    paddd .chacha20_consts(%rip), $A0
+    paddd .chacha20_consts(%rip), $A1
+    paddd .chacha20_consts(%rip), $A2
+    paddd $T1, $B0\npaddd $T1, $B1\npaddd $T1, $B2
+    paddd $T2, $C1\npaddd $T2, $C2
+    paddd $T3, $D1
+    paddd .sse_inc(%rip), $T3
+    paddd $T3, $D2
+    # Clamp and store the key
+    pand .clamp(%rip), $A0
+    movdqa $A0, $r_store
+    movdqa $B0, $s_store
+    # Hash
+    mov %r8, $itr2
+    call poly_hash_ad_internal
+1:
+        cmp \$16, $inl
+        jb open_sse_tail_16
+        sub \$16, $inl\n";
+        # Load for hashing
+        &poly_add("0*8($inp)"); $code.="
+        # Load for decryption
+        movdqu 0*16($inp), $T0
+        pxor $T0, $A1
+        movdqu $A1, 0*16($oup)
+        lea 1*16($inp), $inp
+        lea 1*16($oup), $oup\n";
+        &poly_mul(); $code.="
+        # Shift the stream left
+        movdqa $B1, $A1
+        movdqa $C1, $B1
+        movdqa $D1, $C1
+        movdqa $A2, $D1
+        movdqa $B2, $A2
+        movdqa $C2, $B2
+        movdqa $D2, $C2
+    jmp 1b
+    jmp open_sse_tail_16
+.size chacha20_poly1305_open, .-chacha20_poly1305_open
+.cfi_endproc
+
+################################################################################
+################################################################################
+# void chacha20_poly1305_seal(uint8_t *pt, uint8_t *ct, size_t len_in, uint8_t *ad, size_t len_ad, uint8_t *keyp);
+.globl  chacha20_poly1305_seal
+.type chacha20_poly1305_seal,\@function,2
+.align 64
+chacha20_poly1305_seal:
+.cfi_startproc
+    push %rbp
+.cfi_adjust_cfa_offset 8
+    push %rbx
+.cfi_adjust_cfa_offset 8
+    push %r12
+.cfi_adjust_cfa_offset 8
+    push %r13
+.cfi_adjust_cfa_offset 8
+    push %r14
+.cfi_adjust_cfa_offset 8
+    push %r15
+.cfi_adjust_cfa_offset 8
+    # We write the calculated authenticator back to keyp at the end, so save
+    # the pointer on the stack too.
+    push $keyp
+.cfi_adjust_cfa_offset 8
+    sub \$288 + 32, %rsp
+.cfi_adjust_cfa_offset 288 + 32
+.cfi_offset rbp, -16
+.cfi_offset rbx, -24
+.cfi_offset r12, -32
+.cfi_offset r13, -40
+.cfi_offset r14, -48
+.cfi_offset r15, -56
+    lea 32(%rsp), %rbp
+    and \$-32, %rbp
+    mov 56($keyp), $inl  # extra_in_len
+    addq %rdx, $inl
+    mov $inl, 8+$len_store
+    mov %r8, 0+$len_store
+    mov %rdx, $inl\n"; $code.="
+    mov OPENSSL_ia32cap_P+8(%rip), %eax
+    and \$`(1<<5) + (1<<8)`, %eax # Check both BMI2 and AVX2 are present
+    xor \$`(1<<5) + (1<<8)`, %eax
+    jz  chacha20_poly1305_seal_avx2\n" if ($avx>1);
+$code.="
+    cmp \$128, $inl
+    jbe seal_sse_128
+    # For longer buffers, prepare the poly key + some stream
+    movdqa .chacha20_consts(%rip), $A0
+    movdqu 0*16($keyp), $B0
+    movdqu 1*16($keyp), $C0
+    movdqu 2*16($keyp), $D0
+    movdqa $A0, $A1
+    movdqa $A0, $A2
+    movdqa $A0, $A3
+    movdqa $B0, $B1
+    movdqa $B0, $B2
+    movdqa $B0, $B3
+    movdqa $C0, $C1
+    movdqa $C0, $C2
+    movdqa $C0, $C3
+    movdqa $D0, $D3
+    paddd .sse_inc(%rip), $D0
+    movdqa $D0, $D2
+    paddd .sse_inc(%rip), $D0
+    movdqa $D0, $D1
+    paddd .sse_inc(%rip), $D0
+    # Store on stack
+    movdqa $B0, $state1_store
+    movdqa $C0, $state2_store
+    movdqa $D0, $ctr0_store
+    movdqa $D1, $ctr1_store
+    movdqa $D2, $ctr2_store
+    movdqa $D3, $ctr3_store
+    mov \$10, $acc0
+1:  \n";
+        foreach $l (@loop_body) {$code.=$l."\n";}
+        @loop_body = split /\n/, $chacha_body; $code.="
+        dec $acc0
+    jnz 1b\n";
+    &finalize_state(4); $code.="
+    # Clamp and store the key
+    pand .clamp(%rip), $A3
+    movdqa $A3, $r_store
+    movdqa $B3, $s_store
+    # Hash
+    mov %r8, $itr2
+    call poly_hash_ad_internal\n";
+    &xor_stream($A2,$B2,$C2,$D2,"0*16");
+    &xor_stream($A1,$B1,$C1,$D1,"4*16"); $code.="
+    cmp \$12*16, $inl
+    ja 1f
+    mov \$8*16, $itr1
+    sub \$8*16, $inl
+    lea 8*16($inp), $inp
+    jmp seal_sse_128_seal_hash
+1:  \n";
+    &xor_stream($A0, $B0, $C0, $D0, "8*16"); $code.="
+    mov \$12*16, $itr1
+    sub \$12*16, $inl
+    lea 12*16($inp), $inp
+    mov \$2, $itr1
+    mov \$8, $itr2
+    cmp \$4*16, $inl
+    jbe seal_sse_tail_64
+    cmp \$8*16, $inl
+    jbe seal_sse_tail_128
+    cmp \$12*16, $inl
+    jbe seal_sse_tail_192
+
+1:  \n";
+    # The main loop
+        &prep_state(4); $code.="
+2:  \n";
+            &emit_body(20);
+            &poly_add("0($oup)");
+            &emit_body(20);
+            &poly_stage1();
+            &emit_body(20);
+            &poly_stage2();
+            &emit_body(20);
+            &poly_stage3();
+            &emit_body(20);
+            &poly_reduce_stage();
+            foreach $l (@loop_body) {$code.=$l."\n";}
+            @loop_body = split /\n/, $chacha_body; $code.="
+            lea 16($oup), $oup
+            dec $itr2
+        jge 2b\n";
+            &poly_add("0*8($oup)");
+            &poly_mul(); $code.="
+            lea 16($oup), $oup
+            dec $itr1
+        jg 2b\n";
+
+        &finalize_state(4);$code.="
+        movdqa $D2, $tmp_store\n";
+        &xor_stream_using_temp($A3,$B3,$C3,$D3,0*16,$D2); $code.="
+        movdqa $tmp_store, $D2\n";
+        &xor_stream($A2,$B2,$C2,$D2, 4*16);
+        &xor_stream($A1,$B1,$C1,$D1, 8*16); $code.="
+        cmp \$16*16, $inl
+        ja 3f
+
+        mov \$12*16, $itr1
+        sub \$12*16, $inl
+        lea 12*16($inp), $inp
+        jmp seal_sse_128_seal_hash
+3:  \n";
+        &xor_stream($A0,$B0,$C0,$D0,"12*16"); $code.="
+        lea 16*16($inp), $inp
+        sub \$16*16, $inl
+        mov \$6, $itr1
+        mov \$4, $itr2
+        cmp \$12*16, $inl
+    jg 1b
+    mov $inl, $itr1
+    test $inl, $inl
+    je seal_sse_128_seal_hash
+    mov \$6, $itr1
+    cmp \$4*16, $inl
+    jg 3f
+###############################################################################
+seal_sse_tail_64:\n";
+    &prep_state(1); $code.="
+1:  \n";
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        lea 16($oup), $oup
+2:  \n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right");
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        lea 16($oup), $oup
+    dec $itr1
+    jg 1b
+    dec $itr2
+    jge 2b\n";
+    &finalize_state(1); $code.="
+    jmp seal_sse_128_seal
+3:
+    cmp \$8*16, $inl
+    jg 3f
+###############################################################################
+seal_sse_tail_128:\n";
+    &prep_state(2); $code.="
+1:  \n";
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        lea 16($oup), $oup
+2:  \n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"left");
+        &poly_add("0($oup)");
+        &poly_mul();
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"right"); $code.="
+        lea 16($oup), $oup
+    dec $itr1
+    jg 1b
+    dec $itr2
+    jge 2b\n";
+    &finalize_state(2);
+    &xor_stream($A1,$B1,$C1,$D1,0*16); $code.="
+    mov \$4*16, $itr1
+    sub \$4*16, $inl
+    lea 4*16($inp), $inp
+    jmp seal_sse_128_seal_hash
+3:
+###############################################################################
+seal_sse_tail_192:\n";
+    &prep_state(3); $code.="
+1:  \n";
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        lea 16($oup), $oup
+2:  \n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr($A2,$B2,$C2,$D2,$T0,"left");
+        &poly_add("0($oup)");
+        &poly_mul();
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr($A2,$B2,$C2,$D2,$T0,"right"); $code.="
+        lea 16($oup), $oup
+    dec $itr1
+    jg 1b
+    dec $itr2
+    jge 2b\n";
+    &finalize_state(3);
+    &xor_stream($A2,$B2,$C2,$D2,0*16);
+    &xor_stream($A1,$B1,$C1,$D1,4*16); $code.="
+    mov \$8*16, $itr1
+    sub \$8*16, $inl
+    lea 8*16($inp), $inp
+###############################################################################
+seal_sse_128_seal_hash:
+        cmp \$16, $itr1
+        jb seal_sse_128_seal\n";
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        sub \$16, $itr1
+        lea 16($oup), $oup
+    jmp seal_sse_128_seal_hash
+
+seal_sse_128_seal:
+        cmp \$16, $inl
+        jb seal_sse_tail_16
+        sub \$16, $inl
+        # Load for decryption
+        movdqu 0*16($inp), $T0
+        pxor $T0, $A0
+        movdqu $A0, 0*16($oup)
+        # Then hash
+        add 0*8($oup), $acc0
+        adc 1*8($oup), $acc1
+        adc \$1, $acc2
+        lea 1*16($inp), $inp
+        lea 1*16($oup), $oup\n";
+        &poly_mul(); $code.="
+        # Shift the stream left
+        movdqa $B0, $A0
+        movdqa $C0, $B0
+        movdqa $D0, $C0
+        movdqa $A1, $D0
+        movdqa $B1, $A1
+        movdqa $C1, $B1
+        movdqa $D1, $C1
+    jmp seal_sse_128_seal
+
+seal_sse_tail_16:
+    test $inl, $inl
+    jz process_blocks_of_extra_in
+    # We can only load the PT one byte at a time to avoid buffer overread
+    mov $inl, $itr2
+    mov $inl, $itr1
+    lea -1($inp, $inl), $inp
+    pxor $T3, $T3
+1:
+        pslldq \$1, $T3
+        pinsrb \$0, ($inp), $T3
+        lea -1($inp), $inp
+        dec $itr1
+        jne 1b
+
+    # XOR the keystream with the plaintext.
+    pxor $A0, $T3
+
+    # Write ciphertext out, byte-by-byte.
+    movq $inl, $itr1
+    movdqu $T3, $A0
+2:
+        pextrb \$0, $A0, ($oup)
+        psrldq \$1, $A0
+        add \$1, $oup
+        sub \$1, $itr1
+        jnz 2b
+
+    # $T3 contains the final (partial, non-empty) block of ciphertext which
+    # needs to be fed into the Poly1305 state. The right-most $inl bytes of it
+    # are valid. We need to fill it with extra_in bytes until full, or until we
+    # run out of bytes.
+    #
+    # $keyp points to the tag output, which is actually a struct with the
+    # extra_in pointer and length at offset 48.
+    movq 288+32(%rsp), $keyp
+    movq 56($keyp), $t1  # extra_in_len
+    movq 48($keyp), $t0  # extra_in
+    test $t1, $t1
+    jz process_partial_block  # Common case: no bytes of extra_in
+
+    movq \$16, $t2
+    subq $inl, $t2  # 16-$inl is the number of bytes that fit into $T3.
+    cmpq $t2, $t1   # if extra_in_len < 16-$inl, only copy extra_in_len
+                    # (note that AT&T syntax reverses the arguments)
+    jge load_extra_in
+    movq $t1, $t2
+
+load_extra_in:
+    # $t2 contains the number of bytes of extra_in (pointed to by $t0) to load
+    # into $T3. They are loaded in reverse order.
+    leaq -1($t0, $t2), $inp
+    # Update extra_in and extra_in_len to reflect the bytes that are about to
+    # be read.
+    addq $t2, $t0
+    subq $t2, $t1
+    movq $t0, 48($keyp)
+    movq $t1, 56($keyp)
+
+    # Update $itr2, which is used to select the mask later on, to reflect the
+    # extra bytes about to be added.
+    addq $t2, $itr2
+
+    # Load $t2 bytes of extra_in into $T2.
+    pxor $T2, $T2
+3:
+        pslldq \$1, $T2
+        pinsrb \$0, ($inp), $T2
+        lea -1($inp), $inp
+        sub \$1, $t2
+        jnz 3b
+
+    # Shift $T2 up the length of the remainder from the main encryption. Sadly,
+    # the shift for an XMM register has to be a constant, thus we loop to do
+    # this.
+    movq $inl, $t2
+
+4:
+        pslldq \$1, $T2
+        sub \$1, $t2
+        jnz 4b
+
+    # Mask $T3 (the remainder from the main encryption) so that superfluous
+    # bytes are zero. This means that the non-zero bytes in $T2 and $T3 are
+    # disjoint and so we can merge them with an OR.
+    lea .and_masks(%rip), $t2
+    shl \$4, $inl
+    pand -16($t2, $inl), $T3
+
+    # Merge $T2 into $T3, forming the remainder block.
+    por $T2, $T3
+
+    # The block of ciphertext + extra_in is ready to be included in the
+    # Poly1305 state.
+    movq $T3, $t0
+    pextrq \$1, $T3, $t1
+    add $t0, $acc0
+    adc $t1, $acc1
+    adc \$1, $acc2\n";
+    &poly_mul(); $code.="
+
+process_blocks_of_extra_in:
+    # There may be additional bytes of extra_in to process.
+    movq 288+32(%rsp), $keyp
+    movq 48($keyp), $inp   # extra_in
+    movq 56($keyp), $itr2  # extra_in_len
+    movq $itr2, $itr1
+    shr \$4, $itr2         # number of blocks
+
+5:
+        jz process_extra_in_trailer\n";
+        &poly_add("0($inp)");
+        &poly_mul(); $code.="
+        leaq 16($inp), $inp
+        subq \$1, $itr2
+        jmp 5b
+
+process_extra_in_trailer:
+    andq \$15, $itr1       # remaining num bytes (<16) of extra_in
+    movq $itr1, $inl
+    jz do_length_block
+    leaq -1($inp, $itr1), $inp
+
+6:
+        pslldq \$1, $T3
+        pinsrb \$0, ($inp), $T3
+        lea -1($inp), $inp
+        sub \$1, $itr1
+        jnz 6b
+
+process_partial_block:
+    # $T3 contains $inl bytes of data to be fed into Poly1305. $inl != 0
+    lea .and_masks(%rip), $t2
+    shl \$4, $inl
+    pand -16($t2, $inl), $T3
+    movq $T3, $t0
+    pextrq \$1, $T3, $t1
+    add $t0, $acc0
+    adc $t1, $acc1
+    adc \$1, $acc2\n";
+    &poly_mul(); $code.="
+
+do_length_block:\n";
+    &poly_add($len_store);
+    &poly_mul(); $code.="
+    # Final reduce
+    mov $acc0, $t0
+    mov $acc1, $t1
+    mov $acc2, $t2
+    sub \$-5, $acc0
+    sbb \$-1, $acc1
+    sbb \$3, $acc2
+    cmovc $t0, $acc0
+    cmovc $t1, $acc1
+    cmovc $t2, $acc2
+    # Add in s part of the key
+    add 0+$s_store, $acc0
+    adc 8+$s_store, $acc1
+
+    add \$288 + 32, %rsp
+.cfi_adjust_cfa_offset -(288 + 32)
+    pop $keyp
+.cfi_adjust_cfa_offset -8
+    mov $acc0, 0*8($keyp)
+    mov $acc1, 1*8($keyp)
+
+    pop %r15
+.cfi_adjust_cfa_offset -8
+    pop %r14
+.cfi_adjust_cfa_offset -8
+    pop %r13
+.cfi_adjust_cfa_offset -8
+    pop %r12
+.cfi_adjust_cfa_offset -8
+    pop %rbx
+.cfi_adjust_cfa_offset -8
+    pop %rbp
+.cfi_adjust_cfa_offset -8
+    ret
+.cfi_adjust_cfa_offset (8 * 7) + 288 + 32
+################################################################################
+seal_sse_128:
+    movdqu .chacha20_consts(%rip), $A0\nmovdqa $A0, $A1\nmovdqa $A0, $A2
+    movdqu 0*16($keyp), $B0\nmovdqa $B0, $B1\nmovdqa $B0, $B2
+    movdqu 1*16($keyp), $C0\nmovdqa $C0, $C1\nmovdqa $C0, $C2
+    movdqu 2*16($keyp), $D2
+    movdqa $D2, $D0\npaddd .sse_inc(%rip), $D0
+    movdqa $D0, $D1\npaddd .sse_inc(%rip), $D1
+    movdqa $B0, $T1\nmovdqa $C0, $T2\nmovdqa $D0, $T3
+    mov \$10, $acc0
+1:\n";
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr($A2,$B2,$C2,$D2,$T0,"left");
+        &chacha_qr($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr($A2,$B2,$C2,$D2,$T0,"right"); $code.="
+        dec $acc0
+    jnz 1b
+    paddd .chacha20_consts(%rip), $A0
+    paddd .chacha20_consts(%rip), $A1
+    paddd .chacha20_consts(%rip), $A2
+    paddd $T1, $B0\npaddd $T1, $B1\npaddd $T1, $B2
+    paddd $T2, $C0\npaddd $T2, $C1
+    paddd $T3, $D0
+    paddd .sse_inc(%rip), $T3
+    paddd $T3, $D1
+    # Clamp and store the key
+    pand .clamp(%rip), $A2
+    movdqa $A2, $r_store
+    movdqa $B2, $s_store
+    # Hash
+    mov %r8, $itr2
+    call poly_hash_ad_internal
+    jmp seal_sse_128_seal
+.size chacha20_poly1305_seal, .-chacha20_poly1305_seal\n";
+}
+
+# There should have been a cfi_endproc at the end of that function, but the two
+# following blocks of code are jumped to without a stack frame and the CFI
+# context which they are used in happens to match the CFI context at the end of
+# the previous function. So the CFI table is just extended to the end of them.
+
+if ($avx>1) {
+
+($A0,$A1,$A2,$A3,$B0,$B1,$B2,$B3,$C0,$C1,$C2,$C3,$D0,$D1,$D2,$D3)=map("%ymm$_",(0..15));
+my ($A0x,$A1x,$A2x,$A3x,$B0x,$B1x,$B2x,$B3x,$C0x,$C1x,$C2x,$C3x,$D0x,$D1x,$D2x,$D3x)=map("%xmm$_",(0..15));
+($T0,$T1,$T2,$T3)=($A3,$B3,$C3,$D3);
+$state1_store="2*32(%rbp)";
+$state2_store="3*32(%rbp)";
+$tmp_store="4*32(%rbp)";
+$ctr0_store="5*32(%rbp)";
+$ctr1_store="6*32(%rbp)";
+$ctr2_store="7*32(%rbp)";
+$ctr3_store="8*32(%rbp)";
+
+sub chacha_qr_avx2 {
+my ($a,$b,$c,$d,$t,$dir)=@_;
+$code.=<<___ if ($dir =~ /store/);
+    vmovdqa $t, $tmp_store
+___
+$code.=<<___;
+    vpaddd $b, $a, $a
+    vpxor $a, $d, $d
+    vpshufb .rol16(%rip), $d, $d
+    vpaddd $d, $c, $c
+    vpxor $c, $b, $b
+    vpsrld \$20, $b, $t
+    vpslld \$12, $b, $b
+    vpxor $t, $b, $b
+    vpaddd $b, $a, $a
+    vpxor $a, $d, $d
+    vpshufb .rol8(%rip), $d, $d
+    vpaddd $d, $c, $c
+    vpxor $c, $b, $b
+    vpslld \$7, $b, $t
+    vpsrld \$25, $b, $b
+    vpxor $t, $b, $b
+___
+$code.=<<___ if ($dir =~ /left/);
+    vpalignr \$12, $d, $d, $d
+    vpalignr \$8, $c, $c, $c
+    vpalignr \$4, $b, $b, $b
+___
+$code.=<<___ if ($dir =~ /right/);
+    vpalignr \$4, $d, $d, $d
+    vpalignr \$8, $c, $c, $c
+    vpalignr \$12, $b, $b, $b
+___
+$code.=<<___ if ($dir =~ /load/);
+    vmovdqa $tmp_store, $t
+___
+}
+
+sub prep_state_avx2 {
+my ($n)=@_;
+$code.=<<___;
+    vmovdqa .chacha20_consts(%rip), $A0
+    vmovdqa $state1_store, $B0
+    vmovdqa $state2_store, $C0
+___
+$code.=<<___ if ($n ge 2);
+    vmovdqa $A0, $A1
+    vmovdqa $B0, $B1
+    vmovdqa $C0, $C1
+___
+$code.=<<___ if ($n ge 3);
+    vmovdqa $A0, $A2
+    vmovdqa $B0, $B2
+    vmovdqa $C0, $C2
+___
+$code.=<<___ if ($n ge 4);
+    vmovdqa $A0, $A3
+    vmovdqa $B0, $B3
+    vmovdqa $C0, $C3
+___
+$code.=<<___ if ($n eq 1);
+    vmovdqa .avx2_inc(%rip), $D0
+    vpaddd $ctr0_store, $D0, $D0
+    vmovdqa $D0, $ctr0_store
+___
+$code.=<<___ if ($n eq 2);
+    vmovdqa .avx2_inc(%rip), $D0
+    vpaddd $ctr0_store, $D0, $D1
+    vpaddd $D1, $D0, $D0
+    vmovdqa $D0, $ctr0_store
+    vmovdqa $D1, $ctr1_store
+___
+$code.=<<___ if ($n eq 3);
+    vmovdqa .avx2_inc(%rip), $D0
+    vpaddd $ctr0_store, $D0, $D2
+    vpaddd $D2, $D0, $D1
+    vpaddd $D1, $D0, $D0
+    vmovdqa $D0, $ctr0_store
+    vmovdqa $D1, $ctr1_store
+    vmovdqa $D2, $ctr2_store
+___
+$code.=<<___ if ($n eq 4);
+    vmovdqa .avx2_inc(%rip), $D0
+    vpaddd $ctr0_store, $D0, $D3
+    vpaddd $D3, $D0, $D2
+    vpaddd $D2, $D0, $D1
+    vpaddd $D1, $D0, $D0
+    vmovdqa $D3, $ctr3_store
+    vmovdqa $D2, $ctr2_store
+    vmovdqa $D1, $ctr1_store
+    vmovdqa $D0, $ctr0_store
+___
+}
+
+sub finalize_state_avx2 {
+my ($n)=@_;
+$code.=<<___ if ($n eq 4);
+    vpaddd .chacha20_consts(%rip), $A3, $A3
+    vpaddd $state1_store, $B3, $B3
+    vpaddd $state2_store, $C3, $C3
+    vpaddd $ctr3_store, $D3, $D3
+___
+$code.=<<___ if ($n ge 3);
+    vpaddd .chacha20_consts(%rip), $A2, $A2
+    vpaddd $state1_store, $B2, $B2
+    vpaddd $state2_store, $C2, $C2
+    vpaddd $ctr2_store, $D2, $D2
+___
+$code.=<<___ if ($n ge 2);
+    vpaddd .chacha20_consts(%rip), $A1, $A1
+    vpaddd $state1_store, $B1, $B1
+    vpaddd $state2_store, $C1, $C1
+    vpaddd $ctr1_store, $D1, $D1
+___
+$code.=<<___;
+    vpaddd .chacha20_consts(%rip), $A0, $A0
+    vpaddd $state1_store, $B0, $B0
+    vpaddd $state2_store, $C0, $C0
+    vpaddd $ctr0_store, $D0, $D0
+___
+}
+
+sub xor_stream_avx2 {
+my ($A, $B, $C, $D, $offset, $hlp)=@_;
+$code.=<<___;
+    vperm2i128 \$0x02, $A, $B, $hlp
+    vperm2i128 \$0x13, $A, $B, $B
+    vperm2i128 \$0x02, $C, $D, $A
+    vperm2i128 \$0x13, $C, $D, $C
+    vpxor 0*32+$offset($inp), $hlp, $hlp
+    vpxor 1*32+$offset($inp), $A, $A
+    vpxor 2*32+$offset($inp), $B, $B
+    vpxor 3*32+$offset($inp), $C, $C
+    vmovdqu $hlp, 0*32+$offset($oup)
+    vmovdqu $A, 1*32+$offset($oup)
+    vmovdqu $B, 2*32+$offset($oup)
+    vmovdqu $C, 3*32+$offset($oup)
+___
+}
+
+sub finish_stream_avx2 {
+my ($A, $B, $C, $D, $hlp)=@_;
+$code.=<<___;
+    vperm2i128 \$0x13, $A, $B, $hlp
+    vperm2i128 \$0x02, $A, $B, $A
+    vperm2i128 \$0x02, $C, $D, $B
+    vperm2i128 \$0x13, $C, $D, $D
+    vmovdqa $hlp, $C
+___
+}
+
+sub poly_stage1_mulx {
+$code.=<<___;
+    mov 0+$r_store, %rdx
+    mov %rdx, $t2
+    mulx $acc0, $t0, $t1
+    mulx $acc1, %rax, %rdx
+    imulq $acc2, $t2
+    add %rax, $t1
+    adc %rdx, $t2
+___
+}
+
+sub poly_stage2_mulx {
+$code.=<<___;
+    mov 8+$r_store, %rdx
+    mulx $acc0, $acc0, %rax
+    add $acc0, $t1
+    mulx $acc1, $acc1, $t3
+    adc $acc1, $t2
+    adc \$0, $t3
+    imulq $acc2, %rdx
+___
+}
+
+sub poly_stage3_mulx {
+$code.=<<___;
+    add %rax, $t2
+    adc %rdx, $t3
+___
+}
+
+sub poly_mul_mulx {
+    &poly_stage1_mulx();
+    &poly_stage2_mulx();
+    &poly_stage3_mulx();
+    &poly_reduce_stage();
+}
+
+sub gen_chacha_round_avx2 {
+my ($rot1, $rot2, $shift)=@_;
+my $round="";
+$round=$round ."vmovdqa $C0, $tmp_store\n" if ($rot1 eq 20);
+$round=$round ."vmovdqa $rot2, $C0
+                vpaddd $B3, $A3, $A3
+                vpaddd $B2, $A2, $A2
+                vpaddd $B1, $A1, $A1
+                vpaddd $B0, $A0, $A0
+                vpxor $A3, $D3, $D3
+                vpxor $A2, $D2, $D2
+                vpxor $A1, $D1, $D1
+                vpxor $A0, $D0, $D0
+                vpshufb $C0, $D3, $D3
+                vpshufb $C0, $D2, $D2
+                vpshufb $C0, $D1, $D1
+                vpshufb $C0, $D0, $D0
+                vmovdqa $tmp_store, $C0
+                vpaddd $D3, $C3, $C3
+                vpaddd $D2, $C2, $C2
+                vpaddd $D1, $C1, $C1
+                vpaddd $D0, $C0, $C0
+                vpxor $C3, $B3, $B3
+                vpxor $C2, $B2, $B2
+                vpxor $C1, $B1, $B1
+                vpxor $C0, $B0, $B0
+                vmovdqa $C0, $tmp_store
+                vpsrld \$$rot1, $B3, $C0
+                vpslld \$32-$rot1, $B3, $B3
+                vpxor $C0, $B3, $B3
+                vpsrld \$$rot1, $B2, $C0
+                vpslld \$32-$rot1, $B2, $B2
+                vpxor $C0, $B2, $B2
+                vpsrld \$$rot1, $B1, $C0
+                vpslld \$32-$rot1, $B1, $B1
+                vpxor $C0, $B1, $B1
+                vpsrld \$$rot1, $B0, $C0
+                vpslld \$32-$rot1, $B0, $B0
+                vpxor $C0, $B0, $B0\n";
+($s1,$s2,$s3)=(4,8,12) if ($shift =~ /left/);
+($s1,$s2,$s3)=(12,8,4) if ($shift =~ /right/);
+$round=$round ."vmovdqa $tmp_store, $C0
+                vpalignr \$$s1, $B3, $B3, $B3
+                vpalignr \$$s2, $C3, $C3, $C3
+                vpalignr \$$s3, $D3, $D3, $D3
+                vpalignr \$$s1, $B2, $B2, $B2
+                vpalignr \$$s2, $C2, $C2, $C2
+                vpalignr \$$s3, $D2, $D2, $D2
+                vpalignr \$$s1, $B1, $B1, $B1
+                vpalignr \$$s2, $C1, $C1, $C1
+                vpalignr \$$s3, $D1, $D1, $D1
+                vpalignr \$$s1, $B0, $B0, $B0
+                vpalignr \$$s2, $C0, $C0, $C0
+                vpalignr \$$s3, $D0, $D0, $D0\n"
+if (($shift =~ /left/) || ($shift =~ /right/));
+return $round;
+};
+
+$chacha_body = &gen_chacha_round_avx2(20, ".rol16(%rip)") .
+               &gen_chacha_round_avx2(25, ".rol8(%rip)", "left") .
+               &gen_chacha_round_avx2(20, ".rol16(%rip)") .
+               &gen_chacha_round_avx2(25, ".rol8(%rip)", "right");
+
+@loop_body = split /\n/, $chacha_body;
+
+$code.="
+###############################################################################
+.type chacha20_poly1305_open_avx2,\@function,2
+.align 64
+chacha20_poly1305_open_avx2:
+    vzeroupper
+    vmovdqa .chacha20_consts(%rip), $A0
+    vbroadcasti128 0*16($keyp), $B0
+    vbroadcasti128 1*16($keyp), $C0
+    vbroadcasti128 2*16($keyp), $D0
+    vpaddd .avx2_init(%rip), $D0, $D0
+    cmp \$6*32, $inl
+    jbe open_avx2_192
+    cmp \$10*32, $inl
+    jbe open_avx2_320
+
+    vmovdqa $B0, $state1_store
+    vmovdqa $C0, $state2_store
+    vmovdqa $D0, $ctr0_store
+    mov \$10, $acc0
+1:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right"); $code.="
+        dec $acc0
+    jne 1b
+    vpaddd .chacha20_consts(%rip), $A0, $A0
+    vpaddd $state1_store, $B0, $B0
+    vpaddd $state2_store, $C0, $C0
+    vpaddd $ctr0_store, $D0, $D0
+
+    vperm2i128 \$0x02, $A0, $B0, $T0
+    # Clamp and store key
+    vpand .clamp(%rip), $T0, $T0
+    vmovdqa $T0, $r_store
+    # Stream for the first 64 bytes
+    vperm2i128 \$0x13, $A0, $B0, $A0
+    vperm2i128 \$0x13, $C0, $D0, $B0
+    # Hash AD + first 64 bytes
+    mov %r8, $itr2
+    call poly_hash_ad_internal
+    xor $itr1, $itr1
+    # Hash first 64 bytes
+1:  \n";
+       &poly_add("0($inp, $itr1)");
+       &poly_mul(); $code.="
+       add \$16, $itr1
+       cmp \$2*32, $itr1
+    jne 1b
+    # Decrypt first 64 bytes
+    vpxor 0*32($inp), $A0, $A0
+    vpxor 1*32($inp), $B0, $B0
+    vmovdqu $A0, 0*32($oup)
+    vmovdqu $B0, 1*32($oup)
+    lea 2*32($inp), $inp
+    lea 2*32($oup), $oup
+    sub \$2*32, $inl
+1:
+        # Hash and decrypt 512 bytes each iteration
+        cmp \$16*32, $inl
+        jb 3f\n";
+        &prep_state_avx2(4); $code.="
+        xor $itr1, $itr1
+2:  \n";
+            &poly_add("0*8($inp, $itr1)");
+            &emit_body(10);
+            &poly_stage1_mulx();
+            &emit_body(9);
+            &poly_stage2_mulx();
+            &emit_body(12);
+            &poly_stage3_mulx();
+            &emit_body(10);
+            &poly_reduce_stage();
+            &emit_body(9);
+            &poly_add("2*8($inp, $itr1)");
+            &emit_body(8);
+            &poly_stage1_mulx();
+            &emit_body(18);
+            &poly_stage2_mulx();
+            &emit_body(18);
+            &poly_stage3_mulx();
+            &emit_body(9);
+            &poly_reduce_stage();
+            &emit_body(8);
+            &poly_add("4*8($inp, $itr1)"); $code.="
+            lea 6*8($itr1), $itr1\n";
+            &emit_body(18);
+            &poly_stage1_mulx();
+            &emit_body(8);
+            &poly_stage2_mulx();
+            &emit_body(8);
+            &poly_stage3_mulx();
+            &emit_body(18);
+            &poly_reduce_stage();
+            foreach $l (@loop_body) {$code.=$l."\n";}
+            @loop_body = split /\n/, $chacha_body; $code.="
+            cmp \$10*6*8, $itr1
+        jne 2b\n";
+        &finalize_state_avx2(4); $code.="
+        vmovdqa $A0, $tmp_store\n";
+        &poly_add("10*6*8($inp)");
+        &xor_stream_avx2($A3, $B3, $C3, $D3, 0*32, $A0); $code.="
+        vmovdqa $tmp_store, $A0\n";
+        &poly_mul();
+        &xor_stream_avx2($A2, $B2, $C2, $D2, 4*32, $A3);
+        &poly_add("10*6*8+2*8($inp)");
+        &xor_stream_avx2($A1, $B1, $C1, $D1, 8*32, $A3);
+        &poly_mul();
+        &xor_stream_avx2($A0, $B0, $C0, $D0, 12*32, $A3); $code.="
+        lea 16*32($inp), $inp
+        lea 16*32($oup), $oup
+        sub \$16*32, $inl
+    jmp 1b
+3:
+    test $inl, $inl
+    vzeroupper
+    je open_sse_finalize
+3:
+    cmp \$4*32, $inl
+    ja 3f\n";
+###############################################################################
+    # 1-128 bytes left
+    &prep_state_avx2(1); $code.="
+    xor $itr2, $itr2
+    mov $inl, $itr1
+    and \$-16, $itr1
+    test $itr1, $itr1
+    je 2f
+1:  \n";
+        &poly_add("0*8($inp, $itr2)");
+        &poly_mul(); $code.="
+2:
+        add \$16, $itr2\n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right"); $code.="
+        cmp $itr1, $itr2
+    jb 1b
+        cmp \$160, $itr2
+    jne 2b\n";
+    &finalize_state_avx2(1);
+    &finish_stream_avx2($A0,$B0,$C0,$D0,$T0); $code.="
+    jmp open_avx2_tail_loop
+3:
+    cmp \$8*32, $inl
+    ja 3f\n";
+###############################################################################
+    # 129-256 bytes left
+    &prep_state_avx2(2); $code.="
+    mov $inl, $tmp_store
+    mov $inl, $itr1
+    sub \$4*32, $itr1
+    shr \$4, $itr1
+    mov \$10, $itr2
+    cmp \$10, $itr1
+    cmovg $itr2, $itr1
+    mov $inp, $inl
+    xor $itr2, $itr2
+1:  \n";
+        &poly_add("0*8($inl)");
+        &poly_mul_mulx(); $code.="
+        lea 16($inl), $inl
+2:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"left"); $code.="
+        inc $itr2\n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"right"); $code.="
+        cmp $itr1, $itr2
+    jb 1b
+        cmp \$10, $itr2
+    jne 2b
+    mov $inl, $itr2
+    sub $inp, $inl
+    mov $inl, $itr1
+    mov $tmp_store, $inl
+1:
+        add \$16, $itr1
+        cmp $inl, $itr1
+        jg 1f\n";
+        &poly_add("0*8($itr2)");
+        &poly_mul_mulx(); $code.="
+        lea 16($itr2), $itr2
+    jmp 1b
+1:  \n";
+    &finalize_state_avx2(2);
+    &xor_stream_avx2($A1, $B1, $C1, $D1, 0*32, $T0);
+    &finish_stream_avx2($A0, $B0, $C0, $D0, $T0); $code.="
+    lea 4*32($inp), $inp
+    lea 4*32($oup), $oup
+    sub \$4*32, $inl
+    jmp open_avx2_tail_loop
+3:
+    cmp \$12*32, $inl
+    ja 3f\n";
+###############################################################################
+    # 257-383 bytes left
+    &prep_state_avx2(3); $code.="
+    mov $inl, $tmp_store
+    mov $inl, $itr1
+    sub \$8*32, $itr1
+    shr \$4, $itr1
+    add \$6, $itr1
+    mov \$10, $itr2
+    cmp \$10, $itr1
+    cmovg $itr2, $itr1
+    mov $inp, $inl
+    xor $itr2, $itr2
+1:  \n";
+        &poly_add("0*8($inl)");
+        &poly_mul_mulx(); $code.="
+        lea 16($inl), $inl
+2:  \n";
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"left");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &poly_add("0*8($inl)");
+        &poly_mul(); $code.="
+        lea 16($inl), $inl
+        inc $itr2\n";
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"right");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right"); $code.="
+        cmp $itr1, $itr2
+    jb 1b
+        cmp \$10, $itr2
+    jne 2b
+    mov $inl, $itr2
+    sub $inp, $inl
+    mov $inl, $itr1
+    mov $tmp_store, $inl
+1:
+        add \$16, $itr1
+        cmp $inl, $itr1
+        jg 1f\n";
+        &poly_add("0*8($itr2)");
+        &poly_mul_mulx(); $code.="
+        lea 16($itr2), $itr2
+    jmp 1b
+1:  \n";
+    &finalize_state_avx2(3);
+    &xor_stream_avx2($A2, $B2, $C2, $D2, 0*32, $T0);
+    &xor_stream_avx2($A1, $B1, $C1, $D1, 4*32, $T0);
+    &finish_stream_avx2($A0, $B0, $C0, $D0, $T0); $code.="
+    lea 8*32($inp), $inp
+    lea 8*32($oup), $oup
+    sub \$8*32, $inl
+    jmp open_avx2_tail_loop
+3:  \n";
+###############################################################################
+    # 384-512 bytes left
+    &prep_state_avx2(4); $code.="
+    xor $itr1, $itr1
+    mov $inp, $itr2
+1:  \n";
+        &poly_add("0*8($itr2)");
+        &poly_mul(); $code.="
+        lea 2*8($itr2), $itr2
+2:  \n";
+        &emit_body(37);
+        &poly_add("0*8($itr2)");
+        &poly_mul_mulx();
+        &emit_body(48);
+        &poly_add("2*8($itr2)");
+        &poly_mul_mulx(); $code.="
+        lea 4*8($itr2), $itr2\n";
+        foreach $l (@loop_body) {$code.=$l."\n";}
+        @loop_body = split /\n/, $chacha_body; $code.="
+        inc $itr1
+        cmp \$4, $itr1
+    jl  1b
+        cmp \$10, $itr1
+    jne 2b
+    mov $inl, $itr1
+    sub \$12*32, $itr1
+    and \$-16, $itr1
+1:
+        test $itr1, $itr1
+        je 1f\n";
+        &poly_add("0*8($itr2)");
+        &poly_mul_mulx(); $code.="
+        lea 2*8($itr2), $itr2
+        sub \$2*8, $itr1
+    jmp 1b
+1:  \n";
+    &finalize_state_avx2(4); $code.="
+    vmovdqa $A0, $tmp_store\n";
+    &xor_stream_avx2($A3, $B3, $C3, $D3, 0*32, $A0); $code.="
+    vmovdqa $tmp_store, $A0\n";
+    &xor_stream_avx2($A2, $B2, $C2, $D2, 4*32, $A3);
+    &xor_stream_avx2($A1, $B1, $C1, $D1, 8*32, $A3);
+    &finish_stream_avx2($A0, $B0, $C0, $D0, $A3); $code.="
+    lea 12*32($inp), $inp
+    lea 12*32($oup), $oup
+    sub \$12*32, $inl
+open_avx2_tail_loop:
+    cmp \$32, $inl
+    jb open_avx2_tail
+        sub \$32, $inl
+        vpxor ($inp), $A0, $A0
+        vmovdqu $A0, ($oup)
+        lea 1*32($inp), $inp
+        lea 1*32($oup), $oup
+        vmovdqa $B0, $A0
+        vmovdqa $C0, $B0
+        vmovdqa $D0, $C0
+    jmp open_avx2_tail_loop
+open_avx2_tail:
+    cmp \$16, $inl
+    vmovdqa $A0x, $A1x
+    jb 1f
+    sub \$16, $inl
+    #load for decryption
+    vpxor ($inp), $A0x, $A1x
+    vmovdqu $A1x, ($oup)
+    lea 1*16($inp), $inp
+    lea 1*16($oup), $oup
+    vperm2i128 \$0x11, $A0, $A0, $A0
+    vmovdqa $A0x, $A1x
+1:
+    vzeroupper
+    jmp open_sse_tail_16
+###############################################################################
+open_avx2_192:
+    vmovdqa $A0, $A1
+    vmovdqa $A0, $A2
+    vmovdqa $B0, $B1
+    vmovdqa $B0, $B2
+    vmovdqa $C0, $C1
+    vmovdqa $C0, $C2
+    vpaddd .avx2_inc(%rip), $D0, $D1
+    vmovdqa $D0, $T2
+    vmovdqa $D1, $T3
+    mov \$10, $acc0
+1:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"right"); $code.="
+        dec $acc0
+    jne 1b
+    vpaddd $A2, $A0, $A0
+    vpaddd $A2, $A1, $A1
+    vpaddd $B2, $B0, $B0
+    vpaddd $B2, $B1, $B1
+    vpaddd $C2, $C0, $C0
+    vpaddd $C2, $C1, $C1
+    vpaddd $T2, $D0, $D0
+    vpaddd $T3, $D1, $D1
+    vperm2i128 \$0x02, $A0, $B0, $T0
+    # Clamp and store the key
+    vpand .clamp(%rip), $T0, $T0
+    vmovdqa $T0, $r_store
+    # Stream for up to 192 bytes
+    vperm2i128 \$0x13, $A0, $B0, $A0
+    vperm2i128 \$0x13, $C0, $D0, $B0
+    vperm2i128 \$0x02, $A1, $B1, $C0
+    vperm2i128 \$0x02, $C1, $D1, $D0
+    vperm2i128 \$0x13, $A1, $B1, $A1
+    vperm2i128 \$0x13, $C1, $D1, $B1
+open_avx2_short:
+    mov %r8, $itr2
+    call poly_hash_ad_internal
+open_avx2_hash_and_xor_loop:
+        cmp \$32, $inl
+        jb open_avx2_short_tail_32
+        sub \$32, $inl\n";
+        # Load + hash
+        &poly_add("0*8($inp)");
+        &poly_mul();
+        &poly_add("2*8($inp)");
+        &poly_mul(); $code.="
+        # Load + decrypt
+        vpxor ($inp), $A0, $A0
+        vmovdqu $A0, ($oup)
+        lea 1*32($inp), $inp
+        lea 1*32($oup), $oup
+        # Shift stream
+        vmovdqa $B0, $A0
+        vmovdqa $C0, $B0
+        vmovdqa $D0, $C0
+        vmovdqa $A1, $D0
+        vmovdqa $B1, $A1
+        vmovdqa $C1, $B1
+        vmovdqa $D1, $C1
+        vmovdqa $A2, $D1
+        vmovdqa $B2, $A2
+    jmp open_avx2_hash_and_xor_loop
+open_avx2_short_tail_32:
+    cmp \$16, $inl
+    vmovdqa $A0x, $A1x
+    jb 1f
+    sub \$16, $inl\n";
+    &poly_add("0*8($inp)");
+    &poly_mul(); $code.="
+    vpxor ($inp), $A0x, $A3x
+    vmovdqu $A3x, ($oup)
+    lea 1*16($inp), $inp
+    lea 1*16($oup), $oup
+    vextracti128 \$1, $A0, $A1x
+1:
+    vzeroupper
+    jmp open_sse_tail_16
+###############################################################################
+open_avx2_320:
+    vmovdqa $A0, $A1
+    vmovdqa $A0, $A2
+    vmovdqa $B0, $B1
+    vmovdqa $B0, $B2
+    vmovdqa $C0, $C1
+    vmovdqa $C0, $C2
+    vpaddd .avx2_inc(%rip), $D0, $D1
+    vpaddd .avx2_inc(%rip), $D1, $D2
+    vmovdqa $B0, $T1
+    vmovdqa $C0, $T2
+    vmovdqa $D0, $ctr0_store
+    vmovdqa $D1, $ctr1_store
+    vmovdqa $D2, $ctr2_store
+    mov \$10, $acc0
+1:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"left");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"right"); $code.="
+        dec $acc0
+    jne 1b
+    vpaddd .chacha20_consts(%rip), $A0, $A0
+    vpaddd .chacha20_consts(%rip), $A1, $A1
+    vpaddd .chacha20_consts(%rip), $A2, $A2
+    vpaddd $T1, $B0, $B0
+    vpaddd $T1, $B1, $B1
+    vpaddd $T1, $B2, $B2
+    vpaddd $T2, $C0, $C0
+    vpaddd $T2, $C1, $C1
+    vpaddd $T2, $C2, $C2
+    vpaddd $ctr0_store, $D0, $D0
+    vpaddd $ctr1_store, $D1, $D1
+    vpaddd $ctr2_store, $D2, $D2
+    vperm2i128 \$0x02, $A0, $B0, $T0
+    # Clamp and store the key
+    vpand .clamp(%rip), $T0, $T0
+    vmovdqa $T0, $r_store
+    # Stream for up to 320 bytes
+    vperm2i128 \$0x13, $A0, $B0, $A0
+    vperm2i128 \$0x13, $C0, $D0, $B0
+    vperm2i128 \$0x02, $A1, $B1, $C0
+    vperm2i128 \$0x02, $C1, $D1, $D0
+    vperm2i128 \$0x13, $A1, $B1, $A1
+    vperm2i128 \$0x13, $C1, $D1, $B1
+    vperm2i128 \$0x02, $A2, $B2, $C1
+    vperm2i128 \$0x02, $C2, $D2, $D1
+    vperm2i128 \$0x13, $A2, $B2, $A2
+    vperm2i128 \$0x13, $C2, $D2, $B2
+    jmp open_avx2_short
+.size chacha20_poly1305_open_avx2, .-chacha20_poly1305_open_avx2
+###############################################################################
+###############################################################################
+.type chacha20_poly1305_seal_avx2,\@function,2
+.align 64
+chacha20_poly1305_seal_avx2:
+    vzeroupper
+    vmovdqa .chacha20_consts(%rip), $A0
+    vbroadcasti128 0*16($keyp), $B0
+    vbroadcasti128 1*16($keyp), $C0
+    vbroadcasti128 2*16($keyp), $D0
+    vpaddd .avx2_init(%rip), $D0, $D0
+    cmp \$6*32, $inl
+    jbe seal_avx2_192
+    cmp \$10*32, $inl
+    jbe seal_avx2_320
+    vmovdqa $A0, $A1
+    vmovdqa $A0, $A2
+    vmovdqa $A0, $A3
+    vmovdqa $B0, $B1
+    vmovdqa $B0, $B2
+    vmovdqa $B0, $B3
+    vmovdqa $B0, $state1_store
+    vmovdqa $C0, $C1
+    vmovdqa $C0, $C2
+    vmovdqa $C0, $C3
+    vmovdqa $C0, $state2_store
+    vmovdqa $D0, $D3
+    vpaddd .avx2_inc(%rip), $D3, $D2
+    vpaddd .avx2_inc(%rip), $D2, $D1
+    vpaddd .avx2_inc(%rip), $D1, $D0
+    vmovdqa $D0, $ctr0_store
+    vmovdqa $D1, $ctr1_store
+    vmovdqa $D2, $ctr2_store
+    vmovdqa $D3, $ctr3_store
+    mov \$10, $acc0
+1:  \n";
+        foreach $l (@loop_body) {$code.=$l."\n";}
+        @loop_body = split /\n/, $chacha_body; $code.="
+        dec $acc0
+        jnz 1b\n";
+    &finalize_state_avx2(4); $code.="
+    vperm2i128 \$0x13, $C3, $D3, $C3
+    vperm2i128 \$0x02, $A3, $B3, $D3
+    vperm2i128 \$0x13, $A3, $B3, $A3
+    vpand .clamp(%rip), $D3, $D3
+    vmovdqa $D3, $r_store
+    mov %r8, $itr2
+    call poly_hash_ad_internal
+    # Safely store 320 bytes (otherwise would handle with optimized call)
+    vpxor 0*32($inp), $A3, $A3
+    vpxor 1*32($inp), $C3, $C3
+    vmovdqu $A3, 0*32($oup)
+    vmovdqu $C3, 1*32($oup)\n";
+    &xor_stream_avx2($A2,$B2,$C2,$D2,2*32,$T3);
+    &xor_stream_avx2($A1,$B1,$C1,$D1,6*32,$T3);
+    &finish_stream_avx2($A0,$B0,$C0,$D0,$T3); $code.="
+    lea 10*32($inp), $inp
+    sub \$10*32, $inl
+    mov \$10*32, $itr1
+    cmp \$4*32, $inl
+    jbe seal_avx2_hash
+    vpxor 0*32($inp), $A0, $A0
+    vpxor 1*32($inp), $B0, $B0
+    vpxor 2*32($inp), $C0, $C0
+    vpxor 3*32($inp), $D0, $D0
+    vmovdqu $A0, 10*32($oup)
+    vmovdqu $B0, 11*32($oup)
+    vmovdqu $C0, 12*32($oup)
+    vmovdqu $D0, 13*32($oup)
+    lea 4*32($inp), $inp
+    sub \$4*32, $inl
+    mov \$8, $itr1
+    mov \$2, $itr2
+    cmp \$4*32, $inl
+    jbe seal_avx2_tail_128
+    cmp \$8*32, $inl
+    jbe seal_avx2_tail_256
+    cmp \$12*32, $inl
+    jbe seal_avx2_tail_384
+    cmp \$16*32, $inl
+    jbe seal_avx2_tail_512\n";
+    # We have 448 bytes to hash, but main loop hashes 512 bytes at a time - perform some rounds, before the main loop
+    &prep_state_avx2(4);
+    foreach $l (@loop_body) {$code.=$l."\n";}
+    @loop_body = split /\n/, $chacha_body;
+    &emit_body(41);
+    @loop_body = split /\n/, $chacha_body; $code.="
+    sub \$16, $oup
+    mov \$9, $itr1
+    jmp 4f
+1:  \n";
+        &prep_state_avx2(4); $code.="
+        mov \$10, $itr1
+2:  \n";
+            &poly_add("0*8($oup)");
+            &emit_body(10);
+            &poly_stage1_mulx();
+            &emit_body(9);
+            &poly_stage2_mulx();
+            &emit_body(12);
+            &poly_stage3_mulx();
+            &emit_body(10);
+            &poly_reduce_stage(); $code.="
+4:  \n";
+            &emit_body(9);
+            &poly_add("2*8($oup)");
+            &emit_body(8);
+            &poly_stage1_mulx();
+            &emit_body(18);
+            &poly_stage2_mulx();
+            &emit_body(18);
+            &poly_stage3_mulx();
+            &emit_body(9);
+            &poly_reduce_stage();
+            &emit_body(8);
+            &poly_add("4*8($oup)"); $code.="
+            lea 6*8($oup), $oup\n";
+            &emit_body(18);
+            &poly_stage1_mulx();
+            &emit_body(8);
+            &poly_stage2_mulx();
+            &emit_body(8);
+            &poly_stage3_mulx();
+            &emit_body(18);
+            &poly_reduce_stage();
+            foreach $l (@loop_body) {$code.=$l."\n";}
+            @loop_body = split /\n/, $chacha_body; $code.="
+            dec $itr1
+        jne 2b\n";
+        &finalize_state_avx2(4); $code.="
+        lea 4*8($oup), $oup
+        vmovdqa $A0, $tmp_store\n";
+        &poly_add("-4*8($oup)");
+        &xor_stream_avx2($A3, $B3, $C3, $D3, 0*32, $A0); $code.="
+        vmovdqa $tmp_store, $A0\n";
+        &poly_mul();
+        &xor_stream_avx2($A2, $B2, $C2, $D2, 4*32, $A3);
+        &poly_add("-2*8($oup)");
+        &xor_stream_avx2($A1, $B1, $C1, $D1, 8*32, $A3);
+        &poly_mul();
+        &xor_stream_avx2($A0, $B0, $C0, $D0, 12*32, $A3); $code.="
+        lea 16*32($inp), $inp
+        sub \$16*32, $inl
+        cmp \$16*32, $inl
+    jg 1b\n";
+    &poly_add("0*8($oup)");
+    &poly_mul();
+    &poly_add("2*8($oup)");
+    &poly_mul(); $code.="
+    lea 4*8($oup), $oup
+    mov \$10, $itr1
+    xor $itr2, $itr2
+    cmp \$4*32, $inl
+    ja 3f
+###############################################################################
+seal_avx2_tail_128:\n";
+    &prep_state_avx2(1); $code.="
+1:  \n";
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        lea 2*8($oup), $oup
+2:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &poly_add("0*8($oup)");
+        &poly_mul();
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right");
+        &poly_add("2*8($oup)");
+        &poly_mul(); $code.="
+        lea 4*8($oup), $oup
+        dec $itr1
+    jg 1b
+        dec $itr2
+    jge 2b\n";
+    &finalize_state_avx2(1);
+    &finish_stream_avx2($A0,$B0,$C0,$D0,$T0); $code.="
+    jmp seal_avx2_short_loop
+3:
+    cmp \$8*32, $inl
+    ja 3f
+###############################################################################
+seal_avx2_tail_256:\n";
+    &prep_state_avx2(2); $code.="
+1:  \n";
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        lea 2*8($oup), $oup
+2:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"left");
+        &poly_add("0*8($oup)");
+        &poly_mul();
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"right");
+        &poly_add("2*8($oup)");
+        &poly_mul(); $code.="
+        lea 4*8($oup), $oup
+        dec $itr1
+    jg 1b
+        dec $itr2
+    jge 2b\n";
+    &finalize_state_avx2(2);
+    &xor_stream_avx2($A1,$B1,$C1,$D1,0*32,$T0);
+    &finish_stream_avx2($A0,$B0,$C0,$D0,$T0); $code.="
+    mov \$4*32, $itr1
+    lea 4*32($inp), $inp
+    sub \$4*32, $inl
+    jmp seal_avx2_hash
+3:
+    cmp \$12*32, $inl
+    ja seal_avx2_tail_512
+###############################################################################
+seal_avx2_tail_384:\n";
+    &prep_state_avx2(3); $code.="
+1:  \n";
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        lea 2*8($oup), $oup
+2:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"left");
+        &poly_add("0*8($oup)");
+        &poly_mul();
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"left");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right");
+        &poly_add("2*8($oup)");
+        &poly_mul();
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"right"); $code.="
+        lea 4*8($oup), $oup
+        dec $itr1
+    jg 1b
+        dec $itr2
+    jge 2b\n";
+    &finalize_state_avx2(3);
+    &xor_stream_avx2($A2,$B2,$C2,$D2,0*32,$T0);
+    &xor_stream_avx2($A1,$B1,$C1,$D1,4*32,$T0);
+    &finish_stream_avx2($A0,$B0,$C0,$D0,$T0); $code.="
+    mov \$8*32, $itr1
+    lea 8*32($inp), $inp
+    sub \$8*32, $inl
+    jmp seal_avx2_hash
+###############################################################################
+seal_avx2_tail_512:\n";
+    &prep_state_avx2(4); $code.="
+1:  \n";
+        &poly_add("0($oup)");
+        &poly_mul_mulx(); $code.="
+        lea 2*8($oup), $oup
+2:  \n";
+        &emit_body(20);
+        &poly_add("0*8($oup)");
+        &emit_body(20);
+        &poly_stage1_mulx();
+        &emit_body(20);
+        &poly_stage2_mulx();
+        &emit_body(20);
+        &poly_stage3_mulx();
+        &emit_body(20);
+        &poly_reduce_stage();
+        &emit_body(20);
+        &poly_add("2*8($oup)");
+        &emit_body(20);
+        &poly_stage1_mulx();
+        &emit_body(20);
+        &poly_stage2_mulx();
+        &emit_body(20);
+        &poly_stage3_mulx();
+        &emit_body(20);
+        &poly_reduce_stage();
+        foreach $l (@loop_body) {$code.=$l."\n";}
+        @loop_body = split /\n/, $chacha_body; $code.="
+        lea 4*8($oup), $oup
+        dec $itr1
+    jg 1b
+        dec $itr2
+    jge 2b\n";
+    &finalize_state_avx2(4); $code.="
+    vmovdqa $A0, $tmp_store\n";
+    &xor_stream_avx2($A3, $B3, $C3, $D3, 0*32, $A0); $code.="
+    vmovdqa $tmp_store, $A0\n";
+    &xor_stream_avx2($A2, $B2, $C2, $D2, 4*32, $A3);
+    &xor_stream_avx2($A1, $B1, $C1, $D1, 8*32, $A3);
+    &finish_stream_avx2($A0,$B0,$C0,$D0,$T0); $code.="
+    mov \$12*32, $itr1
+    lea 12*32($inp), $inp
+    sub \$12*32, $inl
+    jmp seal_avx2_hash
+################################################################################
+seal_avx2_320:
+    vmovdqa $A0, $A1
+    vmovdqa $A0, $A2
+    vmovdqa $B0, $B1
+    vmovdqa $B0, $B2
+    vmovdqa $C0, $C1
+    vmovdqa $C0, $C2
+    vpaddd .avx2_inc(%rip), $D0, $D1
+    vpaddd .avx2_inc(%rip), $D1, $D2
+    vmovdqa $B0, $T1
+    vmovdqa $C0, $T2
+    vmovdqa $D0, $ctr0_store
+    vmovdqa $D1, $ctr1_store
+    vmovdqa $D2, $ctr2_store
+    mov \$10, $acc0
+1:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"left");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"right");
+        &chacha_qr_avx2($A2,$B2,$C2,$D2,$T0,"right"); $code.="
+        dec $acc0
+    jne 1b
+    vpaddd .chacha20_consts(%rip), $A0, $A0
+    vpaddd .chacha20_consts(%rip), $A1, $A1
+    vpaddd .chacha20_consts(%rip), $A2, $A2
+    vpaddd $T1, $B0, $B0
+    vpaddd $T1, $B1, $B1
+    vpaddd $T1, $B2, $B2
+    vpaddd $T2, $C0, $C0
+    vpaddd $T2, $C1, $C1
+    vpaddd $T2, $C2, $C2
+    vpaddd $ctr0_store, $D0, $D0
+    vpaddd $ctr1_store, $D1, $D1
+    vpaddd $ctr2_store, $D2, $D2
+    vperm2i128 \$0x02, $A0, $B0, $T0
+    # Clamp and store the key
+    vpand .clamp(%rip), $T0, $T0
+    vmovdqa $T0, $r_store
+    # Stream for up to 320 bytes
+    vperm2i128 \$0x13, $A0, $B0, $A0
+    vperm2i128 \$0x13, $C0, $D0, $B0
+    vperm2i128 \$0x02, $A1, $B1, $C0
+    vperm2i128 \$0x02, $C1, $D1, $D0
+    vperm2i128 \$0x13, $A1, $B1, $A1
+    vperm2i128 \$0x13, $C1, $D1, $B1
+    vperm2i128 \$0x02, $A2, $B2, $C1
+    vperm2i128 \$0x02, $C2, $D2, $D1
+    vperm2i128 \$0x13, $A2, $B2, $A2
+    vperm2i128 \$0x13, $C2, $D2, $B2
+    jmp seal_avx2_short
+################################################################################
+seal_avx2_192:
+    vmovdqa $A0, $A1
+    vmovdqa $A0, $A2
+    vmovdqa $B0, $B1
+    vmovdqa $B0, $B2
+    vmovdqa $C0, $C1
+    vmovdqa $C0, $C2
+    vpaddd .avx2_inc(%rip), $D0, $D1
+    vmovdqa $D0, $T2
+    vmovdqa $D1, $T3
+    mov \$10, $acc0
+1:  \n";
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"left");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"left");
+        &chacha_qr_avx2($A0,$B0,$C0,$D0,$T0,"right");
+        &chacha_qr_avx2($A1,$B1,$C1,$D1,$T0,"right"); $code.="
+        dec $acc0
+    jne 1b
+    vpaddd $A2, $A0, $A0
+    vpaddd $A2, $A1, $A1
+    vpaddd $B2, $B0, $B0
+    vpaddd $B2, $B1, $B1
+    vpaddd $C2, $C0, $C0
+    vpaddd $C2, $C1, $C1
+    vpaddd $T2, $D0, $D0
+    vpaddd $T3, $D1, $D1
+    vperm2i128 \$0x02, $A0, $B0, $T0
+    # Clamp and store the key
+    vpand .clamp(%rip), $T0, $T0
+    vmovdqa $T0, $r_store
+    # Stream for up to 192 bytes
+    vperm2i128 \$0x13, $A0, $B0, $A0
+    vperm2i128 \$0x13, $C0, $D0, $B0
+    vperm2i128 \$0x02, $A1, $B1, $C0
+    vperm2i128 \$0x02, $C1, $D1, $D0
+    vperm2i128 \$0x13, $A1, $B1, $A1
+    vperm2i128 \$0x13, $C1, $D1, $B1
+seal_avx2_short:
+    mov %r8, $itr2
+    call poly_hash_ad_internal
+    xor $itr1, $itr1
+seal_avx2_hash:
+        cmp \$16, $itr1
+        jb seal_avx2_short_loop\n";
+        &poly_add("0($oup)");
+        &poly_mul(); $code.="
+        sub \$16, $itr1
+        add \$16, $oup
+    jmp seal_avx2_hash
+seal_avx2_short_loop:
+        cmp \$32, $inl
+        jb seal_avx2_short_tail
+        sub \$32, $inl
+        # Encrypt
+        vpxor ($inp), $A0, $A0
+        vmovdqu $A0, ($oup)
+        lea 1*32($inp), $inp
+        # Load + hash\n";
+        &poly_add("0*8($oup)");
+        &poly_mul();
+        &poly_add("2*8($oup)");
+        &poly_mul(); $code.="
+        lea 1*32($oup), $oup
+        # Shift stream
+        vmovdqa $B0, $A0
+        vmovdqa $C0, $B0
+        vmovdqa $D0, $C0
+        vmovdqa $A1, $D0
+        vmovdqa $B1, $A1
+        vmovdqa $C1, $B1
+        vmovdqa $D1, $C1
+        vmovdqa $A2, $D1
+        vmovdqa $B2, $A2
+    jmp seal_avx2_short_loop
+seal_avx2_short_tail:
+    cmp \$16, $inl
+    jb 1f
+    sub \$16, $inl
+    vpxor ($inp), $A0x, $A3x
+    vmovdqu $A3x, ($oup)
+    lea 1*16($inp), $inp\n";
+    &poly_add("0*8($oup)");
+    &poly_mul(); $code.="
+    lea 1*16($oup), $oup
+    vextracti128 \$1, $A0, $A0x
+1:
+    vzeroupper
+    jmp seal_sse_tail_16
+.cfi_endproc
+";
+}
+
+if (!$win64) {
+  $code =~ s/\`([^\`]*)\`/eval $1/gem;
+  print $code;
+} else {
+  print <<___;
+.text
+.globl dummy_chacha20_poly1305_asm
+.type dummy_chacha20_poly1305_asm,\@abi-omnipotent
+dummy_chacha20_poly1305_asm:
+    ret
+___
+}
+
+close STDOUT or die "error closing STDOUT";

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -26,6 +26,12 @@ impl From<[u8; KEY_LEN]> for Key {
     }
 }
 
+impl AsRef<[LittleEndian<u32>; KEY_LEN / 4]> for Key {
+    fn as_ref(&self) -> &[LittleEndian<u32>; KEY_LEN / 4] {
+        &self.0
+    }
+}
+
 impl Key {
     #[inline] // Optimize away match on `counter`.
     pub fn encrypt_in_place(&self, counter: Counter, in_out: &mut [u8]) {

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -50,6 +50,34 @@ fn chacha20_poly1305_seal(
     in_out: &mut [u8],
     cpu_features: cpu::Features,
 ) -> Tag {
+    #[cfg(target_arch = "x86_64")]
+    if has_sse41(cpu_features) {
+        let key_block = combine_key_and_nonce(key, nonce);
+
+        extern "C" {
+            fn chacha20_poly1305_seal_asm(
+                in_out: *mut u8,
+                avx2_and_bmi2_capable: u64,
+                len_in: usize,
+                ad: *const u8,
+                len_ad: usize,
+                keyp: &[u32; 12],
+            ) -> TagReturn;
+        }
+
+        return unsafe {
+            chacha20_poly1305_seal_asm(
+                in_out.as_mut_ptr(),
+                if has_avx2_bmi2(cpu_features) { 1 } else { 0 },
+                in_out.len(),
+                aad.as_ref().as_ptr(),
+                aad.as_ref().len(),
+                &key_block,
+            )
+        }
+        .into();
+    }
+
     aead(key, nonce, aad, in_out, Direction::Sealing, cpu_features)
 }
 
@@ -61,6 +89,36 @@ fn chacha20_poly1305_open(
     in_out: &mut [u8],
     cpu_features: cpu::Features,
 ) -> Tag {
+    #[cfg(target_arch = "x86_64")]
+    if has_sse41(cpu_features) {
+        let key_block = combine_key_and_nonce(key, nonce);
+
+        extern "C" {
+            fn chacha20_poly1305_open_asm(
+                in_out: *mut u8,
+                offset: usize,
+                len_in: usize,
+                ad: *const u8,
+                len_ad: usize,
+                keyp: &[u32; 12],
+                avx2_and_bmi2_capable: u64,
+            ) -> TagReturn;
+        }
+
+        return unsafe {
+            chacha20_poly1305_open_asm(
+                in_out.as_mut_ptr(),
+                in_prefix_len,
+                in_out.len() - in_prefix_len,
+                aad.as_ref().as_ptr(),
+                aad.as_ref().len(),
+                &key_block,
+                if has_avx2_bmi2(cpu_features) { 1 } else { 0 },
+            )
+        }
+        .into();
+    }
+
     aead(
         key,
         nonce,
@@ -72,6 +130,46 @@ fn chacha20_poly1305_open(
 }
 
 pub type Key = chacha::Key;
+
+#[cfg(target_arch = "x86_64")]
+#[repr(C)]
+struct TagReturn {
+    lo: u64,
+    hi: u64,
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Into<Tag> for TagReturn {
+    #[inline(always)]
+    fn into(self) -> Tag {
+        let mut tag_vec = [0u8; 16];
+        tag_vec[0..8].copy_from_slice(&self.lo.to_le_bytes());
+        tag_vec[8..16].copy_from_slice(&self.hi.to_le_bytes());
+        Tag(tag_vec)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn combine_key_and_nonce(key: &aead::KeyInner, nonce: Nonce) -> [u32; 12] {
+    let chacha20_key = match key {
+        aead::KeyInner::ChaCha20Poly1305(key) => key,
+        _ => unreachable!(),
+    };
+
+    // Internally the asm version expects the key and nonce values as a consecutive array
+    let mut key_block = [0u32; 12];
+
+    for (i, k) in chacha20_key.as_ref().iter().enumerate() {
+        key_block[i] = (*k).into();
+    }
+    let nonce = nonce.as_ref();
+    key_block[9] = u32::from_le_bytes([nonce[0], nonce[1], nonce[2], nonce[3]]);
+    key_block[10] = u32::from_le_bytes([nonce[4], nonce[5], nonce[6], nonce[7]]);
+    key_block[11] = u32::from_le_bytes([nonce[8], nonce[9], nonce[10], nonce[11]]);
+
+    key_block
+}
 
 #[inline(always)] // Statically eliminate branches on `direction`.
 fn aead(
@@ -141,6 +239,16 @@ pub(super) fn derive_poly1305_key(
     let mut key_bytes = [0u8; 2 * BLOCK_LEN];
     chacha_key.encrypt_iv_xor_blocks_in_place(iv, &mut key_bytes);
     poly1305::Key::new(key_bytes, cpu_features)
+}
+
+#[cfg(target_arch = "x86_64")]
+fn has_sse41(cpu_features: cpu::Features) -> bool {
+    cpu::intel::SSE41.available(cpu_features) && cpu::intel::BMI2.available(cpu_features)
+}
+
+#[cfg(target_arch = "x86_64")]
+fn has_avx2_bmi2(cpu_features: cpu::Features) -> bool {
+    cpu::intel::AVX2.available(cpu_features) && cpu::intel::BMI2.available(cpu_features)
 }
 
 #[cfg(test)]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -359,6 +359,24 @@ pub(crate) mod intel {
         mask: 1 << 28,
     };
 
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) const SSE41: Feature = Feature {
+        word: 1,
+        mask: 1 << 19,
+    };
+
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) const AVX2: Feature = Feature {
+        word: 2,
+        mask: 1 << 5,
+    };
+
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) const BMI2: Feature = Feature {
+        word: 2,
+        mask: 1 << 8,
+    };
+
     #[cfg(all(target_arch = "x86_64", test))]
     mod x86_64_tests {
         use super::*;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -365,18 +365,6 @@ pub(crate) mod intel {
         mask: 1 << 19,
     };
 
-    #[cfg(target_arch = "x86_64")]
-    pub(crate) const AVX2: Feature = Feature {
-        word: 2,
-        mask: 1 << 5,
-    };
-
-    #[cfg(target_arch = "x86_64")]
-    pub(crate) const BMI2: Feature = Feature {
-        word: 2,
-        mask: 1 << 8,
-    };
-
     #[cfg(all(target_arch = "x86_64", test))]
     mod x86_64_tests {
         use super::*;


### PR DESCRIPTION
This is a PR on top of my previous Windows PR.

This is a brand new implementation targeting AArch64. The principle is the same as the SSE4.1 implementation give or take, but takes advantage of the greater number of architectural registers available on AArch64.

The performance I measured (for the seal operation):

Apple A12 | Current | This | Improvement
-- | -- | -- | --
64 | 174.32 | 215.41 | 1.24X
128 | 236.98 | 395.18 | 1.67X
192 | 306.95 | 532.76 | 1.74X
1280 | 574.1 | 933.88 | 1.63X
8192 | 664.77 | 1160.34 | 1.75X

Apple A14 | Current | This |  
-- | -- | -- | --
64 | 216.52 | 259.49 | 1.20X
128 | 296.33 | 479.55 | 1.62X
192 | 392.57 | 666.08 | 1.70X
1280 | 779.28 | 1142.35 | 1.47X
8192 | 909.67 | 1418.39 | 1.56X

Arm N1 platform | Current | This |  Improvement
-- | -- | -- | --
64 | 154.03 | 215.16 | 1.40X
128 | 192.59 | 331.87 | 1.72X
192 | 234.97 | 368.01 | 1.57X
1280 | 359.76 | 727.11 | 2.02X
8192 | 387.71 | 905.49 | 2.34X






