### PR TITLE
RSA: Add the ability to construct an `RsaKeyPair` from components.

### DIFF
--- a/src/io/der.rs
+++ b/src/io/der.rs
@@ -128,7 +128,7 @@ where
     inner.read_all(error, decoder)
 }
 
-fn nonnegative_integer<'a>(
+pub(crate) fn nonnegative_integer<'a>(
     input: &mut untrusted::Reader<'a>,
 ) -> Result<untrusted::Input<'a>, error::Unspecified> {
     let value = expect_tag_and_get_value(input, Tag::Integer)?;

--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -74,6 +74,7 @@ enum N {}
 
 unsafe impl bigint::PublicModulus for N {}
 
+pub mod keypair;
 pub mod public;
 
 pub(crate) mod verification;

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -1,0 +1,5 @@
+//! Low-level RSA key pair (private key) API.
+
+pub(crate) mod components;
+
+pub use components::Components;

--- a/src/rsa/keypair/components.rs
+++ b/src/rsa/keypair/components.rs
@@ -1,0 +1,56 @@
+use super::super::public;
+
+/// RSA key pair components.
+pub struct Components<B> {
+    /// The public key components.
+    pub public_key: public::Components<B>,
+
+    /// The private exponent.
+    pub d: B,
+
+    /// The first prime factor of `d`.
+    pub p: B,
+
+    /// The second prime factor of `d`.
+    pub q: B,
+
+    /// `p`'s public Chinese Remainder Theorem exponent.
+    pub dP: B,
+
+    /// `q`'s public Chinese Remainder Theorem exponent.
+    pub dQ: B,
+
+    /// `q**-1 mod p`.
+    pub qInv: B,
+}
+
+impl<B> Copy for Components<B> where B: Copy {}
+
+impl<B> Clone for Components<B>
+where
+    B: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            public_key: self.public_key.clone(),
+            d: self.d.clone(),
+            p: self.p.clone(),
+            q: self.q.clone(),
+            dP: self.dP.clone(),
+            dQ: self.dQ.clone(),
+            qInv: self.qInv.clone(),
+        }
+    }
+}
+
+impl<B> core::fmt::Debug for Components<B>
+where
+    public::Components<B>: core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        // Non-public components are intentionally skipped
+        f.debug_struct("Components")
+            .field("public_key", &self.public_key)
+            .finish()
+    }
+}

--- a/src/rsa/keypair/components.rs
+++ b/src/rsa/keypair/components.rs
@@ -1,34 +1,40 @@
 use super::super::public;
 
 /// RSA key pair components.
-pub struct Components<B> {
+pub struct Components<Public, Private = Public> {
     /// The public key components.
-    pub public_key: public::Components<B>,
+    pub public_key: super::super::public::Components<Public>,
 
     /// The private exponent.
-    pub d: B,
+    pub d: Private,
 
     /// The first prime factor of `d`.
-    pub p: B,
+    pub p: Private,
 
     /// The second prime factor of `d`.
-    pub q: B,
+    pub q: Private,
 
     /// `p`'s public Chinese Remainder Theorem exponent.
-    pub dP: B,
+    pub dP: Private,
 
     /// `q`'s public Chinese Remainder Theorem exponent.
-    pub dQ: B,
+    pub dQ: Private,
 
     /// `q**-1 mod p`.
-    pub qInv: B,
+    pub qInv: Private,
 }
 
-impl<B> Copy for Components<B> where B: Copy {}
-
-impl<B> Clone for Components<B>
+impl<Public, Private> Copy for Components<Public, Private>
 where
-    B: Clone,
+    public::Components<Public>: Copy,
+    Private: Copy,
+{
+}
+
+impl<Public, Private> Clone for Components<Public, Private>
+where
+    public::Components<Public>: Clone,
+    Private: Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -43,9 +49,9 @@ where
     }
 }
 
-impl<B> core::fmt::Debug for Components<B>
+impl<Public, Private> core::fmt::Debug for Components<Public, Private>
 where
-    public::Components<B>: core::fmt::Debug,
+    public::Components<Public>: core::fmt::Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         // Non-public components are intentionally skipped

--- a/src/rsa/signing.rs
+++ b/src/rsa/signing.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{padding::RsaEncoding, public, N};
+use super::{keypair::Components, padding::RsaEncoding, public, N};
 
 /// RSA PKCS#1 1.5 signatures.
 use crate::{
@@ -46,7 +46,8 @@ impl RsaKeyPair {
     /// Only two-prime (not multi-prime) keys are supported. The public modulus
     /// (n) must be at least 2047 bits. The public modulus must be no larger
     /// than 4096 bits. It is recommended that the public modulus be exactly
-    /// 2048 or 3072 bits. The public exponent must be at least 65537.
+    /// 2048 or 3072 bits. The public exponent must be at least 65537 and must
+    /// be no more than 33 bits long.
     ///
     /// This will generate a 2048-bit RSA private key of the correct form using
     /// OpenSSL's command line tool:
@@ -123,9 +124,6 @@ impl RsaKeyPair {
     ///     validating a key pair for use by some other system; that other
     ///     system must check the value of `d` itself if `d` is to be used.
     ///
-    /// In addition to the NIST requirements, *ring* requires that `p > q` and
-    /// that `e` must be no more than 33 bits.
-    ///
     /// See [RFC 5958] and [RFC 3447 Appendix A.1.2] for more details of the
     /// encoding of the key.
     ///
@@ -180,21 +178,53 @@ impl RsaKeyPair {
             return Err(KeyRejected::version_not_supported());
         }
 
-        fn positive_integer<'a>(
+        fn nonnegative_integer<'a>(
             input: &mut untrusted::Reader<'a>,
-        ) -> Result<io::Positive<'a>, KeyRejected> {
-            der::positive_integer(input)
+        ) -> Result<&'a [u8], KeyRejected> {
+            der::nonnegative_integer(input)
+                .map(|input| input.as_slice_less_safe())
                 .map_err(|error::Unspecified| KeyRejected::invalid_encoding())
         }
 
-        let n = positive_integer(input)?;
-        let e = positive_integer(input)?;
-        let d = positive_integer(input)?.big_endian_without_leading_zero_as_input();
-        let p = positive_integer(input)?.big_endian_without_leading_zero_as_input();
-        let q = positive_integer(input)?.big_endian_without_leading_zero_as_input();
-        let dP = positive_integer(input)?.big_endian_without_leading_zero_as_input();
-        let dQ = positive_integer(input)?.big_endian_without_leading_zero_as_input();
-        let qInv = positive_integer(input)?.big_endian_without_leading_zero_as_input();
+        let n = nonnegative_integer(input)?;
+        let e = nonnegative_integer(input)?;
+        let d = nonnegative_integer(input)?;
+        let p = nonnegative_integer(input)?;
+        let q = nonnegative_integer(input)?;
+        let dP = nonnegative_integer(input)?;
+        let dQ = nonnegative_integer(input)?;
+        let qInv = nonnegative_integer(input)?;
+
+        let components = Components {
+            public_key: super::public::Components { n, e },
+            d,
+            p,
+            q,
+            dP,
+            dQ,
+            qInv,
+        };
+
+        Self::from_components(&components)
+    }
+
+    fn from_components(
+        &Components {
+            public_key,
+            d,
+            p,
+            q,
+            dP,
+            dQ,
+            qInv,
+        }: &Components<&[u8]>,
+    ) -> Result<Self, KeyRejected> {
+        let d = untrusted::Input::from(d);
+        let p = untrusted::Input::from(p);
+        let q = untrusted::Input::from(q);
+        let dP = untrusted::Input::from(dP);
+        let dQ = untrusted::Input::from(dQ);
+        let qInv = untrusted::Input::from(qInv);
 
         let (p, p_bits) = bigint::Nonnegative::from_be_bytes_with_bit_length(p)
             .map_err(|error::Unspecified| KeyRejected::invalid_encoding())?;
@@ -231,9 +261,11 @@ impl RsaKeyPair {
         // Also, this limit might help with memory management decisions later.
 
         // Step 1.c. We validate e >= 65537.
+        let n = untrusted::Input::from(public_key.n);
+        let e = untrusted::Input::from(public_key.e);
         let public_key = public::Key::from_modulus_and_exponent(
-            n.big_endian_without_leading_zero_as_input(),
-            e.big_endian_without_leading_zero_as_input(),
+            n,
+            e,
             bits::BitLength::from_usize_bits(2048),
             super::PRIVATE_KEY_PUBLIC_MODULUS_MAX_BITS,
             public::Exponent::_65537,
@@ -360,7 +392,10 @@ impl RsaKeyPair {
 
         let qq = bigint::elem_mul(&q_mod_n, q_mod_n_decoded, n).into_modulus::<QQ>()?;
 
-        let public_key_serialized = RsaSubjectPublicKey::from_n_and_e(n_bytes, e);
+        // This should never fail since `n` and `e` were validated above.
+
+        let public_key_serialized = RsaSubjectPublicKey::from_n_and_e(n_bytes, e)
+            .map_err(|_: error::Unspecified| KeyRejected::unexpected_error())?;
 
         Ok(Self {
             p,
@@ -405,12 +440,16 @@ impl AsRef<[u8]> for RsaSubjectPublicKey {
 derive_debug_self_as_ref_hex_bytes!(RsaSubjectPublicKey);
 
 impl RsaSubjectPublicKey {
-    fn from_n_and_e(n: io::Positive, e: io::Positive) -> Self {
+    // TODO: Replace this with a conversion from `public::Key` and avoid reparsing.
+    fn from_n_and_e(n: untrusted::Input, e: untrusted::Input) -> Result<Self, error::Unspecified> {
+        let n = io::Positive::from_be_bytes(n)?;
+        let e = io::Positive::from_be_bytes(e)?;
+
         let bytes = der_writer::write_all(der::Tag::Sequence, &|output| {
             der_writer::write_positive_integer(output, &n);
             der_writer::write_positive_integer(output, &e);
         });
-        Self(bytes)
+        Ok(Self(bytes))
     }
 
     /// The public modulus (n).

--- a/tests/rsa_tests.rs
+++ b/tests/rsa_tests.rs
@@ -40,7 +40,7 @@ fn rsa_from_pkcs8_test() {
             let error = test_case.consume_optional_string("Error");
 
             match (signature::RsaKeyPair::from_pkcs8(&input), error) {
-                (Ok(_), None) => (),
+                (Ok(_), None) => {}
                 (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),
                 (Ok(_), Some(e)) => panic!("Succeeded, but expected error \"{}\"", e),
                 (Err(actual), Some(expected)) => assert_eq!(format!("{}", actual), expected),


### PR DESCRIPTION
This makes it easier to implement JWK and similar standards that use non-ASN.1 big-endian encodings for RSA components.