### PR TITLE
Pass prefix from build.rs to src/prefixed.rs through `cargo:rustc-env`.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -369,6 +369,11 @@ struct Target {
 }
 
 fn build_c_code(target: &Target, pregenerated: PathBuf, out_dir: &Path) {
+    println!(
+        "cargo:rustc-env=RING_CORE_PREFIX={}",
+        BORINGSSL_PREFIX_VALUE
+    );
+
     #[cfg(not(feature = "wasm32_c"))]
     {
         if &target.arch == "wasm32" {

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -68,7 +68,7 @@ macro_rules! prefixed_item {
     } => {
         prefixed_item! {
             $attr
-            { concat!("ring_core_dev_", stringify!($name)) }
+            { concat!(env!("RING_CORE_PREFIX"), stringify!($name)) }
             { $( $item )+ }
         }
     };


### PR DESCRIPTION
Eliminate one place where the prefix would have to be manually updated.