### PR TITLE
Add Redox support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,7 +325,7 @@ spin = { version = "0.5.2", default-features = false }
 libc = { version = "0.2.84", default-features = false }
 once_cell = { version = "1.5.2", default-features = false, features=["std"], optional = true }
 
-[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
+[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "openbsd", target_os = "redox", target_os = "solaris"))'.dependencies]
 once_cell = { version = "1.5.2", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]

--- a/build.rs
+++ b/build.rs
@@ -262,6 +262,7 @@ const LINUX_ABI: &[&str] = &[
     "netbsd",
     "openbsd",
     "linux",
+    "redox",
     "solaris",
 ];
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -185,6 +185,7 @@ use self::sysrand_or_urandom::fill as fill_impl;
     target_os = "illumos",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "redox",
     target_os = "solaris",
 ))]
 use self::urandom::fill as fill_impl;
@@ -341,6 +342,7 @@ mod sysrand_or_urandom {
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "redox",
     target_os = "solaris",
     target_os = "illumos"
 ))]


### PR DESCRIPTION
This implements #901 with the requested changes. Also, /dev/urandom now exists on Redox, so that is used instead of rand: to minimize changes. Effectively Redox has the same feature set with ring as BSD and Illumos with these changes