### PR TITLE
AEAD internals: Have each AEAD key type remember the CPU features.

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -144,20 +144,13 @@ impl hkdf::KeyType for &'static Algorithm {
 pub struct Algorithm {
     init: fn(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, error::Unspecified>,
 
-    seal: fn(
-        key: &KeyInner,
-        nonce: Nonce,
-        aad: Aad<&[u8]>,
-        in_out: &mut [u8],
-        cpu_features: cpu::Features,
-    ) -> Tag,
+    seal: fn(key: &KeyInner, nonce: Nonce, aad: Aad<&[u8]>, in_out: &mut [u8]) -> Tag,
     open: fn(
         key: &KeyInner,
         nonce: Nonce,
         aad: Aad<&[u8]>,
         in_out: &mut [u8],
         src: RangeFrom<usize>,
-        cpu_features: cpu::Features,
     ) -> Tag,
 
     key_len: usize,

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -86,7 +86,7 @@ fn aes_gcm_seal(
 
     #[cfg(target_arch = "x86_64")]
     let in_out = {
-        if !aes_key.is_aes_hw() || !auth.is_avx2(cpu_features) {
+        if !aes_key.is_aes_hw() || !auth.is_avx2() {
             in_out
         } else {
             use crate::c;
@@ -163,7 +163,7 @@ fn aes_gcm_open(
 
     #[cfg(target_arch = "x86_64")]
     let in_out = {
-        if !aes_key.is_aes_hw() || !auth.is_avx2(cpu_features) {
+        if !aes_key.is_aes_hw() || !auth.is_avx2() {
             in_out
         } else {
             use crate::c;

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -65,13 +65,7 @@ fn init(
 
 const CHUNK_BLOCKS: usize = 3 * 1024 / 16;
 
-fn aes_gcm_seal(
-    key: &aead::KeyInner,
-    nonce: Nonce,
-    aad: Aad<&[u8]>,
-    in_out: &mut [u8],
-    cpu_features: cpu::Features,
-) -> Tag {
+fn aes_gcm_seal(key: &aead::KeyInner, nonce: Nonce, aad: Aad<&[u8]>, in_out: &mut [u8]) -> Tag {
     let Key { aes_key, gcm_key } = match key {
         aead::KeyInner::AesGcm(key) => key,
         _ => unreachable!(),
@@ -82,7 +76,7 @@ fn aes_gcm_seal(
 
     let total_in_out_len = in_out.len();
     let aad_len = aad.0.len();
-    let mut auth = gcm::Context::new(gcm_key, aad, cpu_features);
+    let mut auth = gcm::Context::new(gcm_key, aad);
 
     #[cfg(target_arch = "x86_64")]
     let in_out = {
@@ -144,7 +138,6 @@ fn aes_gcm_open(
     aad: Aad<&[u8]>,
     in_out: &mut [u8],
     src: RangeFrom<usize>,
-    cpu_features: cpu::Features,
 ) -> Tag {
     let Key { aes_key, gcm_key } = match key {
         aead::KeyInner::AesGcm(key) => key,
@@ -155,7 +148,7 @@ fn aes_gcm_open(
     let tag_iv = ctr.increment();
 
     let aad_len = aad.0.len();
-    let mut auth = gcm::Context::new(gcm_key, aad, cpu_features);
+    let mut auth = gcm::Context::new(gcm_key, aad);
 
     let in_prefix_len = src.start;
 

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -235,8 +235,8 @@ impl Context {
     }
 
     #[cfg(target_arch = "x86_64")]
-    pub(super) fn is_avx2(&self, cpu_features: cpu::Features) -> bool {
-        match detect_implementation(cpu_features) {
+    pub(super) fn is_avx2(&self) -> bool {
+        match detect_implementation(self.cpu_features) {
             Implementation::CLMUL => has_avx_movbe(self.cpu_features),
             _ => false,
         }

--- a/src/aead/quic.rs
+++ b/src/aead/quic.rs
@@ -171,9 +171,12 @@ pub static CHACHA20: Algorithm = Algorithm {
     id: AlgorithmID::CHACHA20,
 };
 
-fn chacha20_init(key: &[u8], _todo: cpu::Features) -> Result<KeyInner, error::Unspecified> {
+fn chacha20_init(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, error::Unspecified> {
     let chacha20_key: [u8; chacha::KEY_LEN] = key.try_into()?;
-    Ok(KeyInner::ChaCha20(chacha::Key::from(chacha20_key)))
+    Ok(KeyInner::ChaCha20(chacha::Key::new(
+        chacha20_key,
+        cpu_features,
+    )))
 }
 
 fn chacha20_new_mask(key: &KeyInner, sample: Sample) -> [u8; 5] {


### PR DESCRIPTION
See the individual commit messages for details.