### PR TITLE
Add basic support for s390x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
           - i686-unknown-linux-musl
           - powerpc64le-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -253,6 +254,9 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: s390x-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: x86_64-pc-windows-gnu
@@ -342,6 +346,7 @@ jobs:
           - aarch64-unknown-linux-musl
           - i686-pc-windows-msvc
           - powerpc64le-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
 
         mode:
@@ -361,6 +366,9 @@ jobs:
             host_os: windows-latest
 
           - target: powerpc64le-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: s390x-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
@@ -498,6 +506,7 @@ jobs:
           - i686-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
           - x86_64-unknown-linux-musl
 
         mode:
@@ -525,6 +534,9 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: s390x-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-musl

--- a/crypto/fipsmodule/aes/aes_nohw.c
+++ b/crypto/fipsmodule/aes/aes_nohw.c
@@ -273,6 +273,9 @@ static inline aes_word_t aes_nohw_delta_swap(aes_word_t a, aes_word_t mask,
 // http://programming.sirrida.de/calcperm.php on smaller inputs.
 #if defined(OPENSSL_64_BIT)
 static inline uint64_t aes_nohw_compact_word(uint64_t a) {
+#if defined(RING_BIG_ENDIAN)
+  a = CRYPTO_bswap8(a);
+#endif
   // Numbering the 64/2 = 16 4-bit chunks, least to most significant, we swap
   // quartets of those chunks:
   //   0 1 2 3 | 4 5 6 7 | 8  9 10 11 | 12 13 14 15 =>
@@ -294,10 +297,16 @@ static inline uint64_t aes_nohw_uncompact_word(uint64_t a) {
   a = aes_nohw_delta_swap(a, UINT64_C(0x00000000ffff0000), 16);
   a = aes_nohw_delta_swap(a, UINT64_C(0x0000ff000000ff00), 8);
   a = aes_nohw_delta_swap(a, UINT64_C(0x00f000f000f000f0), 4);
+#if defined(RING_BIG_ENDIAN)
+  a = CRYPTO_bswap8(a);
+#endif
   return a;
 }
 #else   // !OPENSSL_64_BIT
 static inline uint32_t aes_nohw_compact_word(uint32_t a) {
+#if defined(RING_BIG_ENDIAN)
+  a = CRYPTO_bswap4(a);
+#endif
   // Numbering the 32/2 = 16 pairs of bits, least to most significant, we swap:
   //   0 1 2 3 | 4 5 6 7 | 8  9 10 11 | 12 13 14 15 =>
   //   0 4 2 6 | 1 5 3 7 | 8 12 10 14 |  9 13 11 15
@@ -316,6 +325,9 @@ static inline uint32_t aes_nohw_uncompact_word(uint32_t a) {
   // Reverse the steps of |aes_nohw_uncompact_word|.
   a = aes_nohw_delta_swap(a, 0x0000f0f0, 12);
   a = aes_nohw_delta_swap(a, 0x00cc00cc, 6);
+#if defined(RING_BIG_ENDIAN)
+  a = CRYPTO_bswap4(a);
+#endif
   return a;
 }
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -401,55 +401,77 @@ static inline void *OPENSSL_memset(void *dst, int c, size_t n) {
 // endianness. They use |memcpy|, and so avoid alignment or strict aliasing
 // requirements on the input and output pointers.
 
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define RING_BIG_ENDIAN
+#endif
+#endif
+
 static inline uint32_t CRYPTO_load_u32_le(const void *in) {
   uint32_t v;
   OPENSSL_memcpy(&v, in, sizeof(v));
+#if defined(RING_BIG_ENDIAN)
+  return CRYPTO_bswap4(v);
+#else
   return v;
+#endif
 }
 
 static inline void CRYPTO_store_u32_le(void *out, uint32_t v) {
+#if defined(RING_BIG_ENDIAN)
+  v = CRYPTO_bswap4(v);
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
 }
 
 static inline uint32_t CRYPTO_load_u32_be(const void *in) {
   uint32_t v;
   OPENSSL_memcpy(&v, in, sizeof(v));
+#if !defined(RING_BIG_ENDIAN)
   return CRYPTO_bswap4(v);
+#else
+  return v;
+#endif
 }
 
 static inline void CRYPTO_store_u32_be(void *out, uint32_t v) {
+#if !defined(RING_BIG_ENDIAN)
   v = CRYPTO_bswap4(v);
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
 }
 
 static inline uint64_t CRYPTO_load_u64_le(const void *in) {
   uint64_t v;
   OPENSSL_memcpy(&v, in, sizeof(v));
+#if defined(RING_BIG_ENDIAN)
+  return CRYPTO_bswap8(v);
+#else
   return v;
+#endif
 }
 
 static inline void CRYPTO_store_u64_le(void *out, uint64_t v) {
+#if defined(RING_BIG_ENDIAN)
+  v = CRYPTO_bswap8(v);
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
 }
 
 static inline uint64_t CRYPTO_load_u64_be(const void *ptr) {
   uint64_t ret;
   OPENSSL_memcpy(&ret, ptr, sizeof(ret));
+#if !defined(RING_BIG_ENDIAN)
   return CRYPTO_bswap8(ret);
+#else
+  return ret;
+#endif
 }
 
 static inline void CRYPTO_store_u64_be(void *out, uint64_t v) {
+#if !defined(RING_BIG_ENDIAN)
   v = CRYPTO_bswap8(v);
-  OPENSSL_memcpy(out, &v, sizeof(v));
-}
-
-static inline crypto_word_t CRYPTO_load_word_le(const void *in) {
-  crypto_word_t v;
-  OPENSSL_memcpy(&v, in, sizeof(v));
-  return v;
-}
-
-static inline void CRYPTO_store_word_le(void *out, crypto_word_t v) {
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
 }
 

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -46,6 +46,9 @@
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 8
 #define OPENSSL_64_BIT
 #define OPENSSL_RISCV64
+#elif defined(__s390x__)
+#define OPENSSL_64_BIT
+#define OPENSSL_S390X
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
 #else

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -23,6 +23,7 @@ qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
 qemu_mipsel="qemu-mipsel -L /usr/mipsel-linux-gnu"
 qemu_powerpc64le="qemu-ppc64le -L /usr/powerpc64le-linux-gnu"
 qemu_riscv64="qemu-riscv64 -L /usr/riscv64-linux-gnu"
+qemu_s390x="qemu-s390x -L /usr/s390x-linux-gnu"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may
@@ -113,6 +114,16 @@ case $target in
     export AR_riscv64gc_unknown_linux_gnu=llvm-ar-$llvm_version
     export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
     export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="$qemu_riscv64"
+    ;;
+  s390x-unknown-linux-gnu)
+    export CC_s390x_unknown_linux_gnu=clang-$llvm_version
+    export AR_s390x_unknown_linux_gnu=llvm-ar-$llvm_version
+    # XXX: Using -march=zEC12 to work around a z13 instruction bug in
+    # QEMU 8.0.2 and earlier that causes `test_constant_time` to fail
+    # (https://lists.gnu.org/archive/html/qemu-devel/2023-05/msg06965.html).
+    export CFLAGS_s390x_unknown_linux_gnu="--sysroot=/usr/s390x-linux-gnu -march=zEC12"
+    export CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc
+    export CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="$qemu_s390x"
     ;;
   x86_64-unknown-linux-musl)
     export CC_x86_64_unknown_linux_musl=clang-$llvm_version

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -105,6 +105,14 @@ case $target in
     libc6-dev-riscv64-cross \
     qemu-user
   ;;
+--target=s390x-unknown-linux-gnu)
+  # Clang is needed for code coverage.
+  use_clang=1
+  install_packages \
+    qemu-user \
+    gcc-s390x-linux-gnu \
+    libc6-dev-s390x-cross
+  ;;
 --target=wasm32-unknown-unknown)
   cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner
   use_clang=1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,5 +115,9 @@ mod sealed {
     pub trait Sealed {}
 }
 
-// TODO: https://github.com/briansmith/ring/issues/1555.
-const _LITTLE_ENDIAN_ONLY: () = assert!(cfg!(target_endian = "little"));
+// XXX: 64-bit big endian is tested; 32-bit is not.
+// TODO: Add 32-bit big endian test coverage to CI.
+const _ENDIAN_TESTING: () = assert!(cfg!(any(
+    target_endian = "little",
+    target_pointer_width = "64"
+)));


### PR DESCRIPTION
This adds basic support for Linux on s390x, using the fallback implementation of all algorithms and no assembler routines.   This addresses https://github.com/briansmith/ring/issues/986 and makes "cargo test" fully pass on s390x.

There were two main changes I had to make to get this working:

- Provide a bn_mul_mont fallback implementation.  Note that while there is a fallback implementation on the Rust side for limbs_mont_mul, some elliptic curve code directly calls bn_mul_mont on the C side, where there is currently no fallback.  However, given that we have a bn_from_montgomery_in_place fallback, it is straightforward to add bn_mul_mont (along the lines of the limbs_mont_mul fallback).
- Support big-endian platforms.   This consists of adding a number of endian access primitives in internal.h, and using them where required, currently in aes_nohw.c, poly1305.c, and the p256_scalar_bytes_from_limbs routine (for some reason, the p384 version of that routine is already endian-agnostic).  I have chosen to use a plain C implementation of the primitives rather than bswap intrinsics, because that is easier to maintain, doesn't require platform #ifdef's, and still compiles to good code with any recent compiler.

@briansmith, please let me know if this approach makes sense to you or if this should be done differently.

Once this basic (unoptimized) support is in, we can then build on it by adding assembler optimizations (they're already present in OpenSSL, but would need to be copied over and adapted).