### PR TITLE
io::der: Simplify `big_endian_without_leading_zero()` uses.

### DIFF
--- a/src/io/der.rs
+++ b/src/io/der.rs
@@ -263,8 +263,8 @@ mod tests {
             with_good_i(test_in, |input| {
                 let test_out = [test_out];
                 assert_eq!(
-                    positive_integer(input)?.big_endian_without_leading_zero_as_input(),
-                    untrusted::Input::from(&test_out[..])
+                    positive_integer(input)?.big_endian_without_leading_zero(),
+                    &test_out[..]
                 );
                 Ok(())
             });

--- a/src/io/positive.rs
+++ b/src/io/positive.rs
@@ -90,9 +90,7 @@ mod tests {
         for &(input, result) in TEST_CASES {
             let input = untrusted::Input::from(input);
             assert_eq!(
-                Positive::from_be_bytes(input).map(|p| p
-                    .big_endian_without_leading_zero_as_input()
-                    .as_slice_less_safe()),
+                Positive::from_be_bytes(input).map(|p| p.big_endian_without_leading_zero()),
                 result
             );
         }

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -380,8 +380,7 @@ impl RsaKeyPair {
     pub fn public_modulus_len(&self) -> usize {
         self.public_key
             .modulus()
-            .big_endian_without_leading_zero_as_input()
-            .as_slice_less_safe()
+            .big_endian_without_leading_zero()
             .len()
     }
 }


### PR DESCRIPTION
`big_endian_without_leading_zero_as_input().as_slice_less_safe()` is
equivalent to `big_endian_without_leading_zero()`. Simplify users of the
former to use the latter.

This facilitates moving the unit tests to integration tests.