### PR TITLE
add riscv64gc support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,8 @@ jobs:
           - x86_64-apple-darwin
           - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          - riscv32gc-unknown-linux-gnu
 
         mode:
           - # debug
@@ -257,6 +259,12 @@ jobs:
             host_os: ubuntu-18.04
 
           - target: x86_64-unknown-linux-gnu
+            host_os: ubuntu-18.04
+
+          - target: riscv64gc-unknown-linux-gnu
+            host_os: ubuntu-18.04
+
+          - target: riscv32gc-unknown-linux-gnu
             host_os: ubuntu-18.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,6 @@ jobs:
           - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
-          - riscv32gc-unknown-linux-gnu
 
         mode:
           - # debug
@@ -264,8 +263,6 @@ jobs:
           - target: riscv64gc-unknown-linux-gnu
             host_os: ubuntu-18.04
 
-          - target: riscv32gc-unknown-linux-gnu
-            host_os: ubuntu-18.04
 
     steps:
       - if: ${{ contains(matrix.host_os, 'ubuntu') }}

--- a/build.rs
+++ b/build.rs
@@ -201,6 +201,20 @@ const ASM_TARGETS: &[AsmTarget] = &[
         preassemble: false,
     },
     AsmTarget {
+        oss: LINUX_ABI,
+        arch: "riscv32",
+        perlasm_format: "linux32",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
+        oss: LINUX_ABI,
+        arch: "riscv64",
+        perlasm_format: "linux64",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
         oss: MACOS_ABI,
         arch: "aarch64",
         perlasm_format: "ios64",

--- a/build.rs
+++ b/build.rs
@@ -202,13 +202,6 @@ const ASM_TARGETS: &[AsmTarget] = &[
     },
     AsmTarget {
         oss: LINUX_ABI,
-        arch: "riscv32",
-        perlasm_format: "linux32",
-        asm_extension: "S",
-        preassemble: false,
-    },
-    AsmTarget {
-        oss: LINUX_ABI,
         arch: "riscv64",
         perlasm_format: "linux64",
         asm_extension: "S",

--- a/include/ring-core/base.h
+++ b/include/ring-core/base.h
@@ -91,6 +91,14 @@
 #define OPENSSL_MIPS64
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
+#elif defined(__riscv)
+# if (__riscv_xlen == 64)
+#  define OPENSSL_64_BIT
+#  define OPENSSL_RISCV64
+# elif(__riscv_xlen == 32)
+#  define OPENSSL_32_BIT
+#  define OPENSSL_RISCV32
+# endif
 #else
 // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
 // little-endian architectures. Functions will not produce the correct answer

--- a/include/ring-core/base.h
+++ b/include/ring-core/base.h
@@ -91,14 +91,9 @@
 #define OPENSSL_MIPS64
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
-#elif defined(__riscv)
-# if (__riscv_xlen == 64)
+#elif defined(__riscv) && (__riscv_xlen == 64)
 #  define OPENSSL_64_BIT
 #  define OPENSSL_RISCV64
-# elif(__riscv_xlen == 32)
-#  define OPENSSL_32_BIT
-#  define OPENSSL_RISCV32
-# endif
 #else
 // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
 // little-endian architectures. Functions will not produce the correct answer


### PR DESCRIPTION
built from #1337 

I learned from that [Platform Support](https://doc.rust-lang.org/nightly/rustc/platform-support.html) and realized that Rust has very limited support for RV32 platform . 

So in other to solve that I cut off the support for rv32 in #1337 in the pull request , and I built successfully natively on a QEMU RISC-V 64 platform .

Also I just copied the `.github/workflows/ci.yml` from #1337 , so please review it carefully . 