### PR TITLE
CI: Increase wasm-bindgen-test timeout to 60s.

### DIFF
--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -105,6 +105,7 @@ case $target in
     export CC_wasm32_unknown_unknown=clang-$llvm_version
     export AR_wasm32_unknown_unknown=llvm-ar-$llvm_version
     export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner
+    export WASM_BINDGEN_TEST_TIMEOUT=60
     ;;
   *)
     ;;


### PR DESCRIPTION
See if this prevents some of the wasm32 failures.