### PR TITLE
ECDSA: Add RNG as an input parameter to `EcdsaKeyPair::from_pkcs8`.

### DIFF
--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -105,6 +105,7 @@ impl EcdsaKeyPair {
     pub fn from_pkcs8(
         alg: &'static EcdsaSigningAlgorithm,
         pkcs8: &[u8],
+        rng: &dyn rand::SecureRandom,
     ) -> Result<Self, error::KeyRejected> {
         let key_pair = ec::suite_b::key_pair_from_pkcs8(
             alg.curve,
@@ -112,8 +113,7 @@ impl EcdsaKeyPair {
             untrusted::Input::from(pkcs8),
             cpu::features(),
         )?;
-        let rng = rand::SystemRandom::new(); // TODO: make this a parameter.
-        Self::new(alg, key_pair, &rng)
+        Self::new(alg, key_pair, rng)
     }
 
     /// Constructs an ECDSA key pair from the private key and public key bytes
@@ -136,6 +136,7 @@ impl EcdsaKeyPair {
         alg: &'static EcdsaSigningAlgorithm,
         private_key: &[u8],
         public_key: &[u8],
+        rng: &dyn rand::SecureRandom,
     ) -> Result<Self, error::KeyRejected> {
         let key_pair = ec::suite_b::key_pair_from_bytes(
             alg.curve,
@@ -143,8 +144,7 @@ impl EcdsaKeyPair {
             untrusted::Input::from(public_key),
             cpu::features(),
         )?;
-        let rng = rand::SystemRandom::new(); // TODO: make this a parameter.
-        Self::new(alg, key_pair, &rng)
+        Self::new(alg, key_pair, rng)
     }
 
     fn new(
@@ -515,10 +515,12 @@ static EC_PUBLIC_KEY_P384_PKCS8_V1_TEMPLATE: pkcs8::Template = pkcs8::Template {
 
 #[cfg(test)]
 mod tests {
-    use crate::{signature, test};
+    use crate::{rand, signature, test};
 
     #[test]
     fn signature_ecdsa_sign_fixed_test() {
+        let rng = rand::SystemRandom::new();
+
         test::run(
             test_file!("ecdsa_sign_fixed_tests.txt"),
             |section, test_case| {
@@ -542,7 +544,8 @@ mod tests {
                 };
 
                 let private_key =
-                    signature::EcdsaKeyPair::from_private_key_and_public_key(alg, &d, &q).unwrap();
+                    signature::EcdsaKeyPair::from_private_key_and_public_key(alg, &d, &q, &rng)
+                        .unwrap();
                 let rng = test::rand::FixedSliceRandom { bytes: &k };
 
                 let actual_result = private_key
@@ -558,6 +561,8 @@ mod tests {
 
     #[test]
     fn signature_ecdsa_sign_asn1_test() {
+        let rng = rand::SystemRandom::new();
+
         test::run(
             test_file!("ecdsa_sign_asn1_tests.txt"),
             |section, test_case| {
@@ -581,7 +586,8 @@ mod tests {
                 };
 
                 let private_key =
-                    signature::EcdsaKeyPair::from_private_key_and_public_key(alg, &d, &q).unwrap();
+                    signature::EcdsaKeyPair::from_private_key_and_public_key(alg, &d, &q, &rng)
+                        .unwrap();
                 let rng = test::rand::FixedSliceRandom { bytes: &k };
 
                 let actual_result = private_key

--- a/tests/ecdsa_tests.rs
+++ b/tests/ecdsa_tests.rs
@@ -22,6 +22,8 @@ use ring::{
 
 #[test]
 fn ecdsa_from_pkcs8_test() {
+    let rng = rand::SystemRandom::new();
+
     test::run(
         test_file!("ecdsa_from_pkcs8_tests.txt"),
         |section, test_case| {
@@ -57,7 +59,7 @@ fn ecdsa_from_pkcs8_test() {
             let error = test_case.consume_optional_string("Error");
 
             match (
-                signature::EcdsaKeyPair::from_pkcs8(this_fixed, &input),
+                signature::EcdsaKeyPair::from_pkcs8(this_fixed, &input, &rng),
                 error.clone(),
             ) {
                 (Ok(_), None) => (),
@@ -67,7 +69,7 @@ fn ecdsa_from_pkcs8_test() {
             };
 
             match (
-                signature::EcdsaKeyPair::from_pkcs8(this_asn1, &input),
+                signature::EcdsaKeyPair::from_pkcs8(this_asn1, &input, &rng),
                 error,
             ) {
                 (Ok(_), None) => (),
@@ -76,8 +78,8 @@ fn ecdsa_from_pkcs8_test() {
                 (Err(actual), Some(expected)) => assert_eq!(format!("{}", actual), expected),
             };
 
-            assert!(signature::EcdsaKeyPair::from_pkcs8(other_fixed, &input).is_err());
-            assert!(signature::EcdsaKeyPair::from_pkcs8(other_asn1, &input).is_err());
+            assert!(signature::EcdsaKeyPair::from_pkcs8(other_fixed, &input, &rng).is_err());
+            assert!(signature::EcdsaKeyPair::from_pkcs8(other_asn1, &input, &rng).is_err());
 
             Ok(())
         },
@@ -104,7 +106,7 @@ fn ecdsa_generate_pkcs8_test() {
         println!();
 
         #[cfg(feature = "alloc")]
-        let _ = signature::EcdsaKeyPair::from_pkcs8(*alg, pkcs8.as_ref()).unwrap();
+        let _ = signature::EcdsaKeyPair::from_pkcs8(*alg, pkcs8.as_ref(), &rng).unwrap();
     }
 }
 
@@ -181,9 +183,11 @@ fn ecdsa_test_public_key_coverage() {
     const PUBLIC_KEY: &[u8] = include_bytes!("ecdsa_test_public_key_p256.der");
     const PUBLIC_KEY_DEBUG: &str = include_str!("ecdsa_test_public_key_p256_debug.txt");
 
+    let rng = rand::SystemRandom::new();
     let key_pair = signature::EcdsaKeyPair::from_pkcs8(
         &signature::ECDSA_P256_SHA256_FIXED_SIGNING,
         PRIVATE_KEY,
+        &rng,
     )
     .unwrap();
 
@@ -246,7 +250,7 @@ fn signature_ecdsa_sign_fixed_sign_and_verify_test() {
             };
 
             let private_key =
-                signature::EcdsaKeyPair::from_private_key_and_public_key(signing_alg, &d, &q)
+                signature::EcdsaKeyPair::from_private_key_and_public_key(signing_alg, &d, &q, &rng)
                     .unwrap();
 
             let signature = private_key.sign(&rng, &msg).unwrap();
@@ -300,7 +304,7 @@ fn signature_ecdsa_sign_asn1_test() {
             };
 
             let private_key =
-                signature::EcdsaKeyPair::from_private_key_and_public_key(signing_alg, &d, &q)
+                signature::EcdsaKeyPair::from_private_key_and_public_key(signing_alg, &d, &q, &rng)
                     .unwrap();
 
             let signature = private_key.sign(&rng, &msg).unwrap();


### PR DESCRIPTION
Resolve an old TODO now that we can make breaking API changes.