### PR TITLE
Make aead::Nonce implement RandomlyConstructable

### DIFF
--- a/src/aead/nonce.rs
+++ b/src/aead/nonce.rs
@@ -40,6 +40,10 @@ impl Nonce {
     pub fn assume_unique_for_key(value: [u8; NONCE_LEN]) -> Self {
         Self(value)
     }
+
+    pub(crate) fn inner_bytes_mut(&mut self) -> &mut [u8; NONCE_LEN] {
+        &mut self.0
+    }
 }
 
 impl AsRef<[u8; NONCE_LEN]> for Nonce {

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -71,6 +71,7 @@ where
 }
 
 pub(crate) mod sealed {
+    use crate::aead;
     use crate::error;
 
     pub trait SecureRandom: core::fmt::Debug {
@@ -97,7 +98,17 @@ pub(crate) mod sealed {
         }
     }
 
-    impl_random_arrays![4 8 16 32 48 64 128 256];
+    impl_random_arrays![4 8 12 16 32 48 64 128 256];
+
+    impl RandomlyConstructable for aead::Nonce {
+        fn zero() -> Self {
+            aead::Nonce::assume_unique_for_key([0u8; aead::NONCE_LEN])
+        }
+
+        fn as_mut_bytes(&mut self) -> &mut [u8] {
+            self.inner_bytes_mut()
+        }
+    }
 }
 
 /// A type that can be returned by `ring::rand::generate()`.


### PR DESCRIPTION
This adds the ability to use `ring::rand::random<T>` to generate AEAD nonces with the function by implementing `RandomlyConstructable` for it.