### PR TITLE
add haiku support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ spin = { version = "0.9.2", default-features = false, features = ["once"] }
 libc = { version = "0.2.100", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features=["std"], optional = true }
 
-[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "openbsd", target_os = "redox", target_os = "solaris"))'.dependencies]
+[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "openbsd", target_os = "redox", target_os = "solaris", target_os = "haiku"))'.dependencies]
 once_cell = { version = "1.8.0", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]

--- a/build.rs
+++ b/build.rs
@@ -271,6 +271,7 @@ const LINUX_ABI: &[&str] = &[
     "linux",
     "redox",
     "solaris",
+    "haiku",
 ];
 
 /// Operating systems that have the same ABI as macOS on every architecture

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -187,6 +187,7 @@ use self::sysrand_or_urandom::fill as fill_impl;
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "haiku",
 ))]
 use self::urandom::fill as fill_impl;
 
@@ -344,6 +345,7 @@ mod sysrand_or_urandom {
     target_os = "openbsd",
     target_os = "redox",
     target_os = "solaris",
+    target_os = "haiku",
     target_os = "illumos"
 ))]
 mod urandom {


### PR DESCRIPTION
hello

i've created some patches should allow ring to build on haiku.  example build and test run:

```
~/src/git/rust-libs/ring> uname -a
Haiku shredder 1 hrev55271 Jul 31 2021 07:54:34 x86_64 x86_64 Haiku

~/src/git/rust-libs/ring> cargo version
cargo 1.54.0 (5ae8d74b3 2021-06-22)

~/src/git/rust-libs/ring> cargo build
    Updating crates.io index
   Compiling cc v1.0.69
   Compiling spin v0.9.2
   Compiling once_cell v1.8.0
   Compiling ring v0.17.0-not-released-yet (/boot/home/src/git/rust-libs/ring)
    Finished dev [unoptimized + debuginfo] target(s) in 56.40s
~/src/git/rust-libs/ring> cargo test
  Downloaded libc v0.2.101
  Downloaded 1 crate (530.0 KB) in 4.61s
   Compiling libc v0.2.101
   Compiling criterion-plot v0.4.4
   Compiling num_cpus v1.13.0
   Compiling atty v0.2.14
   Compiling rayon-core v1.9.1
   Compiling rayon v1.5.1
   Compiling criterion v0.3.5
   Compiling ring v0.17.0-not-released-yet (/boot/home/src/git/rust-libs/ring)
    Finished test [unoptimized + debuginfo] target(s) in 2m 17s
     Running unittests (target/debug/deps/ring-3a34d076a6b6c9c5)

running 88 tests
test aead::aes::tests::test_aes ... ok
test aead::aes_gcm::tests::max_input_len_test ... ok
test aead::chacha20_poly1305::tests::max_input_len_test ... ok
test aead::chacha::tests::chacha20_test_default ... ok
test aead::chacha::tests::chacha20_test_fallback ... ok
test aead::poly1305::tests::test_poly1305 ... ok
test arithmetic::bigint::tests::test_elem_exp_consttime ... ok
test arithmetic::bigint::tests::test_elem_mul ... ok
test arithmetic::bigint::tests::test_elem_reduced ... ok
test arithmetic::bigint::tests::test_elem_reduced_once ... ok
test arithmetic::bigint::tests::test_elem_squared ... ok
test arithmetic::bigint::tests::test_modulus_debug ... ok
test arithmetic::bigint::tests::test_mul_add_words ... ok
test arithmetic::bigint::tests::test_public_exponent_debug ... ok
test bssl::tests::result::semantics ... ok
test bssl::tests::result::size_and_alignment ... ok
test c::tests::test_libc_compatible ... ok
test constant_time::tests::test_constant_time ... ok
test cpu::intel::x86_64_tests::test_avx_movbe_mask ... ok
test digest::tests::max_input::SHA1_FOR_LEGACY_USE_ONLY::max_input_test ... ok
test digest::tests::max_input::SHA1_FOR_LEGACY_USE_ONLY::too_long_input_test_block - should panic ... ok
test digest::tests::max_input::SHA1_FOR_LEGACY_USE_ONLY::too_long_input_test_byte - should panic ... ok
test digest::tests::max_input::SHA256::max_input_test ... ok
test digest::tests::max_input::SHA256::too_long_input_test_block - should panic ... ok
test digest::tests::max_input::SHA256::too_long_input_test_byte - should panic ... ok
test digest::tests::max_input::SHA384::max_input_test ... ok
test digest::tests::max_input::SHA384::too_long_input_test_block - should panic ... ok
test digest::tests::max_input::SHA384::too_long_input_test_byte - should panic ... ok
test digest::tests::max_input::SHA512::max_input_test ... ok
test digest::tests::max_input::SHA512::too_long_input_test_block - should panic ... ok
test digest::tests::max_input::SHA512::too_long_input_test_byte - should panic ... ok
test ec::suite_b::ecdh::tests::test_agreement_suite_b_ecdh_generate ... ok
test ec::suite_b::ecdsa::digest_scalar::tests::test ... ok
test ec::suite_b::ecdsa::signing::tests::signature_ecdsa_sign_asn1_test ... ok
test ec::suite_b::ecdsa::signing::tests::signature_ecdsa_sign_fixed_test ... ok
test ec::suite_b::ecdsa::verification::tests::test_digest_based_test_vectors ... ok
test ec::suite_b::ops::tests::p256_elem_add_test ... ok
test ec::suite_b::ops::tests::p256_elem_mul_test ... ok
test ec::suite_b::ops::tests::p256_elem_neg_test ... ok
test ec::suite_b::ops::tests::p256_point_double_test ... ok
test ec::suite_b::ops::tests::p256_point_mul_base_test ... ok
test ec::suite_b::ops::tests::p256_point_mul_serialized_test ... ok
test ec::suite_b::ops::tests::p256_point_mul_test ... ok
test ec::suite_b::ops::tests::p256_point_sum_mixed_test ... ok
test ec::suite_b::ops::tests::p256_point_sum_test ... ok
test ec::suite_b::ops::tests::p256_q_minus_n_plus_n_equals_0_test ... ok
test ec::suite_b::ops::tests::p256_scalar_inv_to_mont_zero_panic_test - should panic ... ok
test ec::suite_b::ops::tests::p256_scalar_mul_test ... ok
test ec::suite_b::ops::tests::p256_scalar_square_test ... ok
test ec::suite_b::ops::tests::p384_elem_add_test ... ok
test ec::suite_b::ops::tests::p384_elem_div_by_2_test ... ok
test ec::suite_b::ops::tests::p384_elem_mul_test ... ok
test ec::suite_b::ops::tests::p384_elem_neg_test ... ok
test ec::suite_b::ops::tests::p384_elem_sub_test ... ok
test ec::suite_b::ops::tests::p384_point_double_test ... ok
test ec::suite_b::ops::tests::p384_point_mul_base_test ... ok
test ec::suite_b::ops::tests::p384_point_mul_test ... ok
test ec::suite_b::ops::tests::p384_point_sum_test ... ok
test ec::suite_b::ops::tests::p384_q_minus_n_plus_n_equals_0_test ... ok
test ec::suite_b::ops::tests::p384_scalar_inv_to_mont_zero_panic_test - should panic ... ok
test ec::suite_b::ops::tests::p384_scalar_mul_test ... ok
test ec::suite_b::public_key::tests::parse_uncompressed_point_test ... ok
test endian::tests::test_big_endian ... ok
test hmac::tests::hmac_signing_key_coverage ... ok
test io::der::tests::test_positive_integer ... ok
test io::der::tests::test_small_nonnegative_integer ... ok
test io::positive::tests::test_from_be_bytes ... ok
test limb::tests::test_big_endian_from_limbs_fewer_limbs - should panic ... ok
test limb::tests::test_big_endian_from_limbs_same_length ... ok
test limb::tests::test_limbs_are_even ... ok
test limb::tests::test_limbs_are_zero ... ok
test limb::tests::test_limbs_equal_limb ... ok
test limb::tests::test_limbs_less_than_limb_constant_time ... ok
test limb::tests::test_limbs_minimal_bits ... ok
test limb::tests::test_parse_big_endian_and_pad_consttime ... ok
test rsa::padding::test::test_pss_padding_encode ... ok
test rsa::padding::test::test_pss_padding_verify ... ok
test rsa::signing::tests::test_signature_rsa_pkcs1_sign_output_buffer_len ... ok
test test::tests::first_err - should panic ... ok
test test::tests::first_panic - should panic ... ok
test test::tests::last_err - should panic ... ok
test test::tests::last_panic - should panic ... ok
test test::tests::middle_err - should panic ... ok
test test::tests::middle_panic - should panic ... ok
test test::tests::one_err - should panic ... ok
test test::tests::one_ok ... ok
test test::tests::one_panics - should panic ... ok
test test::tests::syntax_error - should panic ... ok

test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.70s

     Running tests/aead_tests.rs (target/debug/deps/aead_tests-72090d131bcaf6dd)

running 35 tests
test aead_chacha20_poly1305_openssh ... ok
test aead_test::AES_128_GCM::key_sizes ... ok
test aead_test::AES_128_GCM::less_safe_key_open_in_place ... ok
test aead_test::AES_128_GCM::less_safe_key_open_within ... ok
test aead_test::AES_128_GCM::less_safe_key_seal_in_place_append_tag ... ok
test aead_test::AES_128_GCM::less_safe_key_seal_in_place_separate_tag ... ok
test aead_test::AES_128_GCM::opening_key_open_in_place ... ok
test aead_test::AES_128_GCM::opening_key_open_within ... ok
test aead_test::AES_128_GCM::sealing_key_seal_in_place_append_tag ... ok
test aead_test::AES_128_GCM::sealing_key_seal_in_place_separate_tag ... ok
test aead_test::AES_256_GCM::key_sizes ... ok
test aead_test::AES_256_GCM::less_safe_key_open_in_place ... ok
test aead_test::AES_256_GCM::less_safe_key_open_within ... ok
test aead_test::AES_256_GCM::less_safe_key_seal_in_place_append_tag ... ok
test aead_test::AES_256_GCM::less_safe_key_seal_in_place_separate_tag ... ok
test aead_test::AES_256_GCM::opening_key_open_in_place ... ok
test aead_test::AES_256_GCM::opening_key_open_within ... ok
test aead_test::AES_256_GCM::sealing_key_seal_in_place_append_tag ... ok
test aead_test::AES_256_GCM::sealing_key_seal_in_place_separate_tag ... ok
test aead_test::CHACHA20_POLY1305::key_sizes ... ok
test aead_test::CHACHA20_POLY1305::less_safe_key_open_in_place ... ok
test aead_test::CHACHA20_POLY1305::less_safe_key_open_within ... ok
test aead_test::CHACHA20_POLY1305::less_safe_key_seal_in_place_append_tag ... ok
test aead_test::CHACHA20_POLY1305::less_safe_key_seal_in_place_separate_tag ... ok
test aead_test::CHACHA20_POLY1305::opening_key_open_in_place ... ok
test aead_test::CHACHA20_POLY1305::opening_key_open_within ... ok
test aead_test::CHACHA20_POLY1305::sealing_key_seal_in_place_append_tag ... ok
test aead_test::CHACHA20_POLY1305::sealing_key_seal_in_place_separate_tag ... ok
test aead_test_aad_traits ... ok
test test_aead_key_debug ... ok
test test_aead_lesssafekey_clone_aes_128_gcm ... ok
test test_aead_lesssafekey_clone_aes_256_gcm ... ok
test test_aead_lesssafekey_clone_chacha20_poly1305 ... ok
test test_aead_nonce_sizes ... ok
test test_tag_traits ... ok

test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.71s

     Running tests/agreement_tests.rs (target/debug/deps/agreement_tests-413529538b45534d)

running 3 tests
test agreement_agree_ephemeral ... ok
test agreement_traits ... ok
test test_agreement_ecdh_x25519_rfc_iterated ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.31s

     Running tests/constant_time_tests.rs (target/debug/deps/constant_time_tests-62aae6c704d289bc)

running 1 test
test test_verify_slices_are_equal ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.48s

     Running tests/digest_tests.rs (target/debug/deps/digest_tests-db31697ed2fe8338)

running 15 tests
test digest_misc ... ok
test digest_shavs::SHA1_FOR_LEGACY_USE_ONLY::long_msg_known_answer_test ... ok
test digest_shavs::SHA1_FOR_LEGACY_USE_ONLY::monte_carlo_test ... ok
test digest_shavs::SHA1_FOR_LEGACY_USE_ONLY::short_msg_known_answer_test ... ok
test digest_shavs::SHA256::long_msg_known_answer_test ... ok
test digest_shavs::SHA256::monte_carlo_test ... ok
test digest_shavs::SHA256::short_msg_known_answer_test ... ok
test digest_shavs::SHA384::long_msg_known_answer_test ... ok
test digest_shavs::SHA384::monte_carlo_test ... ok
test digest_shavs::SHA384::short_msg_known_answer_test ... ok
test digest_shavs::SHA512::long_msg_known_answer_test ... ok
test digest_shavs::SHA512::monte_carlo_test ... ok
test digest_shavs::SHA512::short_msg_known_answer_test ... ok
test digest_test_fmt ... ok
test test_fmt_algorithm ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.84s

     Running tests/ecdsa_tests.rs (target/debug/deps/ecdsa_tests-cbff7a164ef71a62)

running 7 tests
test ecdsa_from_pkcs8_test ... ok
test ecdsa_generate_pkcs8_test ... ok
test ecdsa_test_public_key_coverage ... ok
test signature_ecdsa_sign_asn1_test ... ok
test signature_ecdsa_sign_fixed_sign_and_verify_test ... ok
test signature_ecdsa_verify_asn1_test ... ok
test signature_ecdsa_verify_fixed_test ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.26s

     Running tests/ed25519_tests.rs (target/debug/deps/ed25519_tests-ecd7a33488ddc7c6)

running 6 tests
test ed25519_test_public_key_coverage ... ok
test test_ed25519_from_pkcs8 ... ok
test test_ed25519_from_pkcs8_unchecked ... ok
test test_ed25519_from_seed_and_public_key_misuse ... ok
test test_signature_ed25519 ... ok
test test_signature_ed25519_verify ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.05s

     Running tests/error_tests.rs (target/debug/deps/error_tests-dd705d4519fe222d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/hkdf_tests.rs (target/debug/deps/hkdf_tests-5c164263472bf0ec)

running 2 tests
test hkdf_output_len_tests ... ok
test hkdf_tests ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/hmac_tests.rs (target/debug/deps/hmac_tests-fbba672c0f3d9b46)

running 2 tests
test hmac_debug ... ok
test hmac_tests ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/pbkdf2_tests.rs (target/debug/deps/pbkdf2_tests-9a5357e050760c05)

running 1 test
test pbkdf2_tests ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.04s

     Running tests/quic_tests.rs (target/debug/deps/quic_tests-e6f1412f980b4f3d)

running 3 tests
test quic_aes_128 ... ok
test quic_aes_256 ... ok
test quic_chacha20 ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/rand_tests.rs (target/debug/deps/rand_tests-0a5fc9bd05b11d67)

running 2 tests
test test_system_random_lengths ... ok
test test_system_random_traits ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running tests/rsa_tests.rs (target/debug/deps/rsa_tests-1cfda636a8735f1d)

running 7 tests
test rsa_from_pkcs8_test ... ok
test rsa_test_public_key_coverage ... ok
test test_signature_rsa_pkcs1_sign ... ok
test test_signature_rsa_pkcs1_verify ... ok
test test_signature_rsa_primitive_verification ... ok
test test_signature_rsa_pss_sign ... ok
test test_signature_rsa_pss_verify ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.47s

     Running tests/signature_tests.rs (target/debug/deps/signature_tests-f027f8eb8fcb7635)

running 1 test
test signature_impl_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests ring

running 11 tests
test src/agreement.rs - agreement (line 23) ... ok
test src/digest.rs - digest::Context (line 125) ... ok
test src/digest.rs - digest::digest (line 214) ... ok
test src/error.rs - error::Unspecified (line 34) ... ok
test src/hmac.rs - hmac (line 31) ... ok
test src/hmac.rs - hmac (line 51) ... ok
test src/hmac.rs - hmac (line 75) ... ok
test src/pbkdf2.rs - pbkdf2 (line 32) ... ok
test src/signature.rs - signature (line 129) ... ok
test src/signature.rs - signature (line 193) ... ok
test src/test.rs - test (line 53) ... ignored

test result: ok. 10 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 4.47s
```

