### PR TITLE
Reduce compilation flags added in build.rs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,13 +300,9 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_12.4.app &&
           sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
 
-      - if: ${{ !contains(matrix.host_os, 'windows') }}
-        run: |
+      - run: |
           mk/cargo.sh test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
-
-      - if: ${{ contains(matrix.host_os, 'windows') }}
-        run: |
-          cargo test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
+        shell: bash
 
       # Check that all the needed symbol renaming was done.
       # TODO: Do this check on Windows too.

--- a/build.rs
+++ b/build.rs
@@ -115,31 +115,7 @@ fn c_flags(target: &Target) -> &'static [&'static str] {
 
 fn cpp_flags(target: &Target) -> &'static [&'static str] {
     if target.env != MSVC {
-        static NON_MSVC_FLAGS: &[&str] = &[
-            "-pedantic",
-            "-pedantic-errors",
-            "-Wall",
-            "-Wextra",
-            "-Wcast-align",
-            "-Wcast-qual",
-            "-Wconversion",
-            "-Wenum-compare",
-            "-Wfloat-equal",
-            "-Wformat=2",
-            "-Winline",
-            "-Winvalid-pch",
-            "-Wmissing-field-initializers",
-            "-Wmissing-include-dirs",
-            "-Wredundant-decls",
-            "-Wshadow",
-            "-Wsign-compare",
-            "-Wsign-conversion",
-            "-Wundef",
-            "-Wuninitialized",
-            "-Wwrite-strings",
-            "-fno-strict-aliasing",
-            "-fvisibility=hidden",
-        ];
+        static NON_MSVC_FLAGS: &[&str] = &["-fno-strict-aliasing", "-fvisibility=hidden"];
         NON_MSVC_FLAGS
     } else {
         static MSVC_FLAGS: &[&str] = &[
@@ -152,8 +128,6 @@ fn cpp_flags(target: &Target) -> &'static [&'static str] {
             "/Zc:inline",
             "/Zc:rvalueCast",
             // Warnings.
-            "/sdl",
-            "/Wall",
             "/wd4127", // C4127: conditional expression is constant
             "/wd4464", // C4464: relative include path contains '..'
             "/wd4514", // C4514: <name>: unreferenced inline function has be

--- a/build.rs
+++ b/build.rs
@@ -119,14 +119,9 @@ fn cpp_flags(target: &Target) -> &'static [&'static str] {
         NON_MSVC_FLAGS
     } else {
         static MSVC_FLAGS: &[&str] = &[
-            "/GS",   // Buffer security checks.
-            "/Gy",   // Enable function-level linking.
-            "/EHsc", // C++ exceptions only, only in C++.
-            "/GR-",  // Disable RTTI.
-            "/Zc:wchar_t",
-            "/Zc:forScope",
+            "/GS", // Buffer security checks.
+            "/Gy", // Enable function-level linking.
             "/Zc:inline",
-            "/Zc:rvalueCast",
             // Warnings.
             "/wd4127", // C4127: conditional expression is constant
             "/wd4464", // C4464: relative include path contains '..'

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -17,6 +17,18 @@
 set -eux -o pipefail
 IFS=$'\n\t'
 
+NULL=
+
+# cc-rs adds `$CFLAGS` to the MSVC cl.exe command line automatically.
+# For -msvc targets we'll override `$CFLAGS` with `$CFLAGS_MSVC` to
+# take advantage of this.
+export CFLAGS="\
+  -Werror \
+  $NULL"
+CFLAGS_MSVC="\
+  -WX \
+  $NULL"
+
 rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
 qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
@@ -103,6 +115,9 @@ case $target in
     export AR_wasm32_unknown_unknown=llvm-ar-$llvm_version
     export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner
     export WASM_BINDGEN_TEST_TIMEOUT=60
+    ;;
+  *-msvc)
+    export CFLAGS=$CFLAGS_MSVC
     ;;
   *)
     ;;

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -24,9 +24,33 @@ NULL=
 # take advantage of this.
 export CFLAGS="\
   -Werror \
+  -pedantic \
+  -pedantic-errors \
+  -Wall \
+  -Wextra \
+  -Wcast-align \
+  -Wcast-qual \
+  -Wconversion \
+  -Wenum-compare \
+  -Werror \
+  -Wfloat-equal \
+  -Wformat=2 \
+  -Winline \
+  -Winvalid-pch \
+  -Wmissing-field-initializers \
+  -Wmissing-include-dirs \
+  -Wredundant-decls \
+  -Wshadow \
+  -Wsign-compare \
+  -Wsign-conversion \
+  -Wundef \
+  -Wuninitialized \
+  -Wwrite-strings \
   $NULL"
 CFLAGS_MSVC="\
+  -sdl \
   -WX \
+  -Wall \
   $NULL"
 
 rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"


### PR DESCRIPTION
Make build.rs simpler as a step towards supporting alternative build systems better.