### PR TITLE
Reimplement `Block` in terms of `endian` and simplify its API.

### DIFF
--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -196,9 +196,8 @@ impl Key {
 
     #[inline]
     pub fn encrypt_iv_xor_block(&self, iv: Iv, input: Block) -> Block {
-        let mut output = self.encrypt_block(Block::from(&iv.into_bytes_less_safe()));
-        output.bitxor_assign(input);
-        output
+        let encrypted_iv = self.encrypt_block(Block::from(&iv.into_bytes_less_safe()));
+        encrypted_iv ^ input
     }
 
     #[inline]

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -13,38 +13,18 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{endian::*, polyfill};
+use core::ops::{BitXor, BitXorAssign};
 
-/// An array of 16 bytes that can (in the x86_64 and AAarch64 ABIs, at least)
-/// be efficiently passed by value and returned by value (i.e. in registers),
-/// and which meets the alignment requirements of `u32` and `u64` (at least)
-/// for the target.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct Block {
-    subblocks: [u64; 2],
-}
+pub struct Block([BigEndian<u64>; 2]);
 
 pub const BLOCK_LEN: usize = 16;
 
 impl Block {
     #[inline]
     pub fn zero() -> Self {
-        Self { subblocks: [0, 0] }
-    }
-
-    #[inline]
-    pub fn from_u64_be(first: BigEndian<u64>, second: BigEndian<u64>) -> Self {
-        #[allow(deprecated)]
-        Self {
-            subblocks: [first.into_raw_value(), second.into_raw_value()],
-        }
-    }
-
-    pub fn u64s_be_to_native(&self) -> [u64; 2] {
-        [
-            u64::from_be(self.subblocks[0]),
-            u64::from_be(self.subblocks[1]),
-        ]
+        Self([Encoding::ZERO; 2])
     }
 
     #[inline]
@@ -60,53 +40,52 @@ impl Block {
         polyfill::slice::fill(&mut tmp[index..], 0);
         *self = Self::from(&tmp)
     }
+}
 
+impl From<[u64; 2]> for Block {
     #[inline]
-    pub fn bitxor_assign(&mut self, a: Block) {
-        for (r, a) in self.subblocks.iter_mut().zip(a.subblocks.iter()) {
+    fn from(other: [u64; 2]) -> Self {
+        Self([other[0].into(), other[1].into()])
+    }
+}
+
+impl Into<[u64; 2]> for Block {
+    #[inline]
+    fn into(self) -> [u64; 2] {
+        [self.0[0].into(), self.0[1].into()]
+    }
+}
+
+impl BitXorAssign for Block {
+    #[inline]
+    fn bitxor_assign(&mut self, a: Self) {
+        for (r, a) in self.0.iter_mut().zip(a.0.iter()) {
             *r ^= *a;
         }
+    }
+}
+
+impl BitXor for Block {
+    type Output = Self;
+
+    #[inline]
+    fn bitxor(self, a: Self) -> Self {
+        let mut r = self;
+        r.bitxor_assign(a);
+        r
     }
 }
 
 impl From<&'_ [u8; BLOCK_LEN]> for Block {
     #[inline]
     fn from(bytes: &[u8; BLOCK_LEN]) -> Self {
-        unsafe { core::mem::transmute_copy(bytes) }
+        Self(FromByteArray::from_byte_array(bytes))
     }
 }
 
 impl AsRef<[u8; BLOCK_LEN]> for Block {
-    #[allow(clippy::transmute_ptr_to_ptr)]
     #[inline]
     fn as_ref(&self) -> &[u8; BLOCK_LEN] {
-        unsafe { core::mem::transmute(self) }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_bitxor_assign() {
-        const ONES: u64 = -1i64 as u64;
-        const TEST_CASES: &[([u64; 2], [u64; 2], [u64; 2])] = &[
-            ([0, 0], [0, 0], [0, 0]),
-            ([0, 0], [ONES, ONES], [ONES, ONES]),
-            ([0, ONES], [ONES, 0], [ONES, ONES]),
-            ([ONES, 0], [0, ONES], [ONES, ONES]),
-            ([ONES, ONES], [ONES, ONES], [0, 0]),
-        ];
-        for (expected_result, a, b) in TEST_CASES {
-            let mut r = Block::from_u64_be(a[0].into(), a[1].into());
-            r.bitxor_assign(Block::from_u64_be(b[0].into(), b[1].into()));
-            assert_eq!(*expected_result, r.subblocks);
-
-            // XOR is symmetric.
-            let mut r = Block::from_u64_be(b[0].into(), b[1].into());
-            r.bitxor_assign(Block::from_u64_be(a[0].into(), a[1].into()));
-            assert_eq!(*expected_result, r.subblocks);
-        }
+        self.0.as_byte_array()
     }
 }

--- a/src/aead/gcm/gcm_nohw.rs
+++ b/src/aead/gcm/gcm_nohw.rs
@@ -23,7 +23,6 @@
 // Unlike the BearSSL notes, we use u128 in the 64-bit implementation.
 
 use super::{Block, Xi};
-use crate::endian::BigEndian;
 use core::convert::TryInto;
 
 #[cfg(target_pointer_width = "64")]
@@ -235,8 +234,8 @@ pub(super) fn ghash(xi: &mut Xi, h: super::u128, input: &[u8]) {
 
 #[inline]
 fn with_swapped_xi(Xi(xi): &mut Xi, f: impl FnOnce(&mut [u64; 2])) {
-    let unswapped = xi.u64s_be_to_native();
+    let unswapped: [u64; 2] = (*xi).into();
     let mut swapped: [u64; 2] = [unswapped[1], unswapped[0]];
     f(&mut swapped);
-    *xi = Block::from_u64_be(BigEndian::from(swapped[1]), BigEndian::from(swapped[0]))
+    *xi = Block::from([swapped[1], swapped[0]])
 }

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -35,21 +35,25 @@ macro_rules! define_endian {
         #[repr(transparent)]
         pub struct $endian<T>(T);
 
-        impl<T> $endian<T> {
-            #[deprecated]
-            pub fn into_raw_value(self) -> T {
-                self.0
-            }
-        }
-
         impl<T> Copy for $endian<T> where T: Copy {}
 
         impl<T> Clone for $endian<T>
         where
             T: Clone,
         {
+            #[inline]
             fn clone(&self) -> Self {
                 Self(self.0.clone())
+            }
+        }
+
+        impl<T> core::ops::BitXorAssign for $endian<T>
+        where
+            T: core::ops::BitXorAssign,
+        {
+            #[inline(always)]
+            fn bitxor_assign(&mut self, a: Self) {
+                self.0 ^= a.0;
             }
         }
     };
@@ -60,6 +64,7 @@ macro_rules! impl_from_byte_array {
         impl FromByteArray<[u8; $elems * core::mem::size_of::<$base>()]>
             for [$endian<$base>; $elems]
         {
+            #[inline]
             fn from_byte_array(a: &[u8; $elems * core::mem::size_of::<$base>()]) -> Self {
                 unsafe { core::mem::transmute_copy(a) }
             }
@@ -72,6 +77,7 @@ macro_rules! impl_array_encoding {
         impl ArrayEncoding<[u8; $elems * core::mem::size_of::<$base>()]>
             for [$endian<$base>; $elems]
         {
+            #[inline]
             fn as_byte_array(&self) -> &[u8; $elems * core::mem::size_of::<$base>()] {
                 // TODO: When we can require Rust 1.47.0 or later we could avoid
                 // `as` and `unsafe` here using


### PR DESCRIPTION
Remove all the `unsafe` blocks from `Block` by reimplementing it using
`endian`. Simplify the API for endian-swapping.