### PR TITLE
Enable the integrated assembly x86-64 ChaCha20-Poly1305 implementation from BoringSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ include = [
     "crypto/poly1305/poly1305_arm.c",
     "crypto/poly1305/poly1305_arm_asm.S",
     "crypto/poly1305/poly1305_vec.c",
+    "crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl",
     "doc/link-to-readme.md",
     "examples/checkdigest.rs",
     "include/GFp/aes.h",

--- a/build.rs
+++ b/build.rs
@@ -69,6 +69,7 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[X86_64], "crypto/fipsmodule/modes/asm/ghash-x86_64.pl"),
     (&[X86_64], "crypto/poly1305/poly1305_vec.c"),
     (&[X86_64], SHA512_X86_64),
+    (&[X86_64], "crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl"),
 
     (&[AARCH64, ARM], "crypto/fipsmodule/aes/asm/aesv8-armx.pl"),
     (&[AARCH64, ARM], "crypto/fipsmodule/modes/asm/ghashv8-armx.pl"),

--- a/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl
@@ -38,9 +38,7 @@ $avx = 2;
 
 $code.=<<___;
 .text
-.extern OPENSSL_ia32cap_P
-
-chacha20_poly1305_constants:
+.extern GFp_ia32cap_P
 
 .align 64
 .Lchacha20_consts:
@@ -436,16 +434,16 @@ poly_hash_ad_internal:
 
 {
 ################################################################################
-# extern void chacha20_poly1305_open(uint8_t *out_plaintext,
-#                                    const uint8_t *ciphertext,
-#                                    size_t plaintext_len, const uint8_t *ad,
-#                                    size_t ad_len, union open_data *aead_data)
+# extern void GFp_chacha20_poly1305_open(uint8_t *out_plaintext,
+#                                        const uint8_t *ciphertext,
+#                                        size_t plaintext_len, const uint8_t *ad,
+#                                        size_t ad_len, union open_data *data)
 #
 $code.="
-.globl chacha20_poly1305_open
-.type chacha20_poly1305_open,\@function,6
+.globl GFp_chacha20_poly1305_open
+.type GFp_chacha20_poly1305_open,\@function,6
 .align 64
-chacha20_poly1305_open:
+GFp_chacha20_poly1305_open:
 .cfi_startproc
     push %rbp
 .cfi_push %rbp
@@ -484,7 +482,7 @@ $code.="
     mov $adl, 0+$len_store
     mov $inl, 8+$len_store\n";
 $code.="
-    mov OPENSSL_ia32cap_P+8(%rip), %eax
+    mov GFp_ia32cap_P+8(%rip), %eax
     and \$`(1<<5) + (1<<8)`, %eax # Check both BMI2 and AVX2 are present
     xor \$`(1<<5) + (1<<8)`, %eax
     jz chacha20_poly1305_open_avx2\n" if ($avx>1);
@@ -855,16 +853,19 @@ $code.="
         movdqa $C2, $B2
         movdqa $D2, $C2
     jmp .Lopen_sse_128_xor_hash
-.size chacha20_poly1305_open, .-chacha20_poly1305_open
+.size GFp_chacha20_poly1305_open, .-GFp_chacha20_poly1305_open
 .cfi_endproc
 
 ################################################################################
-################################################################################
-# void chacha20_poly1305_seal(uint8_t *in_out, size_t len_in, uint8_t *ad, size_t len_ad, uint8_t keyp[48]);
-.globl  chacha20_poly1305_seal
-.type chacha20_poly1305_seal,\@function,6
+# extern void GFp_chacha20_poly1305_seal(uint8_t *out_ciphertext,
+#                                        const uint8_t *plaintext,
+#                                        size_t plaintext_len, const uint8_t *ad,
+#                                        size_t ad_len, union seal_data *data)
+#
+.globl  GFp_chacha20_poly1305_seal
+.type GFp_chacha20_poly1305_seal,\@function,6
 .align 64
-chacha20_poly1305_seal:
+GFp_chacha20_poly1305_seal:
 .cfi_startproc
     push %rbp
 .cfi_push %rbp
@@ -904,7 +905,7 @@ $code.="
     mov $inl, 8+$len_store
     mov %rdx, $inl\n";
 $code.="
-    mov OPENSSL_ia32cap_P+8(%rip), %eax
+    mov GFp_ia32cap_P+8(%rip), %eax
     and \$`(1<<5) + (1<<8)`, %eax # Check both BMI2 and AVX2 are present
     xor \$`(1<<5) + (1<<8)`, %eax
     jz chacha20_poly1305_seal_avx2\n" if ($avx>1);
@@ -1364,7 +1365,7 @@ $code.="
     mov %r8, $itr2
     call poly_hash_ad_internal
     jmp .Lseal_sse_128_tail_xor
-.size chacha20_poly1305_seal, .-chacha20_poly1305_seal
+.size GFp_chacha20_poly1305_seal, .-GFp_chacha20_poly1305_seal
 .cfi_endproc\n";
 }
 

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -26,6 +26,12 @@ impl From<[u8; KEY_LEN]> for Key {
     }
 }
 
+impl AsRef<[LittleEndian<u32>; KEY_LEN / 4]> for Key {
+    fn as_ref(&self) -> &[LittleEndian<u32>; KEY_LEN / 4] {
+        &self.0
+    }
+}
+
 impl Key {
     #[inline] // Optimize away match on `counter`.
     pub fn encrypt_in_place(&self, counter: Counter, in_out: &mut [u8]) {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -343,6 +343,12 @@ pub(crate) mod intel {
     };
 
     #[cfg(target_arch = "x86_64")]
+    pub(crate) const SSE41: Feature = Feature {
+        word: 1,
+        mask: 1 << 19,
+    };
+
+    #[cfg(target_arch = "x86_64")]
     pub(crate) const MOVBE: Feature = Feature {
         word: 1,
         mask: 1 << 22,


### PR DESCRIPTION
Which is significantly faster.

This new PR keeps the original BoringSSL asm interface.