### PR TITLE
build.rs: Clarify `package` logic after aarch64-pc-windows-msvc support was added.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# pregenerated/ cannot be here because we need `cargo package` to package stuff
+# in it. However, we don't need/want `cargo package` to package pregenerated/tmp,
+# so that can be here.
+pregenerated/tmp
+
 build/
 ssl/test/runner/runner
 *.log

--- a/build.rs
+++ b/build.rs
@@ -459,8 +459,7 @@ fn build_c_code(
         let mut asm_srcs = asm_srcs(perlasm_src_dsts);
 
         // For Windows we also pregenerate the object files for non-Git builds so
-        // the user doesn't need to install the assembler. On other platforms we
-        // assume the C compiler also assembles.
+        // the user doesn't need to install the assembler.
         if use_pregenerated && target.os == WINDOWS {
             asm_srcs = asm_srcs
                 .iter()

--- a/build.rs
+++ b/build.rs
@@ -556,15 +556,15 @@ fn compile(p: &Path, target: &Target, out_dir: &Path) -> String {
     if ext == "o" {
         p.to_str().expect("Invalid path").into()
     } else {
-        let out_path = obj_path(out_dir, p);
+        let out_file = obj_path(out_dir, p);
         let cmd = if target.os != WINDOWS || ext != "asm" {
-            cc(p, ext, target, &out_path, out_dir)
+            cc(p, ext, target, out_dir, &out_file)
         } else {
-            nasm(p, &target.arch, &out_path, out_dir)
+            nasm(p, &target.arch, out_dir, &out_file)
         };
 
         run_command(cmd);
-        out_path.to_str().expect("Invalid path").into()
+        out_file.to_str().expect("Invalid path").into()
     }
 }
 
@@ -577,7 +577,7 @@ fn obj_path(out_dir: &Path, src: &Path) -> PathBuf {
     out_path
 }
 
-fn cc(file: &Path, ext: &str, target: &Target, out_path: &Path, include_dir: &Path) -> Command {
+fn cc(file: &Path, ext: &str, target: &Target, include_dir: &Path, out_file: &Path) -> Command {
     let mut c = cc::Build::new();
 
     // FIXME: On Windows AArch64 we currently must use Clang to compile C code
@@ -664,13 +664,13 @@ fn cc(file: &Path, ext: &str, target: &Target, out_path: &Path, include_dir: &Pa
         .arg(format!(
             "{}{}",
             obj_opt,
-            out_path.to_str().expect("Invalid path")
+            out_file.to_str().expect("Invalid path")
         ))
         .arg(file);
     c
 }
 
-fn nasm(file: &Path, arch: &str, out_file: &Path, include_dir: &Path) -> Command {
+fn nasm(file: &Path, arch: &str, include_dir: &Path, out_file: &Path) -> Command {
     let oformat = match arch {
         "x86_64" => ("win64"),
         "x86" => ("win32"),

--- a/build.rs
+++ b/build.rs
@@ -850,8 +850,6 @@ fn ring_core_prefix() -> String {
 fn generate_prefix_symbols(out_dir: &Path, prefix: &str) -> Result<(), std::io::Error> {
     generate_prefix_symbols_header(out_dir, "prefix_symbols.h", '#', None, prefix)?;
 
-    generate_prefix_symbols_nasm(out_dir, prefix)?;
-
     generate_prefix_symbols_header(
         out_dir,
         "prefix_symbols_asm.h",
@@ -860,17 +858,15 @@ fn generate_prefix_symbols(out_dir: &Path, prefix: &str) -> Result<(), std::io::
         prefix,
     )?;
 
-    Ok(())
-}
-
-fn generate_prefix_symbols_nasm(out_dir: &Path, prefix: &str) -> Result<(), std::io::Error> {
     generate_prefix_symbols_header(
         out_dir,
         "prefix_symbols_nasm.inc",
         '%',
         Some("%ifidn __OUTPUT_FORMAT__,win32"),
         prefix,
-    )
+    )?;
+
+    Ok(())
 }
 
 fn generate_prefix_symbols_header(


### PR DESCRIPTION
See the commit messages of the individual commits for details on each change.