### PR TITLE
Remove `endian::as_byte_slice()`.

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -26,7 +26,7 @@
 
 use crate::{
     c, cpu, debug,
-    endian::{self, BigEndian},
+    endian::{ArrayEncoding, BigEndian},
     polyfill,
 };
 use core::num::Wrapping;
@@ -248,7 +248,7 @@ impl AsRef<[u8]> for Digest {
     #[inline(always)]
     fn as_ref(&self) -> &[u8] {
         let as64 = unsafe { &self.value.as64 };
-        &endian::as_byte_slice(as64)[..self.algorithm.output_len]
+        &as64.as_byte_array()[..self.algorithm.output_len]
     }
 }
 

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -11,13 +11,6 @@ where
     const ZERO: Self;
 }
 
-/// Allow access to a slice of  of `Encoding<T>` as a slice of bytes.
-pub fn as_byte_slice<E: Encoding<T>, T>(x: &[E]) -> &[u8] {
-    unsafe {
-        core::slice::from_raw_parts(x.as_ptr() as *const u8, x.len() * core::mem::size_of::<E>())
-    }
-}
-
 /// Work around the inability to implement `AsRef` for arrays of `Encoding`s
 /// due to the coherence rules.
 pub trait ArrayEncoding<T> {
@@ -73,9 +66,6 @@ macro_rules! impl_array_encoding {
             for [$endian<$base>; $elems]
         {
             fn as_byte_array(&self) -> &[u8; $elems * core::mem::size_of::<$base>()] {
-                // TODO: When we can require Rust 1.47.0 or later we could avoid
-                // `as` and `unsafe` here using
-                // `as_byte_slice(self).try_into().unwrap()`.
                 let as_bytes_ptr =
                     self.as_ptr() as *const [u8; $elems * core::mem::size_of::<$base>()];
                 unsafe { &*as_bytes_ptr }


### PR DESCRIPTION
We don't need it now that `ArrayEncoding::as_byte_array()` can handle larger
arrays.