### PR TITLE
Check for DOCS_RS when compiling C/assembly for cross-compiling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -294,7 +294,7 @@ fn read_env_var(name: &'static str) -> Result<String, std::env::VarError> {
 fn main() {
 	// perform this assignment here because it is necessary to build docs
 	let ring_core_prefix = ring_core_prefix();
-    println!("cargo:rustc-env=RING_CORE_PREFIX={}", ring_core_prefix);
+	println!("cargo:rustc-env=RING_CORE_PREFIX={}", ring_core_prefix);
 	
 	if let Ok(_) = std::env::var("DOCS_RS") {
 		return;

--- a/build.rs
+++ b/build.rs
@@ -292,7 +292,7 @@ fn read_env_var(name: &'static str) -> Result<String, std::env::VarError> {
 }
 
 fn main() {
-	// perform this assignment here because it is necessary to build docs
+	// Perform this assignment here because it is necessary to build docs
 	let ring_core_prefix = ring_core_prefix();
 	println!("cargo:rustc-env=RING_CORE_PREFIX={}", ring_core_prefix);
 	


### PR DESCRIPTION
This fixes docs.rs cross-compile builds failing due to missing compilers. A different approach may be wanted considering this adds an argument to both `ring_build_rs_main` and `pregenerate_asm_main`.

```
root@DESKTOP-8IHQBHP:/mnt/c/Users/Andrew/source/rust/ring# cargo test
    Updating crates.io index
  Downloaded regex-automata v0.1.10
  Downloaded tinytemplate v1.2.1
  Downloaded criterion-plot v0.4.4
  Downloaded cast v0.2.7
  Downloaded clap v2.33.3
  Downloaded oorandom v11.1.3
  Downloaded criterion v0.3.5
  Downloaded serde_cbor v0.11.2
  Downloaded plotters-svg v0.3.1
  Downloaded plotters-backend v0.3.2
  Downloaded rustc_version v0.4.0
  Downloaded crossbeam-deque v0.8.1
  Downloaded same-file v1.0.6
  Downloaded half v1.7.1
  Downloaded crossbeam-epoch v0.9.5
  Downloaded walkdir v2.3.2
  Downloaded scopeguard v1.1.0
  Downloaded rayon v1.5.1
  Downloaded serde_derive v1.0.130
  Downloaded regex-syntax v0.6.25
  Downloaded regex v1.5.4
  Downloaded textwrap v0.11.0
  Downloaded rayon-core v1.9.1
  Downloaded proc-macro2 v1.0.29
  Downloaded syn v1.0.76
  Downloaded cc v1.0.70
  Downloaded untrusted v0.9.0
  Downloaded serde v1.0.130
  Downloaded serde_json v1.0.68
  Downloaded csv-core v0.1.10
  Downloaded semver v1.0.4
  Downloaded crossbeam-channel v0.5.1
  Downloaded bstr v0.2.16
  Downloaded spin v0.9.2
  Downloaded crossbeam-utils v0.8.5
  Downloaded libc v0.2.102
  Downloaded csv v1.1.6
  Downloaded plotters v0.3.1
  Downloaded 38 crates (12.6 MB) in 3.50s (largest was `plotters` at 8.6 MB)
   Compiling autocfg v1.0.1
   Compiling lazy_static v1.4.0
   Compiling crossbeam-utils v0.8.5
   Compiling semver v1.0.4
   Compiling libc v0.2.102
   Compiling serde v1.0.130
   Compiling cfg-if v1.0.0
   Compiling proc-macro2 v1.0.29
   Compiling memchr v2.4.1
   Compiling crossbeam-epoch v0.9.5
   Compiling ryu v1.0.5
   Compiling scopeguard v1.1.0
   Compiling unicode-xid v0.2.2
   Compiling rayon-core v1.9.1
   Compiling syn v1.0.76
   Compiling itoa v0.4.8
   Compiling serde_json v1.0.68
   Compiling either v1.6.1
   Compiling cc v1.0.70
   Compiling unicode-width v0.1.8
   Compiling serde_derive v1.0.130
   Compiling plotters-backend v0.3.2
   Compiling regex-automata v0.1.10
   Compiling regex-syntax v0.6.25
   Compiling half v1.7.1
   Compiling same-file v1.0.6
   Compiling bitflags v1.3.2
   Compiling untrusted v0.9.0
   Compiling once_cell v1.8.0
   Compiling spin v0.9.2
   Compiling oorandom v11.1.3
   Compiling memoffset v0.6.4
   Compiling num-traits v0.2.14
   Compiling rayon v1.5.1
   Compiling textwrap v0.11.0
   Compiling itertools v0.10.1
   Compiling walkdir v2.3.2
   Compiling plotters-svg v0.3.1
   Compiling clap v2.33.3
   Compiling crossbeam-channel v0.5.1
   Compiling csv-core v0.1.10
   Compiling rustc_version v0.4.0
   Compiling regex v1.5.4
   Compiling num_cpus v1.13.0
   Compiling atty v0.2.14
   Compiling quote v1.0.9
   Compiling ring v0.17.0-not-released-yet (/mnt/c/Users/Andrew/source/rust/ring)
   Compiling cast v0.2.7
   Compiling crossbeam-deque v0.8.1
   Compiling plotters v0.3.1
   Compiling criterion-plot v0.4.4
   Compiling bstr v0.2.16
   Compiling serde_cbor v0.11.2
   Compiling csv v1.1.6
   Compiling tinytemplate v1.2.1
   Compiling criterion v0.3.5
    Finished test [unoptimized + debuginfo] target(s) in 34.59s
     Running unittests (target/debug/deps/ring-70dc8edc82c412ec)

running 88 tests
test aead::aes_gcm::tests::max_input_len_test ... ok
test aead::chacha20_poly1305::tests::max_input_len_test ... ok
test aead::aes::tests::test_aes ... ok
test arithmetic::bigint::tests::test_modulus_debug ... ok
test arithmetic::bigint::tests::test_mul_add_words ... ok
test arithmetic::bigint::tests::test_public_exponent_debug ... ok
test arithmetic::bigint::tests::test_elem_reduced_once ... ok
test bssl::tests::result::semantics ... ok
test arithmetic::bigint::tests::test_elem_squared ... ok
test bssl::tests::result::size_and_alignment ... ok
test c::tests::test_libc_compatible ... ok
test constant_time::tests::test_constant_time ... ok
test cpu::intel::x86_64_tests::test_avx_movbe_mask ... ok
test digest::tests::max_input::SHA1_FOR_LEGACY_USE_ONLY::max_input_test ... ok
test digest::tests::max_input::SHA1_FOR_LEGACY_USE_ONLY::too_long_input_test_block - should panic ... ok
test arithmetic::bigint::tests::test_elem_reduced ... ok
test digest::tests::max_input::SHA1_FOR_LEGACY_USE_ONLY::too_long_input_test_byte - should panic ... ok
test digest::tests::max_input::SHA256::max_input_test ... ok
test digest::tests::max_input::SHA256::too_long_input_test_block - should panic ... ok
test digest::tests::max_input::SHA256::too_long_input_test_byte - should panic ... ok
test digest::tests::max_input::SHA384::max_input_test ... ok
test arithmetic::bigint::tests::test_elem_exp_consttime ... ok
test digest::tests::max_input::SHA384::too_long_input_test_block - should panic ... ok
test digest::tests::max_input::SHA384::too_long_input_test_byte - should panic ... ok
test digest::tests::max_input::SHA512::max_input_test ... ok
test digest::tests::max_input::SHA512::too_long_input_test_block - should panic ... ok
test digest::tests::max_input::SHA512::too_long_input_test_byte - should panic ... ok
test ec::suite_b::ecdsa::digest_scalar::tests::test ... ok
test ec::suite_b::ecdsa::signing::tests::signature_ecdsa_sign_asn1_test ... ok
test ec::suite_b::ecdh::tests::test_agreement_suite_b_ecdh_generate ... ok
test aead::poly1305::tests::test_poly1305 ... ok
test ec::suite_b::ops::tests::p256_elem_mul_test ... ok
test ec::suite_b::ops::tests::p256_elem_neg_test ... ok
test ec::suite_b::ops::tests::p256_point_double_test ... ok
test ec::suite_b::ops::tests::p256_point_mul_serialized_test ... ok
test ec::suite_b::ops::tests::p256_q_minus_n_plus_n_equals_0_test ... ok
test ec::suite_b::ops::tests::p256_point_sum_mixed_test ... ok
test ec::suite_b::ops::tests::p256_scalar_inv_to_mont_zero_panic_test - should panic ... ok
test ec::suite_b::ops::tests::p256_scalar_square_test ... ok
test ec::suite_b::ops::tests::p256_scalar_mul_test ... ok
test ec::suite_b::ops::tests::p256_point_sum_test ... ok
test ec::suite_b::ops::tests::p384_elem_div_by_2_test ... ok
test ec::suite_b::ops::tests::p384_elem_mul_test ... ok
test arithmetic::bigint::tests::test_elem_mul ... ok
test ec::suite_b::ops::tests::p384_elem_neg_test ... ok
test ec::suite_b::ops::tests::p256_elem_add_test ... ok
test ec::suite_b::ops::tests::p384_point_double_test ... ok
test ec::suite_b::ops::tests::p384_q_minus_n_plus_n_equals_0_test ... ok
test ec::suite_b::ops::tests::p384_scalar_inv_to_mont_zero_panic_test - should panic ... ok
test ec::suite_b::ops::tests::p384_scalar_mul_test ... ok
test ec::suite_b::ops::tests::p384_point_sum_test ... ok
test endian::tests::test_big_endian ... ok
test ec::suite_b::public_key::tests::parse_uncompressed_point_test ... ok
test hmac::tests::hmac_signing_key_coverage ... ok
test io::der::tests::test_positive_integer ... ok
test io::der::tests::test_small_nonnegative_integer ... ok
test io::positive::tests::test_from_be_bytes ... ok
test limb::tests::test_big_endian_from_limbs_fewer_limbs - should panic ... ok
test limb::tests::test_big_endian_from_limbs_same_length ... ok
test limb::tests::test_limbs_are_even ... ok
test limb::tests::test_limbs_are_zero ... ok
test limb::tests::test_limbs_equal_limb ... ok
test limb::tests::test_limbs_less_than_limb_constant_time ... ok
test limb::tests::test_limbs_minimal_bits ... ok
test ec::suite_b::ops::tests::p384_elem_add_test ... ok
test limb::tests::test_parse_big_endian_and_pad_consttime ... ok
test rsa::signing::tests::test_signature_rsa_pkcs1_sign_output_buffer_len ... ok
test test::tests::first_err - should panic ... ok
test ec::suite_b::ops::tests::p384_elem_sub_test ... ok
test test::tests::first_panic - should panic ... ok
test ec::suite_b::ops::tests::p256_point_mul_base_test ... ok
test test::tests::last_err - should panic ... ok
test test::tests::last_panic - should panic ... ok
test test::tests::middle_err - should panic ... ok
test test::tests::middle_panic - should panic ... ok
test test::tests::one_err - should panic ... ok
test test::tests::one_ok ... ok
test test::tests::one_panics - should panic ... ok
test test::tests::syntax_error - should panic ... ok
test rsa::padding::test::test_pss_padding_encode ... ok
test ec::suite_b::ecdsa::signing::tests::signature_ecdsa_sign_fixed_test ... ok
test aead::chacha::tests::chacha20_test_fallback ... ok
test rsa::padding::test::test_pss_padding_verify ... ok
test ec::suite_b::ops::tests::p256_point_mul_test ... ok
test ec::suite_b::ecdsa::verification::tests::test_digest_based_test_vectors ... ok
test ec::suite_b::ops::tests::p384_point_mul_base_test ... ok
test ec::suite_b::ops::tests::p384_point_mul_test ... ok
test aead::chacha::tests::chacha20_test_default ... ok

test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.68s

     Running tests/aead_tests.rs (target/debug/deps/aead_tests-981aef8eb37a548f)

running 35 tests
test aead_test::AES_128_GCM::key_sizes ... ok
test aead_test::AES_256_GCM::key_sizes ... ok
test aead_chacha20_poly1305_openssh ... ok
test aead_test::AES_128_GCM::less_safe_key_seal_in_place_append_tag ... ok
test aead_test::AES_128_GCM::sealing_key_seal_in_place_separate_tag ... ok
test aead_test::AES_128_GCM::less_safe_key_open_in_place ... ok
test aead_test::AES_256_GCM::less_safe_key_open_in_place ... ok
test aead_test::AES_128_GCM::sealing_key_seal_in_place_append_tag ... ok
test aead_test::AES_256_GCM::less_safe_key_seal_in_place_append_tag ... ok
test aead_test::CHACHA20_POLY1305::key_sizes ... ok
test aead_test::AES_128_GCM::less_safe_key_seal_in_place_separate_tag ... ok
test aead_test::AES_128_GCM::opening_key_open_in_place ... ok
test aead_test::AES_256_GCM::less_safe_key_seal_in_place_separate_tag ... ok
test aead_test::CHACHA20_POLY1305::less_safe_key_open_in_place ... ok
test aead_test::CHACHA20_POLY1305::less_safe_key_seal_in_place_separate_tag ... ok
test aead_test::CHACHA20_POLY1305::less_safe_key_seal_in_place_append_tag ... ok
test aead_test::AES_256_GCM::sealing_key_seal_in_place_separate_tag ... ok
test aead_test::AES_256_GCM::sealing_key_seal_in_place_append_tag ... ok
test aead_test_aad_traits ... ok
test aead_test::AES_256_GCM::opening_key_open_in_place ... ok
test test_aead_key_debug ... ok
test aead_test::AES_128_GCM::opening_key_open_within ... ok
test test_aead_lesssafekey_clone_aes_128_gcm ... ok
test test_aead_lesssafekey_clone_aes_256_gcm ... ok
test test_aead_lesssafekey_clone_chacha20_poly1305 ... ok
test test_aead_nonce_sizes ... ok
test test_tag_traits ... ok
test aead_test::AES_256_GCM::less_safe_key_open_within ... ok
test aead_test::CHACHA20_POLY1305::opening_key_open_in_place ... ok
test aead_test::CHACHA20_POLY1305::less_safe_key_open_within ... ok
test aead_test::CHACHA20_POLY1305::sealing_key_seal_in_place_append_tag ... ok
test aead_test::AES_128_GCM::less_safe_key_open_within ... ok
test aead_test::CHACHA20_POLY1305::sealing_key_seal_in_place_separate_tag ... ok
test aead_test::CHACHA20_POLY1305::opening_key_open_within ... ok
test aead_test::AES_256_GCM::opening_key_open_within ... ok

test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

     Running tests/agreement_tests.rs (target/debug/deps/agreement_tests-1eb8be29230f1cd4)

running 3 tests
test agreement_traits ... ok
test agreement_agree_ephemeral ... ok
test test_agreement_ecdh_x25519_rfc_iterated ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.45s

     Running tests/constant_time_tests.rs (target/debug/deps/constant_time_tests-092b9f926306aa16)

running 1 test
test test_verify_slices_are_equal ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.28s

     Running tests/digest_tests.rs (target/debug/deps/digest_tests-320f59c59f23c680)

running 15 tests
test digest_shavs::SHA1_FOR_LEGACY_USE_ONLY::short_msg_known_answer_test ... ok
test digest_shavs::SHA256::short_msg_known_answer_test ... ok
test digest_test_fmt ... ok
test test_fmt_algorithm ... ok
test digest_shavs::SHA384::short_msg_known_answer_test ... ok
test digest_shavs::SHA512::short_msg_known_answer_test ... ok
test digest_shavs::SHA256::long_msg_known_answer_test ... ok
test digest_shavs::SHA1_FOR_LEGACY_USE_ONLY::long_msg_known_answer_test ... ok
test digest_shavs::SHA256::monte_carlo_test ... ok
test digest_shavs::SHA512::long_msg_known_answer_test ... ok
test digest_shavs::SHA384::long_msg_known_answer_test ... ok
test digest_shavs::SHA512::monte_carlo_test ... ok
test digest_misc ... ok
test digest_shavs::SHA384::monte_carlo_test ... ok
test digest_shavs::SHA1_FOR_LEGACY_USE_ONLY::monte_carlo_test ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.32s

     Running tests/ecdsa_tests.rs (target/debug/deps/ecdsa_tests-20fad042d02ff411)

running 7 tests
test ecdsa_test_public_key_coverage ... ok
test signature_ecdsa_sign_asn1_test ... ok
test ecdsa_generate_pkcs8_test ... ok
test ecdsa_from_pkcs8_test ... ok
test signature_ecdsa_verify_fixed_test ... ok
test signature_ecdsa_sign_fixed_sign_and_verify_test ... ok
test signature_ecdsa_verify_asn1_test ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s

     Running tests/ed25519_tests.rs (target/debug/deps/ed25519_tests-4a2b27a777b5c837)

running 6 tests
test ed25519_test_public_key_coverage ... ok
test test_ed25519_from_seed_and_public_key_misuse ... ok
test test_ed25519_from_pkcs8_unchecked ... ok
test test_ed25519_from_pkcs8 ... ok
test test_signature_ed25519_verify ... ok
test test_signature_ed25519 ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.63s

     Running tests/error_tests.rs (target/debug/deps/error_tests-f345edf7673abb36)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/hkdf_tests.rs (target/debug/deps/hkdf_tests-455415df359975b2)

running 2 tests
test hkdf_tests ... ok
test hkdf_output_len_tests ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/hmac_tests.rs (target/debug/deps/hmac_tests-05bd03509a3d65c1)

running 2 tests
test hmac_debug ... ok
test hmac_tests ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/pbkdf2_tests.rs (target/debug/deps/pbkdf2_tests-9a1d2caf1234f4fa)

running 1 test
test pbkdf2_tests ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.81s

     Running tests/quic_tests.rs (target/debug/deps/quic_tests-43f92ba7aad8d6e2)

running 3 tests
test quic_chacha20 ... ok
test quic_aes_128 ... ok
test quic_aes_256 ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/rand_tests.rs (target/debug/deps/rand_tests-c9dac5dbd573e2e0)

running 2 tests
test test_system_random_traits ... ok
test test_system_random_lengths ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/rsa_tests.rs (target/debug/deps/rsa_tests-64da324df3c03de0)

running 7 tests
test rsa_test_public_key_coverage ... ok
test test_signature_rsa_primitive_verification ... ok
test rsa_from_pkcs8_test ... ok
test test_signature_rsa_pss_verify ... ok
test test_signature_rsa_pss_sign ... ok
test test_signature_rsa_pkcs1_verify ... ok
test test_signature_rsa_pkcs1_sign ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s

     Running tests/signature_tests.rs (target/debug/deps/signature_tests-6e337ffb2b16014d)

running 1 test
test signature_impl_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests ring

running 11 tests
test src/test.rs - test (line 53) ... ignored
test src/signature.rs - signature (line 193) ... ok
test src/error.rs - error::Unspecified (line 34) ... ok
test src/digest.rs - digest::Context (line 125) ... ok
test src/digest.rs - digest::digest (line 214) ... ok
test src/agreement.rs - agreement (line 23) ... ok
test src/hmac.rs - hmac (line 31) ... ok
test src/hmac.rs - hmac (line 51) ... ok
test src/hmac.rs - hmac (line 75) ... ok
test src/signature.rs - signature (line 129) ... ok
test src/pbkdf2.rs - pbkdf2 (line 32) ... ok

test result: ok. 10 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.49s

root@DESKTOP-8IHQBHP:/mnt/c/Users/Andrew/source/rust/ring# cargo version
cargo 1.56.0-nightly (18751dd3f 2021-09-01)
root@DESKTOP-8IHQBHP:/mnt/c/Users/Andrew/source/rust/ring# uname -a
Linux DESKTOP-8IHQBHP 4.4.0-19041-Microsoft #1151-Microsoft Thu Jul 22 21:05:00 PST 2021 x86_64 x86_64 x86_64 GNU/Linux
```