### PR TITLE
Clean up more warning-related stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,23 @@ jobs:
 
     runs-on: ubuntu-18.04
 
+    strategy:
+      matrix:
+        rust_channel:
+          # MSRV
+          - 1.37.0
+          - stable
+
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.37.0
+          toolchain: ${{ matrix.rust_channel }}
           profile: minimal
           components: clippy
 
       - uses: actions/checkout@v2
 
-      - run: cargo +1.37.0 clippy --all-features ---all-targets -- --deny warnings
+      - run: cargo +${{ matrix.rust_channel }} clippy --all-features ---all-targets -- --deny warnings
 
   audit:
     # Don't run duplicate `push` jobs for the repo owner's PRs.

--- a/build.rs
+++ b/build.rs
@@ -19,24 +19,6 @@
 // another for the concrete logging implementation). Instead we use `eprintln!`
 // to log everything to stderr.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 // In the `pregenerate_asm_main()` case we don't want to access (Cargo)
 // environment variables at all, so avoid `use std::env` here.
 

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -300,6 +300,10 @@ impl Key {
         out
     }
 
+    // TODO: use `matches!` when MSRV increases to 1.42.0 and remove this
+    // `#[allow(...)]`
+    #[allow(clippy::unknown_clippy_lints)]
+    #[allow(clippy::match_like_matches_macro)]
     #[cfg(target_arch = "x86_64")]
     #[must_use]
     pub fn is_aes_hw(&self) -> bool {

--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -263,6 +263,11 @@ impl<M> Modulus<M> {
 
         // n_mod_r = n % r. As explained in the documentation for `n0`, this is
         // done by taking the lowest `N0_LIMBS_USED` limbs of `n`.
+        //
+        // TODO: When we stop requiring clippy 1.37.0 to accept the code, clean
+        // up these `#[allow(...)]`s.
+        #[allow(renamed_and_removed_lints, clippy::unknown_clippy_lints)]
+        #[allow(clippy::identity_conversion, clippy::useless_conversion)]
         let n0 = {
             extern "C" {
                 fn GFp_bn_neg_inv_mod_r_u64(n: u64) -> u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@
 #![doc(html_root_url = "https://briansmith.org/rustdoc/")]
 #![allow(
     clippy::collapsible_if,
-    clippy::identity_conversion,
     clippy::identity_op,
     clippy::len_without_is_empty,
     clippy::len_zero,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,16 +70,7 @@
 // `#[derive(...)]` uses `trivial_numeric_casts` and `unused_qualifications`
 // internally.
 #![deny(missing_docs, unused_qualifications, variant_size_differences)]
-#![forbid(
-    anonymous_parameters,
-    trivial_casts,
-    trivial_numeric_casts,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_results,
-    warnings
-)]
+#![forbid(unused_results)]
 #![no_std]
 
 #[cfg(feature = "alloc")]

--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -219,11 +219,9 @@ fn test_aead<Seal, Open>(
         };
         let mut o_in_out = vec![123u8; 4096];
 
-        for in_prefix_len in in_prefix_lengths.iter() {
+        for &in_prefix_len in in_prefix_lengths.iter() {
             o_in_out.truncate(0);
-            for _ in 0..*in_prefix_len {
-                o_in_out.push(123);
-            }
+            o_in_out.resize(in_prefix_len, 123);
             o_in_out.extend_from_slice(&ct[..]);
 
             let nonce = aead::Nonce::try_assume_unique_for_key(&nonce_bytes).unwrap();
@@ -233,7 +231,7 @@ fn test_aead<Seal, Open>(
                 nonce,
                 aead::Aad::from(&aad[..]),
                 &mut o_in_out,
-                *in_prefix_len..,
+                in_prefix_len..,
             );
             match error {
                 None => {

--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -13,23 +13,6 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #![cfg(any(not(target_arch = "wasm32"), feature = "wasm32_c"))]
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};

--- a/tests/agreement_tests.rs
+++ b/tests/agreement_tests.rs
@@ -12,24 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 extern crate alloc;
 
 use ring::{agreement, error, rand, test, test_file};

--- a/tests/agreement_tests.rs
+++ b/tests/agreement_tests.rs
@@ -77,7 +77,6 @@ fn agreement_traits() {
     );
 }
 
-#[allow(clippy::block_in_if_condition_stmt)]
 #[test]
 fn agreement_agree_ephemeral() {
     let rng = rand::SystemRandom::new();
@@ -106,13 +105,12 @@ fn agreement_agree_ephemeral() {
 
                 assert_eq!(my_private.algorithm(), alg);
 
-                assert!(
+                let result =
                     agreement::agree_ephemeral(my_private, &peer_public, (), |key_material| {
                         assert_eq!(key_material, &output[..]);
                         Ok(())
-                    })
-                    .is_ok()
-                );
+                    });
+                assert_eq!(result, Ok(()));
             }
 
             Some(_) => {

--- a/tests/digest_tests.rs
+++ b/tests/digest_tests.rs
@@ -12,24 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 use ring::{digest, test, test_file};
 
 #[cfg(target_arch = "wasm32")]

--- a/tests/ecdsa_tests.rs
+++ b/tests/ecdsa_tests.rs
@@ -86,7 +86,7 @@ fn ecdsa_from_pkcs8_test() {
 
             match (
                 signature::EcdsaKeyPair::from_pkcs8(this_asn1, &input),
-                error.clone(),
+                error,
             ) {
                 (Ok(_), None) => (),
                 (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),

--- a/tests/ecdsa_tests.rs
+++ b/tests/ecdsa_tests.rs
@@ -12,24 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 use ring::{
     rand,
     signature::{self, KeyPair},

--- a/tests/ecdsa_tests.rs
+++ b/tests/ecdsa_tests.rs
@@ -209,7 +209,7 @@ fn ecdsa_test_public_key_coverage() {
     assert_eq!(key_pair.public_key().as_ref(), PUBLIC_KEY);
 
     // Test `Clone`.
-    #[allow(clippy::clone_on_copy)]
+    #[allow(clippy::clone_on_copy, clippy::redundant_clone)]
     let _: <signature::EcdsaKeyPair as KeyPair>::PublicKey = key_pair.public_key().clone();
 
     // Test `Copy`.

--- a/tests/ed25519_tests.rs
+++ b/tests/ed25519_tests.rs
@@ -114,10 +114,7 @@ fn test_ed25519_from_pkcs8_unchecked() {
             let input = test_case.consume_bytes("Input");
             let error = test_case.consume_optional_string("Error");
 
-            match (
-                Ed25519KeyPair::from_pkcs8_maybe_unchecked(&input),
-                error.clone(),
-            ) {
+            match (Ed25519KeyPair::from_pkcs8_maybe_unchecked(&input), error) {
                 (Ok(_), None) => (),
                 (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),
                 (Ok(_), Some(e)) => panic!("Succeeded, but expected error \"{}\"", e),
@@ -139,7 +136,7 @@ fn test_ed25519_from_pkcs8() {
             let input = test_case.consume_bytes("Input");
             let error = test_case.consume_optional_string("Error");
 
-            match (Ed25519KeyPair::from_pkcs8(&input), error.clone()) {
+            match (Ed25519KeyPair::from_pkcs8(&input), error) {
                 (Ok(_), None) => (),
                 (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),
                 (Ok(_), Some(e)) => panic!("Succeeded, but expected error \"{}\"", e),

--- a/tests/ed25519_tests.rs
+++ b/tests/ed25519_tests.rs
@@ -12,24 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 use ring::{
     signature::{self, Ed25519KeyPair, KeyPair},
     test, test_file,

--- a/tests/hkdf_tests.rs
+++ b/tests/hkdf_tests.rs
@@ -12,23 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 use ring::{digest, error, hkdf, test, test_file};
 
 #[cfg(target_arch = "wasm32")]

--- a/tests/hmac_tests.rs
+++ b/tests/hmac_tests.rs
@@ -12,24 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 use ring::{digest, error, hmac, test, test_file};
 
 #[cfg(target_arch = "wasm32")]

--- a/tests/pbkdf2_tests.rs
+++ b/tests/pbkdf2_tests.rs
@@ -12,24 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 use core::num::NonZeroU32;
 use ring::{digest, error, pbkdf2, test, test_file};
 

--- a/tests/quic_tests.rs
+++ b/tests/quic_tests.rs
@@ -12,24 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 use ring::{aead::quic, test, test_file};
 
 #[test]

--- a/tests/rsa_tests.rs
+++ b/tests/rsa_tests.rs
@@ -12,24 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 #[cfg(feature = "alloc")]
 use ring::{
     error,


### PR DESCRIPTION
Deal with CI testing breakage caused by a change to the warning behavior of the most recent Rust Nightly.

Do what's needed to become compatible with Rust Stable Clippy.

Check with both the current Rust Stable Clippy and 1.37's (MSRV) Clippy.

See the individual commit messages for more details.