### PR TITLE
Agreement: Stop requiring the KDF to return a `Result`.

### DIFF
--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -47,12 +47,10 @@
 //! agreement::agree_ephemeral(
 //!     my_private_key,
 //!     &peer_public_key,
-//!     ring::error::Unspecified,
 //!     |_key_material| {
 //!         // In a real application, we'd apply a KDF to the key material and the
 //!         // public keys (as recommended in RFC 7748) and then derive session
 //!         // keys from the result. We omit all that here.
-//!         Ok(())
 //!     },
 //! )?;
 //!
@@ -244,46 +242,34 @@ impl<B: AsRef<[u8]>> UnparsedPublicKey<B> {
 /// details on how keys are to be encoded and what constitutes a valid key for
 /// that algorithm.
 ///
-/// `error_value` is the value to return if an error occurs before `kdf` is
-/// called, e.g. when decoding of the peer's public key fails or when the public
-/// key is otherwise invalid.
-///
 /// After the key agreement is done, `agree_ephemeral` calls `kdf` with the raw
 /// key material from the key agreement operation and then returns what `kdf`
 /// returns.
 #[inline]
-pub fn agree_ephemeral<B: AsRef<[u8]>, F, R, E>(
+pub fn agree_ephemeral<B: AsRef<[u8]>, R>(
     my_private_key: EphemeralPrivateKey,
     peer_public_key: &UnparsedPublicKey<B>,
-    error_value: E,
-    kdf: F,
-) -> Result<R, E>
-where
-    F: FnOnce(&[u8]) -> Result<R, E>,
-{
+    kdf: impl FnOnce(&[u8]) -> R,
+) -> Result<R, error::Unspecified> {
     let peer_public_key = UnparsedPublicKey {
         algorithm: peer_public_key.algorithm,
         bytes: peer_public_key.bytes.as_ref(),
     };
-    agree_ephemeral_(my_private_key, peer_public_key, error_value, kdf)
+    agree_ephemeral_(my_private_key, peer_public_key, kdf)
 }
 
-fn agree_ephemeral_<F, R, E>(
+fn agree_ephemeral_<R>(
     my_private_key: EphemeralPrivateKey,
     peer_public_key: UnparsedPublicKey<&[u8]>,
-    error_value: E,
-    kdf: F,
-) -> Result<R, E>
-where
-    F: FnOnce(&[u8]) -> Result<R, E>,
-{
+    kdf: impl FnOnce(&[u8]) -> R,
+) -> Result<R, error::Unspecified> {
     // NSA Guide Prerequisite 1.
     //
     // The domain parameters are hard-coded. This check verifies that the
     // peer's public key's domain parameters match the domain parameters of
     // this private key.
     if peer_public_key.algorithm != my_private_key.algorithm {
-        return Err(error_value);
+        return Err(error::Unspecified);
     }
 
     let alg = &my_private_key.algorithm;
@@ -309,12 +295,11 @@ where
         shared_key,
         &my_private_key.private_key,
         untrusted::Input::from(peer_public_key.bytes),
-    )
-    .map_err(|_| error_value)?;
+    )?;
 
     // NSA Guide Steps 5 and 6.
     //
     // Again, we have a pretty liberal interpretation of the NIST's spec's
     // "Destroy" that doesn't meet the NSA requirement to "zeroize."
-    kdf(shared_key)
+    Ok(kdf(shared_key))
 }

--- a/tests/agreement_tests.rs
+++ b/tests/agreement_tests.rs
@@ -87,11 +87,9 @@ fn agreement_agree_ephemeral() {
 
                 assert_eq!(my_private.algorithm(), alg);
 
-                let result =
-                    agreement::agree_ephemeral(my_private, &peer_public, (), |key_material| {
-                        assert_eq!(key_material, &output[..]);
-                        Ok(())
-                    });
+                let result = agreement::agree_ephemeral(my_private, &peer_public, |key_material| {
+                    assert_eq!(key_material, &output[..]);
+                });
                 assert_eq!(result, Ok(()));
             }
 
@@ -108,7 +106,6 @@ fn agreement_agree_ephemeral() {
                 assert!(agreement::agree_ephemeral(
                     dummy_private_key,
                     &peer_public,
-                    (),
                     kdf_not_called
                 )
                 .is_err());
@@ -179,12 +176,9 @@ fn x25519_(private_key: &[u8], public_key: &[u8]) -> Result<Vec<u8>, error::Unsp
     let rng = test::rand::FixedSliceRandom { bytes: private_key };
     let private_key = agreement::EphemeralPrivateKey::generate(&agreement::X25519, &rng)?;
     let public_key = agreement::UnparsedPublicKey::new(&agreement::X25519, public_key);
-    agreement::agree_ephemeral(
-        private_key,
-        &public_key,
-        error::Unspecified,
-        |agreed_value| Ok(Vec::from(agreed_value)),
-    )
+    agreement::agree_ephemeral(private_key, &public_key, |agreed_value| {
+        Vec::from(agreed_value)
+    })
 }
 
 fn h(s: &str) -> Vec<u8> {


### PR DESCRIPTION
Many (most?) KDFs are infallible, so optimize for that case. If the KDF
is fallible then the result will be `Ok(Err(_))` which is messy.

This eliminates the `error_value` parameter.