### PR TITLE
Use stronger types for the bounds of `PublicExponent`

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -664,7 +664,10 @@ impl PublicExponent {
     // [1] https://www.imperialviolet.org/2012/03/16/rsae.html
     // [2] https://www.imperialviolet.org/2012/03/17/rsados.html
     // [3] https://msdn.microsoft.com/en-us/library/aa387685(VS.85).aspx
-    const MAX: u64 = (1u64 << 33) - 1;
+    //
+    // TODO: Use `NonZeroU64::new(...).unwrap()` when `feature(const_panic)` is
+    // stable.
+    const MAX: Self = Self(unsafe { NonZeroU64::new_unchecked((1u64 << 33) - 1) });
 
     pub fn from_be_bytes(
         input: untrusted::Input,
@@ -699,7 +702,7 @@ impl PublicExponent {
             return Err(error::KeyRejected::invalid_component());
         }
         debug_assert!(min_value & 1 == 1);
-        debug_assert!(min_value <= Self::MAX);
+        debug_assert!(min_value <= Self::MAX.0.get());
         if min_value < 3 {
             return Err(error::KeyRejected::invalid_component());
         }
@@ -707,7 +710,7 @@ impl PublicExponent {
         if value.get() < min_value {
             return Err(error::KeyRejected::too_small());
         }
-        if value.get() > Self::MAX {
+        if value > Self::MAX.0 {
             return Err(error::KeyRejected::too_large());
         }
 

--- a/src/rsa/public/key.rs
+++ b/src/rsa/public/key.rs
@@ -28,7 +28,7 @@ impl Key {
         e: untrusted::Input,
         n_min_bits: bits::BitLength,
         n_max_bits: bits::BitLength,
-        e_min_value: u64,
+        e_min_value: bigint::PublicExponent,
     ) -> Result<Self, error::KeyRejected> {
         // This is an incomplete implementation of NIST SP800-56Br1 Section
         // 6.4.2.2, "Partial Public-Key Validation for RSA." That spec defers

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -236,7 +236,7 @@ impl RsaKeyPair {
             e.big_endian_without_leading_zero_as_input(),
             bits::BitLength::from_usize_bits(2048),
             super::PRIVATE_KEY_PUBLIC_MODULUS_MAX_BITS,
-            65537,
+            bigint::PublicExponent::_65537,
         )?;
 
         // 6.4.1.4.3 says to skip 6.4.1.2.1 Step 2.

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -204,8 +204,13 @@ pub(crate) fn verify_rsa_(
     // exponent value is 2**16 + 1, but it isn't clear if this is just for
     // signing or also for verification. We support exponents of 3 and larger
     // for compatibility with other commonly-used crypto libraries.
-    let public::Key { n, e, n_bits } =
-        public::Key::from_modulus_and_exponent(n, e, params.min_bits, max_bits, 3)?;
+    let public::Key { n, e, n_bits } = public::Key::from_modulus_and_exponent(
+        n,
+        e,
+        params.min_bits,
+        max_bits,
+        bigint::PublicExponent::_3,
+    )?;
 
     // The signature must be the same length as the modulus, in bytes.
     if signature.len() != n_bits.as_usize_bytes_rounded_up() {


### PR DESCRIPTION
See the individual comment messages for details.