### PR TITLE
CI: Stop excluding Rust 1.47.0 builds since they are never attempted.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,10 @@ jobs:
 
         # Coverage collection is Nightly-only
         rust_channel:
-          - nightly
+          # XXX: Later Rust Nightly uses LLVM 13 which has a new coverage format.
+          # Use this older version until install-build-tools.sh and similar can
+          # be updated to use LLVM 13.
+          - nightly-2021-08-20
 
         # TODO: targets
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,31 +195,6 @@ jobs:
           - 1.52.1 # MSRV
           - beta
 
-        exclude:
-          # The MSRV channel doesn't have aarch64-apple-darwin support yet.
-          - target: aarch64-apple-darwin
-            rust_channel: 1.47.0
-
-          # Only do MSRV testing on release builds.
-          - mode: # debug
-            rust_channel: 1.47.0
-
-          # 1.47.0 doesn't support `-Clink-self-contained`.
-          - target: aarch64-unknown-linux-musl
-            rust_channel: 1.47.0
-
-          # 1.47.0 doesn't support `-Clink-self-contained`.
-          - target: armv7-unknown-linux-musleabihf
-            rust_channel: 1.47.0
-
-          # 1.47.0 doesn't support `-Clink-self-contained`.
-          - target: i686-unknown-linux-musl
-            rust_channel: 1.47.0
-
-          # 1.47.0 doesn't support `-Clink-self-contained`.
-          - target: x86_64-unknown-linux-musl
-            rust_channel: 1.47.0
-
         include:
           - target: aarch64-apple-darwin
             host_os: macos-latest


### PR DESCRIPTION
This logic is a holdover from when Rust 1.47.0 was the MSRV.