### PR TITLE
AEAD: Remove all the `unsafe` from `Block` and clean up its API

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -21,7 +21,6 @@
 //! [AEAD]: http://www-cse.ucsd.edu/~mihir/papers/oem.html
 //! [`crypto.cipher.AEAD`]: https://golang.org/pkg/crypto/cipher/#AEAD
 
-use self::block::{Block, BLOCK_LEN};
 use crate::{constant_time, cpu, error, hkdf, polyfill};
 use core::ops::RangeFrom;
 
@@ -646,7 +645,7 @@ impl AsRef<[u8]> for Tag {
 const MAX_KEY_LEN: usize = 32;
 
 // All the AEADs we support use 128-bit tags.
-const TAG_LEN: usize = BLOCK_LEN;
+const TAG_LEN: usize = 16;
 
 /// The maximum length of a tag for the algorithms in this module.
 pub const MAX_TAG_LEN: usize = TAG_LEN;

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -196,9 +196,8 @@ impl Key {
 
     #[inline]
     pub fn encrypt_iv_xor_block(&self, iv: Iv, input: Block) -> Block {
-        let mut output = self.encrypt_block(Block::from(&iv.into_bytes_less_safe()));
-        output.bitxor_assign(input);
-        output
+        let encrypted_iv = self.encrypt_block(Block::from(&iv.into_bytes_less_safe()));
+        encrypted_iv ^ input
     }
 
     #[inline]

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -12,7 +12,13 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{counter, iv::Iv, quic::Sample, Block, Direction, BLOCK_LEN};
+use super::{
+    block::{Block, BLOCK_LEN},
+    counter,
+    iv::Iv,
+    quic::Sample,
+    Direction,
+};
 use crate::{bits::BitLength, c, cpu, endian::*, error, polyfill};
 
 pub(crate) struct Key {
@@ -410,7 +416,7 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::BLOCK_LEN, *};
+    use super::*;
     use crate::test;
     use core::convert::TryInto;
 

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -14,7 +14,8 @@
 
 use super::{
     aes::{self, Counter},
-    gcm, shift, Aad, Block, Direction, Nonce, Tag, BLOCK_LEN,
+    block::{Block, BLOCK_LEN},
+    gcm, shift, Aad, Direction, Nonce, Tag,
 };
 use crate::{aead, cpu, endian::*, error, polyfill};
 

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -13,38 +13,18 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{endian::*, polyfill};
+use core::ops::{BitXor, BitXorAssign};
 
-/// An array of 16 bytes that can (in the x86_64 and AAarch64 ABIs, at least)
-/// be efficiently passed by value and returned by value (i.e. in registers),
-/// and which meets the alignment requirements of `u32` and `u64` (at least)
-/// for the target.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct Block {
-    subblocks: [u64; 2],
-}
+pub struct Block([BigEndian<u64>; 2]);
 
 pub const BLOCK_LEN: usize = 16;
 
 impl Block {
     #[inline]
     pub fn zero() -> Self {
-        Self { subblocks: [0, 0] }
-    }
-
-    #[inline]
-    pub fn from_u64_be(first: BigEndian<u64>, second: BigEndian<u64>) -> Self {
-        #[allow(deprecated)]
-        Self {
-            subblocks: [first.into_raw_value(), second.into_raw_value()],
-        }
-    }
-
-    pub fn u64s_be_to_native(&self) -> [u64; 2] {
-        [
-            u64::from_be(self.subblocks[0]),
-            u64::from_be(self.subblocks[1]),
-        ]
+        Self([Encoding::ZERO; 2])
     }
 
     #[inline]
@@ -60,53 +40,52 @@ impl Block {
         polyfill::slice::fill(&mut tmp[index..], 0);
         *self = Self::from(&tmp)
     }
+}
 
+impl From<[u64; 2]> for Block {
     #[inline]
-    pub fn bitxor_assign(&mut self, a: Block) {
-        for (r, a) in self.subblocks.iter_mut().zip(a.subblocks.iter()) {
+    fn from(other: [u64; 2]) -> Self {
+        Self([other[0].into(), other[1].into()])
+    }
+}
+
+impl Into<[u64; 2]> for Block {
+    #[inline]
+    fn into(self) -> [u64; 2] {
+        [self.0[0].into(), self.0[1].into()]
+    }
+}
+
+impl BitXorAssign for Block {
+    #[inline]
+    fn bitxor_assign(&mut self, a: Self) {
+        for (r, a) in self.0.iter_mut().zip(a.0.iter()) {
             *r ^= *a;
         }
+    }
+}
+
+impl BitXor for Block {
+    type Output = Self;
+
+    #[inline]
+    fn bitxor(self, a: Self) -> Self {
+        let mut r = self;
+        r.bitxor_assign(a);
+        r
     }
 }
 
 impl From<&'_ [u8; BLOCK_LEN]> for Block {
     #[inline]
     fn from(bytes: &[u8; BLOCK_LEN]) -> Self {
-        unsafe { core::mem::transmute_copy(bytes) }
+        Self(FromByteArray::from_byte_array(bytes))
     }
 }
 
 impl AsRef<[u8; BLOCK_LEN]> for Block {
-    #[allow(clippy::transmute_ptr_to_ptr)]
     #[inline]
     fn as_ref(&self) -> &[u8; BLOCK_LEN] {
-        unsafe { core::mem::transmute(self) }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_bitxor_assign() {
-        const ONES: u64 = -1i64 as u64;
-        const TEST_CASES: &[([u64; 2], [u64; 2], [u64; 2])] = &[
-            ([0, 0], [0, 0], [0, 0]),
-            ([0, 0], [ONES, ONES], [ONES, ONES]),
-            ([0, ONES], [ONES, 0], [ONES, ONES]),
-            ([ONES, 0], [0, ONES], [ONES, ONES]),
-            ([ONES, ONES], [ONES, ONES], [0, 0]),
-        ];
-        for (expected_result, a, b) in TEST_CASES {
-            let mut r = Block::from_u64_be(a[0].into(), a[1].into());
-            r.bitxor_assign(Block::from_u64_be(b[0].into(), b[1].into()));
-            assert_eq!(*expected_result, r.subblocks);
-
-            // XOR is symmetric.
-            let mut r = Block::from_u64_be(b[0].into(), b[1].into());
-            r.bitxor_assign(Block::from_u64_be(a[0].into(), a[1].into()));
-            assert_eq!(*expected_result, r.subblocks);
-        }
+        self.0.as_byte_array()
     }
 }

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -32,16 +32,6 @@ impl Block {
         Self { subblocks: [0, 0] }
     }
 
-    // TODO: Remove this.
-    #[inline]
-    pub fn from_u64_le(first: LittleEndian<u64>, second: LittleEndian<u64>) -> Self {
-        #[allow(deprecated)]
-        Self {
-            subblocks: [first.into_raw_value(), second.into_raw_value()],
-        }
-    }
-
-    // TODO: Remove this.
     #[inline]
     pub fn from_u64_be(first: BigEndian<u64>, second: BigEndian<u64>) -> Self {
         #[allow(deprecated)]
@@ -109,13 +99,13 @@ mod tests {
             ([ONES, ONES], [ONES, ONES], [0, 0]),
         ];
         for (expected_result, a, b) in TEST_CASES {
-            let mut r = Block::from_u64_le(a[0].into(), a[1].into());
-            r.bitxor_assign(Block::from_u64_le(b[0].into(), b[1].into()));
+            let mut r = Block::from_u64_be(a[0].into(), a[1].into());
+            r.bitxor_assign(Block::from_u64_be(b[0].into(), b[1].into()));
             assert_eq!(*expected_result, r.subblocks);
 
             // XOR is symmetric.
-            let mut r = Block::from_u64_le(b[0].into(), b[1].into());
-            r.bitxor_assign(Block::from_u64_le(a[0].into(), a[1].into()));
+            let mut r = Block::from_u64_be(b[0].into(), b[1].into());
+            r.bitxor_assign(Block::from_u64_be(a[0].into(), a[1].into()));
             assert_eq!(*expected_result, r.subblocks);
         }
     }

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -13,7 +13,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{counter, iv::Iv, quic::Sample, BLOCK_LEN};
+use super::{counter, iv::Iv, quic::Sample};
 use crate::{c, endian::*};
 
 #[repr(transparent)]
@@ -40,7 +40,7 @@ impl Key {
     }
 
     #[inline] // Optimize away match on `iv` and length check.
-    pub fn encrypt_iv_xor_blocks_in_place(&self, iv: Iv, in_out: &mut [u8; 2 * BLOCK_LEN]) {
+    pub fn encrypt_iv_xor_in_place(&self, iv: Iv, in_out: &mut [u8; 32]) {
         unsafe {
             self.encrypt(
                 CounterOrIv::Iv(iv),
@@ -130,8 +130,7 @@ enum CounterOrIv {
     Iv(Iv),
 }
 
-const KEY_BLOCKS: usize = 2;
-pub const KEY_LEN: usize = KEY_BLOCKS * BLOCK_LEN;
+pub const KEY_LEN: usize = 32;
 
 #[cfg(test)]
 mod tests {

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -15,7 +15,7 @@
 use super::{
     chacha::{self, Counter},
     iv::Iv,
-    poly1305, Aad, Block, Direction, Nonce, Tag, TAG_LEN,
+    poly1305, Aad, Direction, Nonce, Tag, TAG_LEN,
 };
 use crate::{aead, cpu, endian::*, error, polyfill};
 use core::convert::TryInto;
@@ -109,11 +109,11 @@ fn aead(
     };
 
     ctx.update(
-        Block::from_u64_le(
+        [
             LittleEndian::from(polyfill::u64_from_usize(aad.len())),
             LittleEndian::from(polyfill::u64_from_usize(in_out_len)),
-        )
-        .as_ref(),
+        ]
+        .as_byte_array(),
     );
     ctx.finish()
 }

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -15,7 +15,7 @@
 use super::{
     chacha::{self, Counter},
     iv::Iv,
-    poly1305, Aad, Block, Direction, Nonce, Tag, BLOCK_LEN,
+    poly1305, Aad, Block, Direction, Nonce, Tag, TAG_LEN,
 };
 use crate::{aead, cpu, endian::*, error, polyfill};
 use core::convert::TryInto;
@@ -120,7 +120,7 @@ fn aead(
 
 #[inline]
 fn poly1305_update_padded_16(ctx: &mut poly1305::Context, input: &[u8]) {
-    let remainder_len = input.len() % BLOCK_LEN;
+    let remainder_len = input.len() % TAG_LEN;
     let whole_len = input.len() - remainder_len;
     if whole_len > 0 {
         ctx.update(&input[..whole_len]);
@@ -138,8 +138,8 @@ pub(super) fn derive_poly1305_key(
     iv: Iv,
     cpu_features: cpu::Features,
 ) -> poly1305::Key {
-    let mut key_bytes = [0u8; 2 * BLOCK_LEN];
-    chacha_key.encrypt_iv_xor_blocks_in_place(iv, &mut key_bytes);
+    let mut key_bytes = [0u8; poly1305::KEY_LEN];
+    chacha_key.encrypt_iv_xor_in_place(iv, &mut key_bytes);
     poly1305::Key::new(key_bytes, cpu_features)
 }
 

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -13,6 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{
+    block::Block,
     chacha::{self, Counter},
     iv::Iv,
     poly1305, Aad, Direction, Nonce, Tag, TAG_LEN,

--- a/src/aead/chacha20_poly1305_openssh.rs
+++ b/src/aead/chacha20_poly1305_openssh.rs
@@ -181,7 +181,7 @@ pub const KEY_LEN: usize = chacha::KEY_LEN * 2;
 pub const PACKET_LENGTH_LEN: usize = 4; // 32 bits
 
 /// The length in bytes of an authentication tag.
-pub const TAG_LEN: usize = super::BLOCK_LEN;
+pub const TAG_LEN: usize = super::TAG_LEN;
 
 fn verify(key: poly1305::Key, msg: &[u8], tag: &[u8; TAG_LEN]) -> Result<(), error::Unspecified> {
     let Tag(calculated_tag) = poly1305::sign(key, msg);

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -12,7 +12,10 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{Aad, Block, BLOCK_LEN};
+use super::{
+    block::{Block, BLOCK_LEN},
+    Aad,
+};
 use crate::cpu;
 
 #[cfg(not(target_arch = "aarch64"))]

--- a/src/aead/gcm/gcm_nohw.rs
+++ b/src/aead/gcm/gcm_nohw.rs
@@ -23,7 +23,6 @@
 // Unlike the BearSSL notes, we use u128 in the 64-bit implementation.
 
 use super::{Block, Xi};
-use crate::endian::BigEndian;
 use core::convert::TryInto;
 
 #[cfg(target_pointer_width = "64")]
@@ -235,8 +234,8 @@ pub(super) fn ghash(xi: &mut Xi, h: super::u128, input: &[u8]) {
 
 #[inline]
 fn with_swapped_xi(Xi(xi): &mut Xi, f: impl FnOnce(&mut [u64; 2])) {
-    let unswapped = xi.u64s_be_to_native();
+    let unswapped: [u64; 2] = (*xi).into();
     let mut swapped: [u64; 2] = [unswapped[1], unswapped[0]];
     f(&mut swapped);
-    *xi = Block::from_u64_be(BigEndian::from(swapped[1]), BigEndian::from(swapped[0]))
+    *xi = Block::from([swapped[1], swapped[0]])
 }

--- a/src/aead/gcm/gcm_nohw.rs
+++ b/src/aead/gcm/gcm_nohw.rs
@@ -22,7 +22,7 @@
 //
 // Unlike the BearSSL notes, we use u128 in the 64-bit implementation.
 
-use super::{super::Block, Xi};
+use super::{Block, Xi};
 use crate::endian::BigEndian;
 use core::convert::TryInto;
 

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -15,7 +15,7 @@
 
 // TODO: enforce maximum input length.
 
-use super::{block::BLOCK_LEN, Tag, TAG_LEN};
+use super::{Tag, TAG_LEN};
 use crate::{c, cpu};
 
 /// A Poly1305 key.
@@ -24,7 +24,7 @@ pub(super) struct Key {
     cpu_features: cpu::Features,
 }
 
-const KEY_LEN: usize = 2 * BLOCK_LEN;
+const KEY_LEN: usize = 2 * TAG_LEN;
 
 impl Key {
     #[inline]
@@ -141,7 +141,7 @@ mod tests {
         test::run(test_file!("poly1305_test.txt"), |section, test_case| {
             assert_eq!(section, "");
             let key = test_case.consume_bytes("Key");
-            let key: &[u8; BLOCK_LEN * 2] = key.as_slice().try_into().unwrap();
+            let key: &[u8; KEY_LEN] = key.as_slice().try_into().unwrap();
             let input = test_case.consume_bytes("Input");
             let expected_mac = test_case.consume_bytes("MAC");
             let key = Key::new(*key, cpu_features);

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -24,7 +24,7 @@ pub(super) struct Key {
     cpu_features: cpu::Features,
 }
 
-const KEY_LEN: usize = 2 * TAG_LEN;
+pub(super) const KEY_LEN: usize = 2 * TAG_LEN;
 
 impl Key {
     #[inline]

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -35,21 +35,25 @@ macro_rules! define_endian {
         #[repr(transparent)]
         pub struct $endian<T>(T);
 
-        impl<T> $endian<T> {
-            #[deprecated]
-            pub fn into_raw_value(self) -> T {
-                self.0
-            }
-        }
-
         impl<T> Copy for $endian<T> where T: Copy {}
 
         impl<T> Clone for $endian<T>
         where
             T: Clone,
         {
+            #[inline]
             fn clone(&self) -> Self {
                 Self(self.0.clone())
+            }
+        }
+
+        impl<T> core::ops::BitXorAssign for $endian<T>
+        where
+            T: core::ops::BitXorAssign,
+        {
+            #[inline(always)]
+            fn bitxor_assign(&mut self, a: Self) {
+                self.0 ^= a.0;
             }
         }
     };
@@ -60,6 +64,7 @@ macro_rules! impl_from_byte_array {
         impl FromByteArray<[u8; $elems * core::mem::size_of::<$base>()]>
             for [$endian<$base>; $elems]
         {
+            #[inline]
             fn from_byte_array(a: &[u8; $elems * core::mem::size_of::<$base>()]) -> Self {
                 unsafe { core::mem::transmute_copy(a) }
             }
@@ -72,6 +77,7 @@ macro_rules! impl_array_encoding {
         impl ArrayEncoding<[u8; $elems * core::mem::size_of::<$base>()]>
             for [$endian<$base>; $elems]
         {
+            #[inline]
             fn as_byte_array(&self) -> &[u8; $elems * core::mem::size_of::<$base>()] {
                 as_byte_slice(self).try_into().unwrap()
             }


### PR DESCRIPTION
Remove all (direct) uses of `unsafe` from `Block` by re-implementing it in terms of `ring::endian`.

Simplify its API from the caller's perspective.
