### PR TITLE
AEAD: Fix typo in docs for `OpeningKey::open_within`.

### DIFF
--- a/src/aead/opening_key.rs
+++ b/src/aead/opening_key.rs
@@ -122,7 +122,7 @@ impl<N: NonceSequence> OpeningKey<N> {
     ///        “Split stream reassembled in place”
     /// ```
     ///
-    /// This reassembly be accomplished with three calls to `open_within()`.
+    /// This reassembly can be accomplished with three calls to `open_within()`.
     #[inline]
     pub fn open_within<'in_out, A>(
         &mut self,


### PR DESCRIPTION
See the individual commits for details.