### PR TITLE
Show error if building on unsupported platform

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -354,7 +354,12 @@ fn build_c_code(target: &Target, pregenerated: PathBuf, out_dir: &Path) {
             let &(entry_arch, entry_os, _) = *entry;
             entry_arch == target.arch && is_none_or_equals(entry_os, &target.os)
         })
-        .unwrap();
+        .unwrap_or_else(|| {
+            panic!(
+                "Operating system '{}' and/or architecture '{}' is not supported",
+                target.os, target.arch
+            )
+        });
 
     let use_pregenerated = !target.is_git;
     let warnings_are_errors = target.is_git;


### PR DESCRIPTION
When building on a unsupported platform a cryptic error message is shown:

```
   Compiling ring v0.16.19
error: failed to run custom build command for `ring v0.16.19`

Caused by:
  process didn't exit successfully: `/home/bs/Code/ev/rust_test/hello_world/target/release/build/ring-a6c015645fcb51f3/build-script-build` (exit code: 101)
  --- stderr
  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /home/bs/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.19/build.rs:375:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Now a human readable error message is shown:

```
error: failed to run custom build command for `ring v0.16.19 (/home/bs/Code/p/ring)`

Caused by:
  process didn't exit successfully: `/home/bs/Code/p/ring/target/release/build/ring-ebe46f27c25935e4/build-script-build` (exit code: 101)                                                                                                               
  --- stderr
  thread 'main' panicked at 'Operating system 'linux' and/or architecture 'mips' is not supported', build.rs:357:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
/tmp/d/openwrt-sdk-19.07.6-ath79-generic_gcc-7.5.0_musl.Linux-x86_64/staging_dir/toolchain-mips_24kc_gcc-7.5.0_musl/bin/mips-openwrt-linux-strip: 'target/mips-unknown-linux-musl/release/hello_world': No such file                                    
```

I'm not sure about the wording though,...