### PR TITLE
Move `bigint::PublicExponent` to `rsa::public::Exponent`.

### DIFF
--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -20,7 +20,7 @@
 //! Low-level RSA primitives.
 
 use crate::{
-    arithmetic::{bigint, montgomery},
+    arithmetic::bigint,
     bits, error,
     io::{self, der},
     limb,
@@ -55,16 +55,16 @@ fn parse_public_key(
 
 /// Calculates base**exponent (mod m).
 fn elem_exp_vartime<M>(
-    base: bigint::Elem<M, montgomery::Unencoded>,
+    base: bigint::Elem<M>,
     exponent: public::Exponent,
     m: &bigint::Modulus<M>,
-) -> bigint::Elem<M, montgomery::R> {
+) -> bigint::Elem<M> {
     let base = bigint::elem_mul(m.oneRR().as_ref(), base, m);
     // During RSA public key operations the exponent is almost always either
     // 65537 (0b10000000000000001) or 3 (0b11), both of which have a Hamming
     // weight of 2. The maximum bit length and maximum hamming weight of the
     // exponent is bounded by the value of `public::Exponent::MAX`.
-    bigint::elem_exp_vartime(base, exponent.into(), &m.as_partial())
+    bigint::elem_exp_vartime(base, exponent.into(), &m.as_partial()).into_unencoded(m)
 }
 
 // Type-level representation of an RSA public modulus *n*. See

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -54,17 +54,17 @@ fn parse_public_key(
 }
 
 /// Calculates base**exponent (mod m).
-fn elem_exp_vartime<M>(
-    base: bigint::Elem<M>,
+fn elem_exp_vartime(
+    base: bigint::Elem<N>,
     exponent: public::Exponent,
-    m: &bigint::Modulus<M>,
-) -> bigint::Elem<M> {
-    let base = bigint::elem_mul(m.oneRR().as_ref(), base, m);
+    n: &bigint::Modulus<N>,
+) -> bigint::Elem<N> {
+    let base = bigint::elem_mul(n.oneRR().as_ref(), base, n);
     // During RSA public key operations the exponent is almost always either
     // 65537 (0b10000000000000001) or 3 (0b11), both of which have a Hamming
     // weight of 2. The maximum bit length and maximum hamming weight of the
     // exponent is bounded by the value of `public::Exponent::MAX`.
-    bigint::elem_exp_vartime(base, exponent.into(), &m.as_partial()).into_unencoded(m)
+    bigint::elem_exp_vartime(base, exponent.into(), &n.as_partial()).into_unencoded(n)
 }
 
 // Type-level representation of an RSA public modulus *n*. See

--- a/src/rsa/public.rs
+++ b/src/rsa/public.rs
@@ -15,6 +15,7 @@
 //! Low-level RSA public key API.
 
 mod components;
+mod exponent;
 mod key;
 
-pub use {components::Components, key::Key};
+pub use {components::Components, exponent::Exponent, key::Key};

--- a/src/rsa/public/exponent.rs
+++ b/src/rsa/public/exponent.rs
@@ -1,0 +1,105 @@
+use crate::error;
+use core::num::NonZeroU64;
+
+/// The exponent `e` of the RSA public key.
+#[derive(Clone, Copy, Debug)]
+pub struct Exponent(NonZeroU64);
+
+impl Exponent {
+    #[cfg(test)]
+    const ALL_CONSTANTS: [Self; 3] = [Self::_3, Self::_65537, Self::MAX];
+
+    // TODO: Use `NonZeroU64::new(...).unwrap()` when `feature(const_panic)` is
+    // stable.
+    pub(in crate::rsa) const _3: Self = Self(unsafe { NonZeroU64::new_unchecked(3) });
+    pub(in crate::rsa) const _65537: Self = Self(unsafe { NonZeroU64::new_unchecked(65537) });
+
+    // This limit was chosen to bound the performance of the simple
+    // exponentiation-by-squaring implementation in `elem_exp_vartime`. In
+    // particular, it helps mitigate theoretical resource exhaustion attacks. 33
+    // bits was chosen as the limit based on the recommendations in [1] and
+    // [2]. Windows CryptoAPI (at least older versions) doesn't support values
+    // larger than 32 bits [3], so it is unlikely that exponents larger than 32
+    // bits are being used for anything Windows commonly does.
+    //
+    // [1] https://www.imperialviolet.org/2012/03/16/rsae.html
+    // [2] https://www.imperialviolet.org/2012/03/17/rsados.html
+    // [3] https://msdn.microsoft.com/en-us/library/aa387685(VS.85).aspx
+    //
+    // TODO: Use `NonZeroU64::new(...).unwrap()` when `feature(const_panic)` is
+    // stable.
+    const MAX: Self = Self(unsafe { NonZeroU64::new_unchecked((1u64 << 33) - 1) });
+
+    pub fn from_be_bytes(
+        input: untrusted::Input,
+        min_value: Self,
+    ) -> Result<Self, error::KeyRejected> {
+        if input.len() > 5 {
+            return Err(error::KeyRejected::too_large());
+        }
+        let value = input.read_all(error::KeyRejected::invalid_encoding(), |input| {
+            // The exponent can't be zero and it can't be prefixed with
+            // zero-valued bytes.
+            if input.peek(0) {
+                return Err(error::KeyRejected::invalid_encoding());
+            }
+            let mut value = 0u64;
+            loop {
+                let byte = input
+                    .read_byte()
+                    .map_err(|untrusted::EndOfInput| error::KeyRejected::invalid_encoding())?;
+                value = (value << 8) | u64::from(byte);
+                if input.at_end() {
+                    return Ok(value);
+                }
+            }
+        })?;
+
+        // Step 2 / Step b. NIST SP800-89 defers to FIPS 186-3, which requires
+        // `e >= 65537`. We enforce this when signing, but are more flexible in
+        // verification, for compatibility. Only small public exponents are
+        // supported.
+        let value = NonZeroU64::new(value).ok_or_else(error::KeyRejected::too_small)?;
+        if value < min_value.0 {
+            return Err(error::KeyRejected::too_small());
+        }
+        if value.get() & 1 != 1 {
+            return Err(error::KeyRejected::invalid_component());
+        }
+        if value > Self::MAX.0 {
+            return Err(error::KeyRejected::too_large());
+        }
+
+        Ok(Self(value))
+    }
+}
+
+impl From<Exponent> for NonZeroU64 {
+    fn from(Exponent(value): Exponent) -> Self {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    #[test]
+    fn test_public_exponent_debug() {
+        let exponent =
+            Exponent::from_be_bytes(untrusted::Input::from(&[0x1, 0x00, 0x01]), Exponent::_65537)
+                .unwrap();
+        assert_eq!("Exponent(65537)", format!("{:?}", exponent));
+    }
+
+    #[test]
+    fn test_public_exponent_constants() {
+        for value in Exponent::ALL_CONSTANTS.iter() {
+            let value: u64 = value.0.into();
+            assert_eq!(value & 1, 1);
+            assert!(value >= Exponent::_3.0.into()); // The absolute minimum.
+            assert!(value <= Exponent::MAX.0.into());
+        }
+    }
+}

--- a/src/rsa/public/key.rs
+++ b/src/rsa/public/key.rs
@@ -12,13 +12,13 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::super::N;
+use super::super::{public, N};
 use crate::{arithmetic::bigint, bits, error};
 
 #[derive(Debug)]
 pub struct Key {
     pub(in crate::rsa) n: bigint::Modulus<N>,
-    pub(in crate::rsa) e: bigint::PublicExponent,
+    pub(in crate::rsa) e: public::Exponent,
     pub(in crate::rsa) n_bits: bits::BitLength,
 }
 
@@ -28,7 +28,7 @@ impl Key {
         e: untrusted::Input,
         n_min_bits: bits::BitLength,
         n_max_bits: bits::BitLength,
-        e_min_value: bigint::PublicExponent,
+        e_min_value: public::Exponent,
     ) -> Result<Self, error::KeyRejected> {
         // This is an incomplete implementation of NIST SP800-56Br1 Section
         // 6.4.2.2, "Partial Public-Key Validation for RSA." That spec defers
@@ -63,7 +63,7 @@ impl Key {
 
         // Step 2 / Step b.
         // Step 3 / Step c for `e`.
-        let e = bigint::PublicExponent::from_be_bytes(e, e_min_value)?;
+        let e = public::Exponent::from_be_bytes(e, e_min_value)?;
 
         // If `n` is less than `e` then somebody has probably accidentally swapped
         // them. The largest acceptable `e` is smaller than the smallest acceptable

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -591,7 +591,6 @@ impl RsaKeyPair {
         // not verified during `KeyPair` construction.
         {
             let verify = super::elem_exp_vartime(m.clone(), self.public.e, n);
-            let verify = verify.into_unencoded(n);
             bigint::elem_verify_equal_consttime(&verify, &c)?;
         }
 

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -236,7 +236,7 @@ impl RsaKeyPair {
             e.big_endian_without_leading_zero_as_input(),
             bits::BitLength::from_usize_bits(2048),
             super::PRIVATE_KEY_PUBLIC_MODULUS_MAX_BITS,
-            bigint::PublicExponent::_65537,
+            public::Exponent::_65537,
         )?;
 
         // 6.4.1.4.3 says to skip 6.4.1.2.1 Step 2.
@@ -590,7 +590,7 @@ impl RsaKeyPair {
         // minimum value, since the relationship of `e` to `d`, `p`, and `q` is
         // not verified during `KeyPair` construction.
         {
-            let verify = bigint::elem_exp_vartime(m.clone(), self.public.e, n);
+            let verify = super::elem_exp_vartime(m.clone(), self.public.e, n);
             let verify = verify.into_unencoded(n);
             bigint::elem_verify_equal_consttime(&verify, &c)?;
         }

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -209,7 +209,7 @@ pub(crate) fn verify_rsa_(
         e,
         params.min_bits,
         max_bits,
-        bigint::PublicExponent::_3,
+        public::Exponent::_3,
     )?;
 
     // The signature must be the same length as the modulus, in bytes.
@@ -226,7 +226,7 @@ pub(crate) fn verify_rsa_(
     }
 
     // Step 2.
-    let m = bigint::elem_exp_vartime(s, e, &n);
+    let m = super::elem_exp_vartime(s, e, &n);
     let m = m.into_unencoded(&n);
 
     // Step 3.

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -227,7 +227,6 @@ pub(crate) fn verify_rsa_(
 
     // Step 2.
     let m = super::elem_exp_vartime(s, e, &n);
-    let m = m.into_unencoded(&n);
 
     // Step 3.
     let mut decoded = [0u8; PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN];


### PR DESCRIPTION
Besides organizing things better, this is a step towards exposing a RSA public key type to users of *ring*.