### PR TITLE
add riscv support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,8 @@ jobs:
           - x86_64-apple-darwin
           - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          - riscv32gc-unknown-linux-gnu
 
         mode:
           - # debug
@@ -273,6 +275,12 @@ jobs:
             host_os: ubuntu-18.04
 
           - target: x86_64-unknown-linux-gnu
+            host_os: ubuntu-18.04
+
+          - target: riscv64gc-unknown-linux-gnu
+            host_os: ubuntu-18.04
+
+          - target: riscv32gc-unknown-linux-gnu
             host_os: ubuntu-18.04
 
     steps:

--- a/build.rs
+++ b/build.rs
@@ -201,6 +201,20 @@ const ASM_TARGETS: &[AsmTarget] = &[
         preassemble: false,
     },
     AsmTarget {
+        oss: LINUX_ABI,
+        arch: "riscv32",
+        perlasm_format: "linux32",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
+        oss: LINUX_ABI,
+        arch: "riscv64",
+        perlasm_format: "linux64",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
         oss: MACOS_ABI,
         arch: "aarch64",
         perlasm_format: "ios64",

--- a/include/ring-core/base.h
+++ b/include/ring-core/base.h
@@ -91,6 +91,14 @@
 #define OPENSSL_MIPS64
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
+#elif defined(__riscv)
+# if (__riscv_xlen == 64)
+#  define OPENSSL_64_BIT
+#  define OPENSSL_RISCV64
+# elif(__riscv_xlen == 32)
+#  define OPENSSL_32_BIT
+#  define OPENSSL_RISCV32
+# endif
 #else
 // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
 // little-endian architectures. Functions will not produce the correct answer


### PR DESCRIPTION
fix #1182

I'm not 100% confident about the changes to `.github/workflows/ci.yml`.
Please review carefully.

Built successfully (release + debug) natively on a QEMU RISC-V 64 from https://wiki.ubuntu.com/RISC-V