### PR TITLE
Remove now-superfluous uses of `ring::aead::block`

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -21,7 +21,6 @@
 //! [AEAD]: http://www-cse.ucsd.edu/~mihir/papers/oem.html
 //! [`crypto.cipher.AEAD`]: https://golang.org/pkg/crypto/cipher/#AEAD
 
-use self::block::{Block, BLOCK_LEN};
 use crate::{constant_time, cpu, error, hkdf, polyfill};
 use core::ops::RangeFrom;
 
@@ -646,7 +645,7 @@ impl AsRef<[u8]> for Tag {
 const MAX_KEY_LEN: usize = 32;
 
 // All the AEADs we support use 128-bit tags.
-const TAG_LEN: usize = BLOCK_LEN;
+const TAG_LEN: usize = 16;
 
 /// The maximum length of a tag for the algorithms in this module.
 pub const MAX_TAG_LEN: usize = TAG_LEN;

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -12,7 +12,13 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{counter, iv::Iv, quic::Sample, Block, Direction, BLOCK_LEN};
+use super::{
+    block::{Block, BLOCK_LEN},
+    counter,
+    iv::Iv,
+    quic::Sample,
+    Direction,
+};
 use crate::{bits::BitLength, c, cpu, endian::*, error, polyfill};
 
 pub(crate) struct Key {
@@ -410,7 +416,7 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::BLOCK_LEN, *};
+    use super::*;
     use crate::test;
     use core::convert::TryInto;
 

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -14,7 +14,8 @@
 
 use super::{
     aes::{self, Counter},
-    gcm, shift, Aad, Block, Direction, Nonce, Tag, BLOCK_LEN,
+    block::{Block, BLOCK_LEN},
+    gcm, shift, Aad, Direction, Nonce, Tag,
 };
 use crate::{aead, cpu, endian::*, error, polyfill};
 

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -32,16 +32,6 @@ impl Block {
         Self { subblocks: [0, 0] }
     }
 
-    // TODO: Remove this.
-    #[inline]
-    pub fn from_u64_le(first: LittleEndian<u64>, second: LittleEndian<u64>) -> Self {
-        #[allow(deprecated)]
-        Self {
-            subblocks: [first.into_raw_value(), second.into_raw_value()],
-        }
-    }
-
-    // TODO: Remove this.
     #[inline]
     pub fn from_u64_be(first: BigEndian<u64>, second: BigEndian<u64>) -> Self {
         #[allow(deprecated)]
@@ -109,13 +99,13 @@ mod tests {
             ([ONES, ONES], [ONES, ONES], [0, 0]),
         ];
         for (expected_result, a, b) in TEST_CASES {
-            let mut r = Block::from_u64_le(a[0].into(), a[1].into());
-            r.bitxor_assign(Block::from_u64_le(b[0].into(), b[1].into()));
+            let mut r = Block::from_u64_be(a[0].into(), a[1].into());
+            r.bitxor_assign(Block::from_u64_be(b[0].into(), b[1].into()));
             assert_eq!(*expected_result, r.subblocks);
 
             // XOR is symmetric.
-            let mut r = Block::from_u64_le(b[0].into(), b[1].into());
-            r.bitxor_assign(Block::from_u64_le(a[0].into(), a[1].into()));
+            let mut r = Block::from_u64_be(b[0].into(), b[1].into());
+            r.bitxor_assign(Block::from_u64_be(a[0].into(), a[1].into()));
             assert_eq!(*expected_result, r.subblocks);
         }
     }

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -13,7 +13,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{counter, iv::Iv, quic::Sample, BLOCK_LEN};
+use super::{counter, iv::Iv, quic::Sample};
 use crate::{c, endian::*};
 
 #[repr(transparent)]
@@ -40,7 +40,7 @@ impl Key {
     }
 
     #[inline] // Optimize away match on `iv` and length check.
-    pub fn encrypt_iv_xor_blocks_in_place(&self, iv: Iv, in_out: &mut [u8; 2 * BLOCK_LEN]) {
+    pub fn encrypt_iv_xor_in_place(&self, iv: Iv, in_out: &mut [u8; 32]) {
         unsafe {
             self.encrypt(
                 CounterOrIv::Iv(iv),
@@ -130,8 +130,7 @@ enum CounterOrIv {
     Iv(Iv),
 }
 
-const KEY_BLOCKS: usize = 2;
-pub const KEY_LEN: usize = KEY_BLOCKS * BLOCK_LEN;
+pub const KEY_LEN: usize = 32;
 
 #[cfg(test)]
 mod tests {

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -15,7 +15,7 @@
 use super::{
     chacha::{self, Counter},
     iv::Iv,
-    poly1305, Aad, Block, Direction, Nonce, Tag, TAG_LEN,
+    poly1305, Aad, Direction, Nonce, Tag, TAG_LEN,
 };
 use crate::{aead, cpu, endian::*, error, polyfill};
 use core::convert::TryInto;
@@ -109,11 +109,11 @@ fn aead(
     };
 
     ctx.update(
-        Block::from_u64_le(
+        [
             LittleEndian::from(polyfill::u64_from_usize(aad.len())),
             LittleEndian::from(polyfill::u64_from_usize(in_out_len)),
-        )
-        .as_ref(),
+        ]
+        .as_byte_array(),
     );
     ctx.finish()
 }

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -15,7 +15,7 @@
 use super::{
     chacha::{self, Counter},
     iv::Iv,
-    poly1305, Aad, Block, Direction, Nonce, Tag, BLOCK_LEN,
+    poly1305, Aad, Block, Direction, Nonce, Tag, TAG_LEN,
 };
 use crate::{aead, cpu, endian::*, error, polyfill};
 use core::convert::TryInto;
@@ -120,7 +120,7 @@ fn aead(
 
 #[inline]
 fn poly1305_update_padded_16(ctx: &mut poly1305::Context, input: &[u8]) {
-    let remainder_len = input.len() % BLOCK_LEN;
+    let remainder_len = input.len() % TAG_LEN;
     let whole_len = input.len() - remainder_len;
     if whole_len > 0 {
         ctx.update(&input[..whole_len]);
@@ -138,8 +138,8 @@ pub(super) fn derive_poly1305_key(
     iv: Iv,
     cpu_features: cpu::Features,
 ) -> poly1305::Key {
-    let mut key_bytes = [0u8; 2 * BLOCK_LEN];
-    chacha_key.encrypt_iv_xor_blocks_in_place(iv, &mut key_bytes);
+    let mut key_bytes = [0u8; poly1305::KEY_LEN];
+    chacha_key.encrypt_iv_xor_in_place(iv, &mut key_bytes);
     poly1305::Key::new(key_bytes, cpu_features)
 }
 

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -13,6 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{
+    block::Block,
     chacha::{self, Counter},
     iv::Iv,
     poly1305, Aad, Direction, Nonce, Tag, TAG_LEN,

--- a/src/aead/chacha20_poly1305_openssh.rs
+++ b/src/aead/chacha20_poly1305_openssh.rs
@@ -181,7 +181,7 @@ pub const KEY_LEN: usize = chacha::KEY_LEN * 2;
 pub const PACKET_LENGTH_LEN: usize = 4; // 32 bits
 
 /// The length in bytes of an authentication tag.
-pub const TAG_LEN: usize = super::BLOCK_LEN;
+pub const TAG_LEN: usize = super::TAG_LEN;
 
 fn verify(key: poly1305::Key, msg: &[u8], tag: &[u8; TAG_LEN]) -> Result<(), error::Unspecified> {
     let Tag(calculated_tag) = poly1305::sign(key, msg);

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -12,7 +12,10 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{Aad, Block, BLOCK_LEN};
+use super::{
+    block::{Block, BLOCK_LEN},
+    Aad,
+};
 use crate::cpu;
 
 #[cfg(not(target_arch = "aarch64"))]

--- a/src/aead/gcm/gcm_nohw.rs
+++ b/src/aead/gcm/gcm_nohw.rs
@@ -22,7 +22,7 @@
 //
 // Unlike the BearSSL notes, we use u128 in the 64-bit implementation.
 
-use super::{super::Block, Xi};
+use super::{Block, Xi};
 use crate::endian::BigEndian;
 use core::convert::TryInto;
 

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -15,7 +15,7 @@
 
 // TODO: enforce maximum input length.
 
-use super::{block::BLOCK_LEN, Tag, TAG_LEN};
+use super::{Tag, TAG_LEN};
 use crate::{c, cpu};
 
 /// A Poly1305 key.
@@ -24,7 +24,7 @@ pub(super) struct Key {
     cpu_features: cpu::Features,
 }
 
-const KEY_LEN: usize = 2 * BLOCK_LEN;
+const KEY_LEN: usize = 2 * TAG_LEN;
 
 impl Key {
     #[inline]
@@ -141,7 +141,7 @@ mod tests {
         test::run(test_file!("poly1305_test.txt"), |section, test_case| {
             assert_eq!(section, "");
             let key = test_case.consume_bytes("Key");
-            let key: &[u8; BLOCK_LEN * 2] = key.as_slice().try_into().unwrap();
+            let key: &[u8; KEY_LEN] = key.as_slice().try_into().unwrap();
             let input = test_case.consume_bytes("Input");
             let expected_mac = test_case.consume_bytes("MAC");
             let key = Key::new(*key, cpu_features);

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -24,7 +24,7 @@ pub(super) struct Key {
     cpu_features: cpu::Features,
 }
 
-const KEY_LEN: usize = 2 * TAG_LEN;
+pub(super) const KEY_LEN: usize = 2 * TAG_LEN;
 
 impl Key {
     #[inline]


### PR DESCRIPTION
After recent refactorings, especailly the switch to BoringSSL's Poly1305, the use of `ring::aead::block` outside of AES and GCM doesn't make so much sense. Clean up those uses.