### PR TITLE
RSA internals: Stop re-exporting `rsa::padding` items from `rsa`.

### DIFF
--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -25,13 +25,7 @@ use crate::{
     limb,
 };
 
-mod padding;
-
-// `RSA_PKCS1_SHA1` is intentionally not exposed.
-pub use self::padding::{
-    RsaEncoding, RSA_PKCS1_SHA256, RSA_PKCS1_SHA384, RSA_PKCS1_SHA512, RSA_PSS_SHA256,
-    RSA_PSS_SHA384, RSA_PSS_SHA512,
-};
+pub(crate) mod padding;
 
 // Maximum RSA modulus size supported for signature verification (in bytes).
 const PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN: usize = bigint::MODULUS_MAX_LIMBS * limb::LIMB_BYTES;

--- a/src/rsa/padding.rs
+++ b/src/rsa/padding.rs
@@ -133,36 +133,43 @@ fn pkcs1_encode(pkcs1: &PKCS1, m_hash: &digest::Digest, m_out: &mut [u8]) {
 }
 
 macro_rules! rsa_pkcs1_padding {
-    ( $PADDING_ALGORITHM:ident, $digest_alg:expr, $digestinfo_prefix:expr,
+    ( $vis:vis $PADDING_ALGORITHM:ident, $digest_alg:expr, $digestinfo_prefix:expr,
       $doc_str:expr ) => {
         #[doc=$doc_str]
-        pub static $PADDING_ALGORITHM: PKCS1 = PKCS1 {
+        $vis static $PADDING_ALGORITHM: PKCS1 = PKCS1 {
             digest_alg: $digest_alg,
             digestinfo_prefix: $digestinfo_prefix,
         };
     };
 }
 
+// Intentionally not exposed except internally for signature verification. At a
+// minimum, we'd need to create test vectors for signing with it, which we
+// don't currently have. But, it's a bad idea to use SHA-1 anyway, so perhaps
+// we just won't ever expose it.
 rsa_pkcs1_padding!(
-    RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY,
+    pub(in super) RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY,
     &digest::SHA1_FOR_LEGACY_USE_ONLY,
     &SHA1_PKCS1_DIGESTINFO_PREFIX,
     "PKCS#1 1.5 padding using SHA-1 for RSA signatures."
 );
+
 rsa_pkcs1_padding!(
-    RSA_PKCS1_SHA256,
+    pub RSA_PKCS1_SHA256,
     &digest::SHA256,
     &SHA256_PKCS1_DIGESTINFO_PREFIX,
     "PKCS#1 1.5 padding using SHA-256 for RSA signatures."
 );
+
 rsa_pkcs1_padding!(
-    RSA_PKCS1_SHA384,
+    pub RSA_PKCS1_SHA384,
     &digest::SHA384,
     &SHA384_PKCS1_DIGESTINFO_PREFIX,
     "PKCS#1 1.5 padding using SHA-384 for RSA signatures."
 );
+
 rsa_pkcs1_padding!(
-    RSA_PKCS1_SHA512,
+    pub RSA_PKCS1_SHA512,
     &digest::SHA512,
     &SHA512_PKCS1_DIGESTINFO_PREFIX,
     "PKCS#1 1.5 padding using SHA-512 for RSA signatures."
@@ -479,30 +486,32 @@ fn pss_digest(
 }
 
 macro_rules! rsa_pss_padding {
-    ( $PADDING_ALGORITHM:ident, $digest_alg:expr, $doc_str:expr ) => {
+    ( $vis:vis $PADDING_ALGORITHM:ident, $digest_alg:expr, $doc_str:expr ) => {
         #[doc=$doc_str]
-        pub static $PADDING_ALGORITHM: PSS = PSS {
+        $vis static $PADDING_ALGORITHM: PSS = PSS {
             digest_alg: $digest_alg,
         };
     };
 }
 
 rsa_pss_padding!(
-    RSA_PSS_SHA256,
+    pub RSA_PSS_SHA256,
     &digest::SHA256,
     "RSA PSS padding using SHA-256 for RSA signatures.\n\nSee
                  \"`RSA_PSS_*` Details\" in `ring::signature`'s module-level
                  documentation for more details."
 );
+
 rsa_pss_padding!(
-    RSA_PSS_SHA384,
+    pub RSA_PSS_SHA384,
     &digest::SHA384,
     "RSA PSS padding using SHA-384 for RSA signatures.\n\nSee
                  \"`RSA_PSS_*` Details\" in `ring::signature`'s module-level
                  documentation for more details."
 );
+
 rsa_pss_padding!(
-    RSA_PSS_SHA512,
+    pub RSA_PSS_SHA512,
     &digest::SHA512,
     "RSA PSS padding using SHA-512 for RSA signatures.\n\nSee
                  \"`RSA_PSS_*` Details\" in `ring::signature`'s module-level

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -12,7 +12,8 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{verification, RsaEncoding, N};
+use super::{padding::RsaEncoding, verification, N};
+
 /// RSA PKCS#1 1.5 signatures.
 use crate::{
     arithmetic::{

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -137,7 +137,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
     1024,
-    &super::RSA_PKCS1_SHA256,
+    &super::padding::RSA_PKCS1_SHA256,
     "Verification of signatures using RSA keys of 1024-8192 bits,
              PKCS#1.5 padding, and SHA-256.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -145,7 +145,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_2048_8192_SHA256,
     2048,
-    &super::RSA_PKCS1_SHA256,
+    &super::padding::RSA_PKCS1_SHA256,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PKCS#1.5 padding, and SHA-256.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -153,7 +153,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_2048_8192_SHA384,
     2048,
-    &super::RSA_PKCS1_SHA384,
+    &super::padding::RSA_PKCS1_SHA384,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PKCS#1.5 padding, and SHA-384.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -161,7 +161,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_2048_8192_SHA512,
     2048,
-    &super::RSA_PKCS1_SHA512,
+    &super::padding::RSA_PKCS1_SHA512,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PKCS#1.5 padding, and SHA-512.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -169,7 +169,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_1024_8192_SHA512_FOR_LEGACY_USE_ONLY,
     1024,
-    &super::RSA_PKCS1_SHA512,
+    &super::padding::RSA_PKCS1_SHA512,
     "Verification of signatures using RSA keys of 1024-8192 bits,
              PKCS#1.5 padding, and SHA-512.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -177,7 +177,7 @@ rsa_params!(
 rsa_params!(
     RSA_PKCS1_3072_8192_SHA384,
     3072,
-    &super::RSA_PKCS1_SHA384,
+    &super::padding::RSA_PKCS1_SHA384,
     "Verification of signatures using RSA keys of 3072-8192 bits,
              PKCS#1.5 padding, and SHA-384.\n\nSee \"`RSA_PKCS1_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -186,7 +186,7 @@ rsa_params!(
 rsa_params!(
     RSA_PSS_2048_8192_SHA256,
     2048,
-    &super::RSA_PSS_SHA256,
+    &super::padding::RSA_PSS_SHA256,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PSS padding, and SHA-256.\n\nSee \"`RSA_PSS_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -194,7 +194,7 @@ rsa_params!(
 rsa_params!(
     RSA_PSS_2048_8192_SHA384,
     2048,
-    &super::RSA_PSS_SHA384,
+    &super::padding::RSA_PSS_SHA384,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PSS padding, and SHA-384.\n\nSee \"`RSA_PSS_*` Details\" in
              `ring::signature`'s module-level documentation for more details."
@@ -202,7 +202,7 @@ rsa_params!(
 rsa_params!(
     RSA_PSS_2048_8192_SHA512,
     2048,
-    &super::RSA_PSS_SHA512,
+    &super::padding::RSA_PSS_SHA512,
     "Verification of signatures using RSA keys of 2048-8192 bits,
              PSS padding, and SHA-512.\n\nSee \"`RSA_PSS_*` Details\" in
              `ring::signature`'s module-level documentation for more details."

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -278,9 +278,12 @@ pub use crate::ec::{
 
 #[cfg(feature = "alloc")]
 pub use crate::rsa::{
+    padding::{
+        RsaEncoding, RSA_PKCS1_SHA256, RSA_PKCS1_SHA384, RSA_PKCS1_SHA512, RSA_PSS_SHA256,
+        RSA_PSS_SHA384, RSA_PSS_SHA512,
+    },
     signing::RsaKeyPair,
     signing::RsaSubjectPublicKey,
-
     verification::{
         RsaPublicKeyComponents, RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,
         RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
@@ -289,21 +292,7 @@ pub use crate::rsa::{
         RSA_PKCS1_2048_8192_SHA384, RSA_PKCS1_2048_8192_SHA512, RSA_PKCS1_3072_8192_SHA384,
         RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384, RSA_PSS_2048_8192_SHA512,
     },
-
-    RsaEncoding,
     RsaParameters,
-
-    // `RSA_PKCS1_SHA1` is intentionally not exposed. At a minimum, we'd need
-    // to create test vectors for signing with it, which we don't currently
-    // have. But, it's a bad idea to use SHA-1 anyway, so perhaps we just won't
-    // ever expose it.
-    RSA_PKCS1_SHA256,
-    RSA_PKCS1_SHA384,
-    RSA_PKCS1_SHA512,
-
-    RSA_PSS_SHA256,
-    RSA_PSS_SHA384,
-    RSA_PSS_SHA512,
 };
 
 /// A public key signature returned from a signing operation.


### PR DESCRIPTION
Prepare for making the `rsa` module public.