### PR TITLE
Bump MSRV to 1.47.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,41 +173,33 @@ jobs:
         rust_channel:
           - stable
           - nightly
-          - 1.37.0 # MSRV
+          - 1.47.0 # MSRV
           - beta
 
         exclude:
-          # The stable channel doesn't have aarch64-apple-darwin support yet.
-          - target: aarch64-apple-darwin
-            rust_channel: stable
-
           # The MSRV channel doesn't have aarch64-apple-darwin support yet.
           - target: aarch64-apple-darwin
-            rust_channel: 1.37.0
+            rust_channel: 1.47.0
 
           # Only do MSRV testing on release builds.
           - mode: # debug
-            rust_channel: 1.37.0
+            rust_channel: 1.47.0
 
-          # 1.37.0 doesn't support `-Clink-self-contained`.
+          # 1.47.0 doesn't support `-Clink-self-contained`.
           - target: aarch64-unknown-linux-musl
-            rust_channel: 1.37.0
+            rust_channel: 1.47.0
 
-          # 1.37.0 doesn't support `-Clink-self-contained`.
+          # 1.47.0 doesn't support `-Clink-self-contained`.
           - target: armv7-unknown-linux-musleabihf
-            rust_channel: 1.37.0
+            rust_channel: 1.47.0
 
-          # 1.37.0 doesn't support `-Clink-self-contained`.
+          # 1.47.0 doesn't support `-Clink-self-contained`.
           - target: i686-unknown-linux-musl
-            rust_channel: 1.37.0
+            rust_channel: 1.47.0
 
-          # 1.37.0 doesn't support `-Clink-self-contained`.
+          # 1.47.0 doesn't support `-Clink-self-contained`.
           - target: x86_64-unknown-linux-musl
-            rust_channel: 1.37.0
-
-          # https://github.com/rust-lang/rust/pull/67429
-          - target: x86_64-pc-windows-gnu
-            rust_channel: 1.37.0
+            rust_channel: 1.47.0
 
         include:
           - target: aarch64-apple-darwin

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -310,17 +310,13 @@ impl Key {
         out
     }
 
-    // TODO: use `matches!` when MSRV increases to 1.42.0 and remove this
-    // `#[allow(...)]`
-    #[allow(clippy::unknown_clippy_lints)]
-    #[allow(clippy::match_like_matches_macro)]
     #[cfg(target_arch = "x86_64")]
     #[must_use]
     pub fn is_aes_hw(&self) -> bool {
-        match detect_implementation(self.cpu_features) {
-            Implementation::HWAES => true,
-            _ => false,
-        }
+        matches!(
+            detect_implementation(self.cpu_features),
+            Implementation::HWAES
+        )
     }
 
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
This allows us to use more `const fn` goodness and no more
`array::LengthAtMost32` limitations.