### PR TITLE
CI/CD: Run tests on MSRV; use only latest stable Clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,13 +172,42 @@ jobs:
 
         rust_channel:
           - stable
-          - beta
           - nightly
+          - 1.37.0 # MSRV
+          - beta
 
         exclude:
           # The stable channel doesn't have aarch64-apple-darwin support yet.
           - target: aarch64-apple-darwin
             rust_channel: stable
+
+          # The MSRV channel doesn't have aarch64-apple-darwin support yet.
+          - target: aarch64-apple-darwin
+            rust_channel: 1.37.0
+
+          # Only do MSRV testing on release builds.
+          - mode: # debug
+            rust_channel: 1.37.0
+
+          # 1.37.0 doesn't support `-Clink-self-contained`.
+          - target: aarch64-unknown-linux-musl
+            rust_channel: 1.37.0
+
+          # 1.37.0 doesn't support `-Clink-self-contained`.
+          - target: armv7-unknown-linux-musleabihf
+            rust_channel: 1.37.0
+
+          # 1.37.0 doesn't support `-Clink-self-contained`.
+          - target: i686-unknown-linux-musl
+            rust_channel: 1.37.0
+
+          # 1.37.0 doesn't support `-Clink-self-contained`.
+          - target: x86_64-unknown-linux-musl
+            rust_channel: 1.37.0
+
+          # https://github.com/rust-lang/rust/pull/67429
+          - target: x86_64-pc-windows-gnu
+            rust_channel: 1.37.0
 
         include:
           - target: aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,16 @@ jobs:
 
     runs-on: ubuntu-18.04
 
-    strategy:
-      matrix:
-        rust_channel:
-          # MSRV
-          - 1.37.0
-          - stable
-
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust_channel }}
+          toolchain: stable
           profile: minimal
           components: clippy
 
       - uses: actions/checkout@v2
 
-      - run: cargo +${{ matrix.rust_channel }} clippy --all-features ---all-targets -- --deny warnings
+      - run: cargo clippy --all-features ---all-targets -- --deny warnings
 
   audit:
     # Don't run duplicate `push` jobs for the repo owner's PRs.

--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -263,11 +263,7 @@ impl<M> Modulus<M> {
 
         // n_mod_r = n % r. As explained in the documentation for `n0`, this is
         // done by taking the lowest `N0_LIMBS_USED` limbs of `n`.
-        //
-        // TODO: When we stop requiring clippy 1.37.0 to accept the code, clean
-        // up these `#[allow(...)]`s.
-        #[allow(renamed_and_removed_lints, clippy::unknown_clippy_lints)]
-        #[allow(clippy::identity_conversion, clippy::useless_conversion)]
+        #[allow(clippy::useless_conversion)]
         let n0 = {
             extern "C" {
                 fn GFp_bn_neg_inv_mod_r_u64(n: u64) -> u64;


### PR DESCRIPTION
It is too tedious to maintain compatibility with the MSRV version of Clippy *and* the latest stable version. Drop the use of the MSRV version.

Instead, do full testing on the MSRV, for release-mode builds only, for targets where 1.37.0 works with our recommended configuration.