### PR TITLE
derive Copy and Clone for UnboundKey

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -384,6 +384,7 @@ impl Aad<[u8; 0]> {
 }
 
 /// An AEAD key without a designated role or nonce sequence.
+#[derive(Copy, Clone)]
 pub struct UnboundKey {
     inner: KeyInner,
     algorithm: &'static Algorithm,
@@ -399,6 +400,7 @@ impl core::fmt::Debug for UnboundKey {
 }
 
 #[allow(clippy::large_enum_variant, variant_size_differences)]
+#[derive(Copy, Clone)]
 enum KeyInner {
     AesGcm(aes_gcm::Key),
     ChaCha20Poly1305(chacha20_poly1305::Key),

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -15,6 +15,7 @@
 use super::{counter, iv::Iv, quic::Sample, Block, Direction, BLOCK_LEN};
 use crate::{bits::BitLength, c, cpu, endian::*, error, polyfill};
 
+#[derive(Copy, Clone)]
 pub(crate) struct Key {
     inner: AES_KEY,
     cpu_features: cpu::Features,
@@ -322,6 +323,7 @@ impl Key {
 
 // Keep this in sync with AES_KEY in aes.h.
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub(super) struct AES_KEY {
     pub rd_key: [u32; 4 * (MAX_ROUNDS + 1)],
     pub rounds: c::uint,

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -38,6 +38,7 @@ pub static AES_256_GCM: aead::Algorithm = aead::Algorithm {
     max_input_len: AES_GCM_MAX_INPUT_LEN,
 };
 
+#[derive(Copy, Clone)]
 pub struct Key {
     gcm_key: gcm::Key, // First because it has a large alignment requirement.
     aes_key: aes::Key,

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -17,6 +17,7 @@ use super::{counter, iv::Iv, quic::Sample, BLOCK_LEN};
 use crate::{c, endian::*};
 
 #[repr(transparent)]
+#[derive(Copy, Clone)]
 pub struct Key([LittleEndian<u32>; KEY_LEN / 4]);
 
 impl From<[u8; KEY_LEN]> for Key {

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -18,6 +18,7 @@ use crate::cpu;
 #[cfg(not(target_arch = "aarch64"))]
 mod gcm_nohw;
 
+#[derive(Copy, Clone)]
 pub struct Key(HTable);
 
 impl Key {
@@ -86,7 +87,7 @@ impl Context {
             inner: ContextInner {
                 Xi: Xi(Block::zero()),
                 _unused: Block::zero(),
-                Htable: key.0.clone(),
+                Htable: key.0,
             },
             cpu_features,
         };
@@ -234,7 +235,7 @@ impl Context {
 }
 
 // The alignment is required by non-Rust code that uses `GCM128_CONTEXT`.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 #[repr(C, align(16))]
 struct HTable {
     Htable: [u128; HTABLE_LEN],


### PR DESCRIPTION
OpeningKey and SealingKey intentionally avoid implementing Copy and
Clone, because they're attached to a nonce sequence that should be
unique. UnboundKey isn't attached to a nonce sequence, though, and in
the case of AES it also takes some nontrivial key setup work to
construct from raw bytes. Making it Copy and Clone allows lets callers
avoid repeating that work in cases where a key is reused without a fixed
nonce sequence.

---

Copying keys around is a risky business, which is why this hierarchy of types exists in the first place, and I wouldn't be surprised if there were some objections here. Maybe some folks would prefer to implement `Clone` but not `Copy`, for example. I figured it would be easier to start that conversation with some code than to just open an issue, so here's a first draft PR :)