### PR TITLE
RSA: Create a new public key type.

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -12,19 +12,28 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+//! Bit lengths.
+
 use crate::error;
 
+/// The length of something, in bits.
+///
+/// This can represent a bit length that isn't a whole number of bytes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub struct BitLength(usize);
 
 // Lengths measured in bits, where all arithmetic is guaranteed not to
 // overflow.
 impl BitLength {
+    /// Constructs a `BitLength` from the given length in bits.
     #[inline]
     pub const fn from_usize_bits(bits: usize) -> Self {
         Self(bits)
     }
 
+    /// Constructs a `BitLength` from the given length in bytes.
+    ///
+    /// Fails if `bytes * 8` is too large for a `usize`.
     #[inline]
     pub fn from_usize_bytes(bytes: usize) -> Result<Self, error::Unspecified> {
         let bits = bytes.checked_mul(8).ok_or(error::Unspecified)?;
@@ -33,16 +42,18 @@ impl BitLength {
 
     #[cfg(feature = "alloc")]
     #[inline]
-    pub fn half_rounded_up(&self) -> Self {
+    pub(crate) fn half_rounded_up(&self) -> Self {
         let round_up = self.0 & 1;
         Self((self.0 / 2) + round_up)
     }
 
+    /// The number of bits this bit length represents, as a `usize`.
     #[inline]
     pub fn as_usize_bits(&self) -> usize {
         self.0
     }
 
+    /// The bit length, rounded up to a whole number of bytes.
     #[cfg(feature = "alloc")]
     #[inline]
     pub fn as_usize_bytes_rounded_up(&self) -> usize {
@@ -57,7 +68,7 @@ impl BitLength {
 
     #[cfg(feature = "alloc")]
     #[inline]
-    pub fn try_sub_1(self) -> Result<Self, error::Unspecified> {
+    pub(crate) fn try_sub_1(self) -> Result<Self, error::Unspecified> {
         let sum = self.0.checked_sub(1).ok_or(error::Unspecified)?;
         Ok(Self(sum))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ mod polyfill;
 pub mod aead;
 pub mod agreement;
 
-mod bits;
+pub mod bits;
 
 pub(crate) mod c;
 pub mod constant_time;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub mod pkcs8;
 pub mod rand;
 
 #[cfg(feature = "alloc")]
-mod rsa;
+pub mod rsa;
 
 pub mod signature;
 

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -17,7 +17,7 @@
 // naming conventions. Also the standard camelCase names are used for `KeyPair`
 // components.
 
-//! Low-level RSA primitives.
+//! RSA.
 
 use crate::{
     arithmetic::bigint,

--- a/src/rsa/public.rs
+++ b/src/rsa/public.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-//! Low-level RSA public key API.
+//! RSA public keys.
 
 mod components;
 mod exponent;

--- a/src/rsa/public/exponent.rs
+++ b/src/rsa/public/exponent.rs
@@ -11,8 +11,8 @@ impl Exponent {
 
     // TODO: Use `NonZeroU64::new(...).unwrap()` when `feature(const_panic)` is
     // stable.
-    pub(in crate::rsa) const _3: Self = Self(unsafe { NonZeroU64::new_unchecked(3) });
-    pub(in crate::rsa) const _65537: Self = Self(unsafe { NonZeroU64::new_unchecked(65537) });
+    pub(in super::super) const _3: Self = Self(unsafe { NonZeroU64::new_unchecked(3) });
+    pub(in super::super) const _65537: Self = Self(unsafe { NonZeroU64::new_unchecked(65537) });
 
     // This limit was chosen to bound the performance of the simple
     // exponentiation-by-squaring implementation in `elem_exp_vartime`. In

--- a/src/rsa/public/exponent.rs
+++ b/src/rsa/public/exponent.rs
@@ -1,7 +1,7 @@
 use crate::error;
 use core::num::NonZeroU64;
 
-/// The exponent `e` of the RSA public key.
+/// The exponent `e` of an RSA public key.
 #[derive(Clone, Copy, Debug)]
 pub struct Exponent(NonZeroU64);
 
@@ -30,7 +30,7 @@ impl Exponent {
     // stable.
     const MAX: Self = Self(unsafe { NonZeroU64::new_unchecked((1u64 << 33) - 1) });
 
-    pub fn from_be_bytes(
+    pub(super) fn from_be_bytes(
         input: untrusted::Input,
         min_value: Self,
     ) -> Result<Self, error::KeyRejected> {

--- a/src/rsa/public/key.rs
+++ b/src/rsa/public/key.rs
@@ -15,6 +15,7 @@
 use super::{Exponent, Modulus};
 use crate::{bits, error};
 
+/// An RSA Public Key.
 #[derive(Debug)]
 pub struct Key {
     n: Modulus,
@@ -22,7 +23,7 @@ pub struct Key {
 }
 
 impl Key {
-    pub fn from_modulus_and_exponent(
+    pub(in super::super) fn from_modulus_and_exponent(
         n: untrusted::Input,
         e: untrusted::Input,
         n_min_bits: bits::BitLength,
@@ -52,10 +53,14 @@ impl Key {
         Ok(Self { n, e })
     }
 
+    /// The public modulus.
+    #[inline]
     pub fn n(&self) -> &Modulus {
         &self.n
     }
 
+    /// The public exponent.
+    #[inline]
     pub fn e(&self) -> Exponent {
         self.e
     }

--- a/src/rsa/public/modulus.rs
+++ b/src/rsa/public/modulus.rs
@@ -48,8 +48,9 @@ impl Modulus {
         Ok(Self { value, bits })
     }
 
+    /// The length of the modulus in bits.
     #[inline]
-    pub(crate) fn len_bits(&self) -> bits::BitLength {
+    pub fn len_bits(&self) -> bits::BitLength {
         self.bits
     }
 

--- a/src/rsa/public/modulus.rs
+++ b/src/rsa/public/modulus.rs
@@ -1,6 +1,7 @@
 use crate::{arithmetic::bigint, bits, error, rsa::N};
 use core::ops::RangeInclusive;
 
+/// The modulus (n) of an RSA public key.
 pub struct Modulus {
     value: bigint::Modulus<N>,
     bits: bits::BitLength,

--- a/src/rsa/public/modulus.rs
+++ b/src/rsa/public/modulus.rs
@@ -13,7 +13,7 @@ impl core::fmt::Debug for Modulus {
 }
 
 impl Modulus {
-    pub(in crate::rsa) fn from_be_bytes(
+    pub(super) fn from_be_bytes(
         n: untrusted::Input,
         allowed_bit_lengths: RangeInclusive<bits::BitLength>,
     ) -> Result<Self, error::KeyRejected> {
@@ -52,7 +52,7 @@ impl Modulus {
         self.bits
     }
 
-    pub(in crate::rsa) fn value(&self) -> &bigint::Modulus<N> {
+    pub(in super::super) fn value(&self) -> &bigint::Modulus<N> {
         &self.value
     }
 }

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -373,14 +373,18 @@ impl RsaKeyPair {
         })
     }
 
+    /// Returns a reference to the public key.
+    pub fn public(&self) -> &public::Key {
+        &self.public
+    }
+
     /// Returns the length in bytes of the key pair's public modulus.
     ///
     /// A signature has the same length as the public modulus.
+    #[deprecated = "Use `public().n().len_bits().as_usize_bits()`"]
+    #[inline]
     pub fn public_modulus_len(&self) -> usize {
-        self.public_key
-            .modulus()
-            .big_endian_without_leading_zero()
-            .len()
+        self.public().n().len_bits().as_usize_bits()
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -207,7 +207,7 @@
 //! // SHA256 digest algorithm.
 //! const MESSAGE: &'static [u8] = b"hello, world";
 //! let rng = rand::SystemRandom::new();
-//! let mut signature = vec![0; key_pair.public_modulus_len()];
+//! let mut signature = vec![0; key_pair.public().n().len().as_usize_bytes_rounded_up()];
 //! key_pair.sign(&signature::RSA_PKCS1_SHA256, &rng, MESSAGE, &mut signature)
 //!     .map_err(|_| MyError::OOM)?;
 //!

--- a/tests/rsa_tests.rs
+++ b/tests/rsa_tests.rs
@@ -82,7 +82,8 @@ fn test_signature_rsa_pkcs1_sign() {
 
             // XXX: This test is too slow on Android ARM Travis CI builds.
             // TODO: re-enable these tests on Android ARM.
-            let mut actual = vec![0u8; key_pair.public_modulus_len()];
+            let mut actual =
+                vec![0u8; key_pair.public().n().len_bits().as_usize_bytes_rounded_up()];
             key_pair
                 .sign(alg, &rng, &msg, actual.as_mut_slice())
                 .unwrap();
@@ -121,7 +122,8 @@ fn test_signature_rsa_pss_sign() {
 
             let rng = test::rand::FixedSliceRandom { bytes: &salt };
 
-            let mut actual = vec![0u8; key_pair.public_modulus_len()];
+            let mut actual =
+                vec![0u8; key_pair.public().n().len_bits().as_usize_bytes_rounded_up()];
             key_pair.sign(alg, &rng, &msg, actual.as_mut_slice())?;
             assert_eq!(actual.as_slice() == &expected[..], result == "Pass");
             Ok(())
@@ -143,7 +145,7 @@ fn test_signature_rsa_pkcs1_sign_output_buffer_len() {
     let key_pair = signature::RsaKeyPair::from_der(PRIVATE_KEY_DER).unwrap();
 
     // The output buffer is one byte too short.
-    let mut signature = vec![0; key_pair.public_modulus_len() - 1];
+    let mut signature = vec![0; key_pair.public().n().len_bits().as_usize_bytes_rounded_up() - 1];
 
     assert!(key_pair
         .sign(&signature::RSA_PKCS1_SHA256, &rng, MESSAGE, &mut signature)


### PR DESCRIPTION
Expose a set of public types with minimal functionality for RSA public key operations. We'll add new functionality on top of this.