### PR TITLE
Revert "CI: Use nightly-2021-08-13 to work around regression in latest Rust nightly."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,9 +191,7 @@ jobs:
 
         rust_channel:
           - stable
-          # Work around failure to link on aarch64-apple-darwin in later
-          # nightly toolchains.
-          - nightly-2021-08-13
+          - nightly
           - 1.52.1 # MSRV
           - beta
 


### PR DESCRIPTION
This reverts commit c8ca693ff7e6c619e1f2dd8ea915c335836af3a8 so we'll use the latest
nightly in CI. The rustc bug was fixed.