### PR TITLE
Add tests that ECDSA and RSA PSS signatures are nondeterministic.

### DIFF
--- a/tests/ecdsa_tests.rs
+++ b/tests/ecdsa_tests.rs
@@ -259,6 +259,24 @@ fn signature_ecdsa_sign_fixed_sign_and_verify_test() {
     );
 }
 
+#[test]
+fn signature_ecdsa_sign_nondeterministic() {
+    let rng = rand::SystemRandom::new();
+    const PRIVATE_KEY: &[u8] = include_bytes!("ecdsa_test_private_key_p256.p8");
+
+    let key_pair = signature::EcdsaKeyPair::from_pkcs8(
+        &signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+        PRIVATE_KEY,
+    )
+    .unwrap();
+
+    const MSG: &[u8] = &[];
+
+    let sig1 = key_pair.sign(&rng, MSG).unwrap();
+    let sig2 = key_pair.sign(&rng, MSG).unwrap();
+    assert_ne!(sig1.as_ref(), sig2.as_ref());
+}
+
 // This test is not a known-answer test, though it re-uses the known-answer
 // test vectors. Because the nonce is randomized, the signature will be
 // different each time. Because of that, here we simply verify that the

--- a/tests/rsa_tests.rs
+++ b/tests/rsa_tests.rs
@@ -94,6 +94,31 @@ fn test_signature_rsa_pkcs1_sign() {
     );
 }
 
+#[test]
+fn signature_rsa_pss_sign_nondeterministic() {
+    let rng = rand::SystemRandom::new();
+    const PRIVATE_KEY: &[u8] = include_bytes!("rsa_test_private_key_2048.p8");
+
+    let key_pair = signature::RsaKeyPair::from_pkcs8(PRIVATE_KEY).unwrap();
+
+    static ALG: &'static dyn signature::RsaEncoding = &signature::RSA_PSS_SHA256;
+    const MSG: &[u8] = &[];
+
+    let sig1 = {
+        let mut sig = vec![0u8; key_pair.public_modulus_len()];
+        key_pair.sign(ALG, &rng, MSG, &mut sig).unwrap();
+        sig
+    };
+
+    let sig2 = {
+        let mut sig = vec![0u8; key_pair.public_modulus_len()];
+        key_pair.sign(ALG, &rng, MSG, &mut sig).unwrap();
+        sig
+    };
+
+    assert_ne!(sig1, sig2);
+}
+
 #[cfg(feature = "alloc")]
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", feature = "wasm32_c"), wasm_bindgen_test)]


### PR DESCRIPTION
BoringSSL added a similar smoketest.