### PR TITLE
implement Clone for LessSafeKey

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -128,6 +128,7 @@ where
 impl<A> Eq for Aad<A> where A: Eq {}
 
 #[allow(clippy::large_enum_variant, variant_size_differences)]
+#[derive(Clone)]
 enum KeyInner {
     AesGcm(aes_gcm::Key),
     ChaCha20Poly1305(chacha20_poly1305::Key),

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 use core::ops::RangeFrom;
 
+#[derive(Clone)]
 pub(crate) struct Key {
     inner: AES_KEY,
     cpu_features: cpu::Features,
@@ -306,6 +307,7 @@ impl Key {
 
 // Keep this in sync with AES_KEY in aes.h.
 #[repr(C)]
+#[derive(Clone)]
 pub(super) struct AES_KEY {
     pub rd_key: [u32; 4 * (MAX_ROUNDS + 1)],
     pub rounds: c::uint,

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -40,6 +40,7 @@ pub static AES_256_GCM: aead::Algorithm = aead::Algorithm {
     max_input_len: AES_GCM_MAX_INPUT_LEN,
 };
 
+#[derive(Clone)]
 pub struct Key {
     gcm_key: gcm::Key, // First because it has a large alignment requirement.
     aes_key: aes::Key,

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -32,6 +32,7 @@ mod fallback;
 
 use core::ops::RangeFrom;
 
+#[derive(Clone)]
 pub struct Key {
     words: [u32; KEY_LEN / 4],
     cpu_features: cpu::Features,

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -22,6 +22,7 @@ use core::ops::BitXorAssign;
 #[cfg(not(target_arch = "aarch64"))]
 mod gcm_nohw;
 
+#[derive(Clone)]
 pub struct Key {
     h_table: HTable,
     cpu_features: cpu::Features,

--- a/src/aead/less_safe_key.rs
+++ b/src/aead/less_safe_key.rs
@@ -20,6 +20,7 @@ use core::ops::RangeFrom;
 /// `NonceSequence` cannot reasonably be used.
 ///
 /// Prefer to use `OpeningKey`/`SealingKey` and `NonceSequence` when practical.
+#[derive(Clone)]
 pub struct LessSafeKey {
     inner: KeyInner,
     algorithm: &'static Algorithm,


### PR DESCRIPTION
OpeningKey and SealingKey intentionally avoid implementing Copy and
Clone, because they're attached to a fixed nonce sequence that should be
unique. LessSafeKey isn't attached to a nonce sequence, though, and
making it Clone lets callers avoid repeating key setup work.

Coming from https://github.com/briansmith/ring/pull/1158#issuecomment-765050031.