### PR TITLE
Make `io::Positive` parsing API more robust.

### DIFF
--- a/src/io/der.rs
+++ b/src/io/der.rs
@@ -202,9 +202,7 @@ pub fn small_nonnegative_integer(input: &mut untrusted::Reader) -> Result<u8, er
 pub fn positive_integer<'a>(
     input: &mut untrusted::Reader<'a>,
 ) -> Result<Positive<'a>, error::Unspecified> {
-    Ok(Positive::new_non_empty_without_leading_zeros(
-        nonnegative_integer(input, 1)?,
-    ))
+    Positive::from_be_bytes(nonnegative_integer(input, 1)?)
 }
 
 #[cfg(test)]

--- a/src/io/positive.rs
+++ b/src/io/positive.rs
@@ -14,16 +14,25 @@
 
 //! Serialization and deserialization.
 
+use crate::error;
+
 /// A serialized positive integer.
 #[derive(Copy, Clone)]
 pub struct Positive<'a>(untrusted::Input<'a>);
 
 impl<'a> Positive<'a> {
     #[inline]
-    pub(crate) fn new_non_empty_without_leading_zeros(input: untrusted::Input<'a>) -> Self {
-        debug_assert!(!input.is_empty());
-        debug_assert!(input.len() == 1 || input.as_slice_less_safe()[0] != 0);
-        Self(input)
+    pub(crate) fn from_be_bytes(input: untrusted::Input<'a>) -> Result<Self, error::Unspecified> {
+        // Empty inputs are not allowed.
+        let &first_byte = input
+            .as_slice_less_safe()
+            .first()
+            .ok_or(error::Unspecified)?;
+        // Zero isn't allowed and leading zeros aren't allowed.
+        if first_byte == 0 {
+            return Err(error::Unspecified);
+        }
+        Ok(Self(input))
     }
 
     /// Returns the value, ordered from significant byte to least significant
@@ -49,5 +58,43 @@ impl Positive<'_> {
     pub fn first_byte(&self) -> u8 {
         // This won't panic because
         self.0.as_slice_less_safe()[0]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_be_bytes() {
+        static TEST_CASES: &[(&[u8], Result<&[u8], error::Unspecified>)] = &[
+            // An empty input isn't a number.
+            (&[], Err(error::Unspecified)),
+            // Zero is not positive.
+            (&[0x00], Err(error::Unspecified)),
+            // Minimum value. No leading zero required or allowed.
+            (&[0x00, 0x01], Err(error::Unspecified)),
+            (&[0x01], Ok(&[0x01])),
+            // Maximum first byte. No leading zero required or allowed.
+            (&[0xff], Ok(&[0xff])),
+            (&[0x00, 0xff], Err(error::Unspecified)),
+            // The last byte can be zero.
+            (&[0x01, 0x00], Ok(&[0x01, 0x00])),
+            (&[0x01, 0x00, 0x00], Ok(&[0x01, 0x00, 0x00])),
+            // Having no zero bytes are also allowed.
+            (&[0x01, 0x01], Ok(&[0x01, 0x01])),
+            // A middle byte can be zero.
+            (&[0x01, 0x00, 0x01], Ok(&[0x01, 0x00, 0x01])),
+            (&[0x01, 0x01, 0x01], Ok(&[0x01, 0x01, 0x01])),
+        ];
+        for &(input, result) in TEST_CASES {
+            let input = untrusted::Input::from(input);
+            assert_eq!(
+                Positive::from_be_bytes(input).map(|p| p
+                    .big_endian_without_leading_zero_as_input()
+                    .as_slice_less_safe()),
+                result
+            );
+        }
     }
 }


### PR DESCRIPTION
Use normal error handling instead of panicking. That is, don't require/assume that the caller
of `io::Positive::new_non_empty_without_leading_zeros()` already validated the input. This
adds redundant error checking when it is used by `io::der`, but will simplify (future)
callers outside of `io::der`.

Rename the function.