### PR TITLE
build.rs: Use cc-rs's built-in logic for warnings-as-errors.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -614,12 +614,7 @@ fn cc(
     }
 
     if warnings_are_errors {
-        let flag = if &target.env != "msvc" {
-            "-Werror"
-        } else {
-            "/WX"
-        };
-        let _ = c.flag(flag);
+        c.warnings_into_errors(true);
     }
     if is_musl {
         // Some platforms enable _FORTIFY_SOURCE by default, but musl


### PR DESCRIPTION
Take a step towards supporting Clang as the compiler for -msvc targets.