### PR TITLE
Enable ed25519 to be built in wasm target with wasm32_c gate

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,7 +44,7 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[], "crypto/poly1305/poly1305.c"),
 
     (&[AARCH64, ARM, X86_64, X86], "crypto/crypto.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/curve25519/curve25519.c"),
+    (&[], "crypto/curve25519/curve25519.c"),
     (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/ecp_nistz.c"),
     (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p256.c"),
     (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p384.c"),

--- a/tests/ed25519_tests.rs
+++ b/tests/ed25519_tests.rs
@@ -18,8 +18,16 @@ use ring::{
     test, test_file,
 };
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test_configure!(run_in_browser);
+
 /// Test vectors from BoringSSL.
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm32_c"))]
 fn test_signature_ed25519() {
     test::run(test_file!("ed25519_tests.txt"), |section, test_case| {
         assert_eq!(section, "");
@@ -63,6 +71,8 @@ fn test_signature_ed25519() {
 
 /// Test vectors from BoringSSL.
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm32_c"))]
 fn test_signature_ed25519_verify() {
     test::run(
         test_file!("ed25519_verify_tests.txt"),
@@ -96,6 +106,8 @@ fn test_signature_verification(
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm32_c"))]
 fn test_ed25519_from_seed_and_public_key_misuse() {
     const PRIVATE_KEY: &[u8] = include_bytes!("ed25519_test_private_key.bin");
     const PUBLIC_KEY: &[u8] = include_bytes!("ed25519_test_public_key.bin");
@@ -113,6 +125,8 @@ fn test_ed25519_from_seed_and_public_key_misuse() {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm32_c"))]
 fn test_ed25519_from_pkcs8_unchecked() {
     // Just test that we can parse the input.
     test::run(
@@ -135,6 +149,8 @@ fn test_ed25519_from_pkcs8_unchecked() {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm32_c"))]
 fn test_ed25519_from_pkcs8() {
     // Just test that we can parse the input.
     test::run(
@@ -157,6 +173,8 @@ fn test_ed25519_from_pkcs8() {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm32_c"))]
 fn ed25519_test_public_key_coverage() {
     const PRIVATE_KEY: &[u8] = include_bytes!("ed25519_test_private_key.p8");
     const PUBLIC_KEY: &[u8] = include_bytes!("ed25519_test_public_key.der");


### PR DESCRIPTION
I was curious about https://github.com/briansmith/ring/issues/918 and tried enabling a few tests to understand what's going on here. The curve25519 module doesn't seems to depend on assembly functions, so it looks safe to enable as per https://github.com/briansmith/ring/issues/918#issuecomment-634860137.

Before enabling these tests, I verified that I could reproduce an error about missing a module named `env`.

```
% wasm-pack test --firefox --headless --  --test ed25519_tests 
...
[INFO]: ⬇️  Installing wasm-bindgen...
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running target/wasm32-unknown-unknown/debug/deps/ed25519_tests-af557e71142febbd.wasm
...
driver stderr:
    *** You are running in headless mode.
    JavaScript error: http://127.0.0.1:62601/wasm-bindgen-test, line 1: TypeError: Error resolving module specifier “env”. Relative module specifiers must start with “./”, “../” or “/”.
```

<details>
  <summary>Full output</summary>

```bash
% wasm-pack test --firefox --headless --  --test ed25519_tests 
[INFO]: 🎯  Checking for the Wasm target...
   Compiling ring v0.16.19 (/Users/amiyaguchi/Work/ring)
    Finished dev [unoptimized + debuginfo] target(s) in 1.86s
[INFO]: ⬇️  Installing wasm-bindgen...
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running target/wasm32-unknown-unknown/debug/deps/ed25519_tests-af557e71142febbd.wasm
Set timeout to 20 seconds...
Running headless tests in Firefox on `http://127.0.0.1:62602/`
Try find `webdriver.json` for configure browser's capabilities:
Not found
Failed to detect test as having been run. It might have timed out.
output div contained:
    Loading scripts...

driver status: signal: 9                          
driver stdout:
    1611356824151       geckodriver     INFO    Listening on 127.0.0.1:62602
    1611356824255       mozrunner::runner       INFO    Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "--marionette" "-headless" "-foreground" "-no-remote" "-profile" "/var/folders/q6/m7bqqf2n05l5dvng72_xvvlw0000gn/T/rust_mozprofileZY7YL3"
    console.warn: SearchSettings: "get: No settings file exists, new profile?" (new Error("", "(unknown module)"))
    1611356825619       Marionette      INFO    Listening on port 62606
    1611356845909       Marionette      INFO    Stopped listening on port 62606

driver stderr:
    *** You are running in headless mode.
    JavaScript error: http://127.0.0.1:62601/wasm-bindgen-test, line 1: TypeError: Error resolving module specifier “env”. Relative module specifiers must start with “./”, “../” or “/”.

Error: some tests failed                          
error: test failed, to rerun pass '--test ed25519_tests'
Error: Running Wasm tests with wasm-bindgen-test failed
Caused by: failed to execute `cargo test`: exited with exit code: 1
  full command: "cargo" "test" "--target" "wasm32-unknown-unknown" "--test" "ed25519_tests"
```

</details>

The wat output shows that the extern'ed C functions are not available to wasm.

```bash
% wasm2wat target/wasm32-unknown-unknown/debug/deps/ed25519_tests-af557e71142febbd.wasm | grep '(import "env"' 
  (import "env" "GFp_x25519_ge_scalarmult_base" (func $GFp_x25519_ge_scalarmult_base (type 5)))
  (import "env" "GFp_x25519_sc_muladd" (func $GFp_x25519_sc_muladd (type 4)))
  (import "env" "GFp_x25519_sc_reduce" (func $GFp_x25519_sc_reduce (type 3)))
  (import "env" "GFp_x25519_sc_mask" (func $GFp_x25519_sc_mask (type 3)))
  (import "env" "GFp_x25519_fe_neg" (func $GFp_x25519_fe_neg (type 3)))
  (import "env" "GFp_x25519_ge_frombytes_vartime" (func $GFp_x25519_ge_frombytes_vartime (type 11)))
  (import "env" "GFp_x25519_fe_invert" (func $GFp_x25519_fe_invert (type 5)))
  (import "env" "GFp_x25519_fe_mul_ttt" (func $GFp_x25519_fe_mul_ttt (type 6)))
  (import "env" "GFp_x25519_fe_tobytes" (func $GFp_x25519_fe_tobytes (type 5)))
  (import "env" "GFp_x25519_fe_isnegative" (func $GFp_x25519_fe_isnegative (type 18)))
  (import "env" "GFp_x25519_ge_double_scalarmult_vartime" (func $GFp_x25519_ge_double_scalarmult_vartime (type 4)))
  (import "env" "LIMBS_less_than" (func $LIMBS_less_than (type 12)))
  (import "env" "LIMBS_are_zero" (func $LIMBS_are_zero (type 11)))
```

This patch enables the tests and allows the appropriate C file to be compiled when the wasm32_c feature is enabled. This was tested using the following command.

```
 % wasm-pack test --firefox --headless --  --features wasm32_c --test ed25519_tests
```

Is there a place that would be appropriate for documenting how to run the wasm-bindgen tests? It's not obvious unless you're already familiar with the workflow. 