### PR TITLE
Adding tests and fuzzing to der.rs (using cargo-fuzz)

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+
+[package]
+name = "ring-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+untrusted = "0.7.1"
+
+[dependencies.ring]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_bit_string_with_no_unused_bits"
+path = "fuzz_targets/fuzz_bit_string_with_no_unused_bits.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_bit_string_with_no_unused_bits.rs
+++ b/fuzz/fuzz_targets/fuzz_bit_string_with_no_unused_bits.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut reader = untrusted::Reader::new(untrusted::Input::from(data));
+    let _ = ring::io::der::bit_string_with_no_unused_bits(&mut reader);
+});

--- a/src/io/der.rs
+++ b/src/io/der.rs
@@ -308,4 +308,46 @@ mod tests {
             });
         }
     }
+
+    fn bytes_reader(bytes: &[u8]) -> untrusted::Reader {
+        return untrusted::Reader::new(untrusted::Input::from(bytes));
+    }
+
+    #[test]
+    fn test_bit_string_with_no_unused_bits() {
+        // Unexpected type
+        assert_eq!(
+            Err(error::Unspecified),
+            bit_string_with_no_unused_bits(&mut bytes_reader(&[0x01, 0x01, 0xff]))
+        );
+
+        // Unexpected nonexistent type
+        assert_eq!(
+            Err(error::Unspecified),
+            bit_string_with_no_unused_bits(&mut bytes_reader(&[0x42, 0xff, 0xff]))
+        );
+
+        // Unexpected empty input
+        assert_eq!(
+            Err(error::Unspecified),
+            bit_string_with_no_unused_bits(&mut bytes_reader(&[]))
+        );
+
+        // Valid input with non-zero unused bits
+        assert_eq!(
+            Err(error::Unspecified),
+            bit_string_with_no_unused_bits(&mut bytes_reader(&[0x03, 0x03, 0x04, 0x12, 0x34]))
+        );
+
+        // Valid input
+        assert_eq!(
+            untrusted::Input::from(&[0x12, 0x34]),
+            bit_string_with_no_unused_bits(&mut bytes_reader(&[0x03, 0x03, 0x00, 0x12, 0x34]))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn fuzz_bit_string_with_no_unused_bits() {
+    }
 }


### PR DESCRIPTION
Here is an _experiment_ to add fuzzing to `der.rs`. Bunch of thoughts and notes:

 * It looks like there are two popular options for fuzzing in Rust: `cargo-fuzz` and `afl.rs`. I picked the first one, not for any specific reason. It may be interesting to try to implement the same with `afl.rs` to see what the experience is.
 * This was easy to setup but it does require _Rust Nightly_ tooling.
 * I implemented a super basic fuzzer for `` which may not be the best function to fuzz. I'll add some more der.rs coverage in the coming days.
 * With `cargo-fuzz`, fuzzers are small standalone binaries. You basically implement a single function that the fuzzer tooling with turn into a binary that can then run in the fuzzing framework.
 * Simply running `cargo fuzz run fuzz_bit_string_with_no_unused_bits` is very nice and easy to automate
 *  I had hoped you could combine `test_*` and `fuzz_*` functions easily in a module's test section, but that is not possible. It is definitely possible to extract common code and share that between fuzzing and unit testing. (Although I am not familiar enough with Rust yet to understand how that would work with public/private and test namespaces.)

Let me know what you think @briansmith .. I'll play around with this a bit more. No expectation that this PR will land - consider it an experiment.