### PR TITLE
add support for Hermit 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,10 @@ web-sys = { version = "0.3.37", default-features = false, features = ["Crypto", 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", default-features = false, features = ["ntsecapi", "wtypesbase"] }
 
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit-sys = "0.1"
+hermit-abi = "0.1"
+
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.18", default-features = false }
 
@@ -328,6 +332,7 @@ libc = { version = "0.2.84", default-features = false }
 # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
 [build-dependencies]
 cc = { version = "1.0.66", default-features = false }
+
 
 [features]
 # These features are documented in the top-level module's documentation.


### PR DESCRIPTION
To [build it for RustyHermit](/hermitcore/rusty-hermit), .cargo/config.toml should contain something like
```toml
[unstable]
build-std = ["std", "core", "alloc", "panic_abort"]
build-std-features = ["compiler-builtins-mem"]

[build]
target = "x86_64-unknown-hermit"
```
or build with
```bash
cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
```