### PR TITLE
RSA: Clarify validity checking for exponents.

### DIFF
--- a/src/rsa/public/exponent.rs
+++ b/src/rsa/public/exponent.rs
@@ -34,6 +34,9 @@ impl Exponent {
         input: untrusted::Input,
         min_value: Self,
     ) -> Result<Self, error::KeyRejected> {
+        // See `public::Key::from_modulus_and_exponent` for background on the step
+        // numbering.
+
         if input.len() > 5 {
             return Err(error::KeyRejected::too_large());
         }
@@ -63,11 +66,13 @@ impl Exponent {
         if value < min_value.0 {
             return Err(error::KeyRejected::too_small());
         }
-        if value.get() & 1 != 1 {
-            return Err(error::KeyRejected::invalid_component());
-        }
         if value > Self::MAX.0 {
             return Err(error::KeyRejected::too_large());
+        }
+
+        // Step 3 / Step c.
+        if value.get() & 1 != 1 {
+            return Err(error::KeyRejected::invalid_component());
         }
 
         Ok(Self(value))

--- a/src/rsa/public/key.rs
+++ b/src/rsa/public/key.rs
@@ -40,8 +40,6 @@ impl Key {
 
         let n = Modulus::from_be_bytes(n, n_min_bits..=n_max_bits)?;
 
-        // Step 2 / Step b.
-        // Step 3 / Step c for `e`.
         let e = Exponent::from_be_bytes(e, e_min_value)?;
 
         // If `n` is less than `e` then somebody has probably accidentally swapped


### PR DESCRIPTION
Move the comments citing the standard to more appropriate places. Do the
steps in order.