### PR TITLE
CI: Always use `macos-latest` and Xcode 12.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,7 @@ jobs:
 
         include:
           - target: aarch64-apple-darwin
-            # macos-latest didn't work.
-            host_os: macos-11.0
+            host_os: macos-latest
             # GitHub Actions doesn't have a way to run this target yet.
             cargo_options: --no-run
 
@@ -281,8 +280,11 @@ jobs:
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust_channel }}
 
+      # https://github.com/actions/virtual-environments/issues/2557#issuecomment-769611326
       - if: ${{ matrix.target == 'aarch64-apple-darwin' }}
-        run: echo "DEVELOPER_DIR=/Applications/Xcode_12.2.app/Contents/Developer" >> $GITHUB_ENV
+        run: |
+          sudo xcode-select -s /Applications/Xcode_12.4.app &&
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |


### PR DESCRIPTION
macos-11.0 is pre-production. Use macos-latest instead, to (I hope)
make macOS jobs more likely to succeed. (Presently, they frequently
fail with no logs.)

Upgrade to Xcode 12.4 in hopes that this will make things work.