### PR TITLE
Stop using `PartialEq`/`Eq` implementations for `untrusted::Input`.

### DIFF
--- a/src/ec/suite_b.rs
+++ b/src/ec/suite_b.rs
@@ -191,7 +191,7 @@ fn key_pair_from_pkcs8_<'a>(
         let actual_alg_id =
             der::expect_tag_and_get_value(input, der::Tag::ContextSpecificConstructed0)
                 .map_err(|error::Unspecified| error::KeyRejected::invalid_encoding())?;
-        if actual_alg_id != template.curve_oid() {
+        if actual_alg_id.as_slice_less_safe() != template.curve_oid().as_slice_less_safe() {
             return Err(error::KeyRejected::wrong_algorithm());
         }
     }
@@ -220,7 +220,7 @@ pub(crate) fn key_pair_from_bytes(
 
     let r = ec::KeyPair::derive(seed)
         .map_err(|error::Unspecified| error::KeyRejected::unexpected_error())?;
-    if public_key_bytes != *r.public_key().as_ref() {
+    if public_key_bytes.as_slice_less_safe() != r.public_key().as_ref() {
         return Err(error::KeyRejected::inconsistent_components());
     }
 

--- a/src/pkcs8.rs
+++ b/src/pkcs8.rs
@@ -119,7 +119,7 @@ fn unwrap_key__<'a>(
 
     let actual_alg_id = der::expect_tag_and_get_value(input, der::Tag::Sequence)
         .map_err(|error::Unspecified| error::KeyRejected::invalid_encoding())?;
-    if actual_alg_id != alg_id {
+    if actual_alg_id.as_slice_less_safe() != alg_id.as_slice_less_safe() {
         return Err(error::KeyRejected::wrong_algorithm());
     }
 

--- a/src/rsa/padding.rs
+++ b/src/rsa/padding.rs
@@ -100,7 +100,7 @@ impl Verification for PKCS1 {
         let mut calculated = [0u8; PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN];
         let calculated = &mut calculated[..mod_bits.as_usize_bytes_rounded_up()];
         pkcs1_encode(&self, m_hash, calculated);
-        if m.read_bytes_to_end() != *calculated {
+        if m.read_bytes_to_end().as_slice_less_safe() != calculated {
             return Err(error::Unspecified);
         }
         Ok(())
@@ -394,7 +394,7 @@ impl Verification for PSS {
         let h_prime = pss_digest(self.digest_alg, m_hash, salt);
 
         // Step 14.
-        if h_hash != *h_prime.as_ref() {
+        if h_hash.as_slice_less_safe() != h_prime.as_ref() {
             return Err(error::Unspecified);
         }
 


### PR DESCRIPTION
Prepare for the removal of the `PartialEq`/`Eq` implementations from
`untrusted`. The goal of such removal is to make timing leaks more
obvious, and to make the absense of timing leaks more clear.