### PR TITLE
Build fix for FreeBSD i686

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -546,6 +546,7 @@ fn cc(
     if target.os != "none"
         && target.os != "redox"
         && target.os != "windows"
+        && target.os != "freebsd"
         && target.arch != "wasm32"
     {
         let _ = c.flag("-fstack-protector");


### PR DESCRIPTION
To fix the following error on build:
```
          /project/crypto/curve25519/curve25519.c:165: undefined reference to `__stack_chk_fail_local'
          /usr/local/lib/gcc/i686-unknown-freebsd12/6.4.0/../../../../i686-unknown-freebsd12/bin/ld: /target/i686-unknown-freebsd/debug/deps/libring-0f5e6e28709f9147.rlib(curve25519.o): in function `GFp_x25519_ge_scalarmult_base':
          /project/crypto/curve25519/curve25519.c:828: undefined reference to `__stack_chk_fail_local'
...
```

How to repro:
- install `cross`: https://github.com/rust-embedded/cross
- Create `Cross.toml` with the following:
```
[target.x86_64-unknown-freebsd]
image = "rustembedded/cross:x86_64-unknown-freebsd"

[target.i686-unknown-freebsd]
image = "rustembedded/cross:i686-unknown-freebsd"
```
- Run the following command:
```
# cross build --target i686-unknown-freebsd -> this will fail with the above message
# cross build --target x86_64-unknown-freebsd
```

Actually the error only happens with i686 but seems harmless on x86_64 too.