### PR TITLE
"Fix" clippy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - run: cargo clippy --all-features ---all-targets -- --deny warnings
+      - run: mk/clippy.sh
 
   audit:
     # Don't run duplicate `push` jobs for the repo owner's PRs.

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export NULL=""
+cargo clippy \
+  --target-dir=target/clippy \
+  --all-features ---all-targets \
+  -- \
+  --deny warnings \
+  --allow clippy::from_over_into \
+  --allow clippy::ptr_arg \
+  --allow clippy::redundant_slicing \
+  --allow clippy::upper_case_acronyms \
+  --allow clippy::vec_init_then_push \
+  $NULL

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -6,9 +6,24 @@ cargo clippy \
   --all-features ---all-targets \
   -- \
   --deny warnings \
+  --allow clippy::collapsible_if \
   --allow clippy::from_over_into \
+  --allow clippy::identity_op \
+  --allow clippy::len_without_is_empty \
+  --allow clippy::len_zero \
   --allow clippy::ptr_arg \
+  --allow clippy::let_unit_value \
+  --allow clippy::many_single_char_names \
+  --allow clippy::needless_range_loop \
+  --allow clippy::new_without_default \
+  --allow clippy::neg_cmp_op_on_partial_ord \
+  --allow clippy::range_plus_one \
   --allow clippy::redundant_slicing \
+  --allow clippy::too_many_arguments \
+  --allow clippy::trivially_copy_pass_by_ref \
+  --allow clippy::type_complexity \
+  --allow clippy::unreadable_literal \
   --allow clippy::upper_case_acronyms \
   --allow clippy::vec_init_then_push \
+
   $NULL

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,20 +47,6 @@
 
 #![doc(html_root_url = "https://briansmith.org/rustdoc/")]
 #![allow(
-    clippy::collapsible_if,
-    clippy::identity_op,
-    clippy::len_without_is_empty,
-    clippy::len_zero,
-    clippy::let_unit_value,
-    clippy::many_single_char_names,
-    clippy::needless_range_loop,
-    clippy::new_without_default,
-    clippy::neg_cmp_op_on_partial_ord,
-    clippy::range_plus_one,
-    clippy::too_many_arguments,
-    clippy::trivially_copy_pass_by_ref,
-    clippy::type_complexity,
-    clippy::unreadable_literal,
     missing_copy_implementations,
     missing_debug_implementations,
     non_camel_case_types,


### PR DESCRIPTION
Add mk/clippy.sh to make it easier to run Clippy with the same configuration as is used in CI.

Always run Clippy jobs using a separate target directory to work around the Clippy caching bug.

Disable some new (as of the most recent Rust release) lints that weren't triggered previously.

Clippy sometimes adds and/or removes lints. To prevent the *ring* source from being sensitive to that, move the `allow` directives that disable some Clippy lints from lib.rs to the command line in mk/clippy.sh.
