### PR TITLE
Internal: Replace some manual big-endian encoding w/ standard library use.

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -249,7 +249,10 @@ pub fn big_endian_from_limbs(limbs: &[Limb], out: &mut [u8]) {
 /// The number of bytes returned will be a multiple of `LIMB_BYTES`.
 fn be_bytes(limbs: &[Limb]) -> impl ExactSizeIterator<Item = u8> + Clone + '_ {
     // The unwrap is safe because a slice can never be larger than `usize` bytes.
-    ArrayFlatMap::new(limbs.iter().rev().copied(), Limb::to_be_bytes).unwrap()
+    ArrayFlatMap::new(limbs.iter().rev().copied(), |limb| {
+        core::array::IntoIter::new(Limb::to_be_bytes(limb))
+    })
+    .unwrap()
 }
 
 #[cfg(feature = "alloc")]

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -27,6 +27,7 @@ pub fn usize_from_u32(x: u32) -> usize {
 #[macro_use]
 mod chunks_fixed;
 
+mod array_flat_map;
 pub(crate) mod array_map;
 
-pub use chunks_fixed::*;
+pub use self::{array_flat_map::ArrayFlatMap, chunks_fixed::*};

--- a/src/polyfill/array_flat_map.rs
+++ b/src/polyfill/array_flat_map.rs
@@ -1,0 +1,148 @@
+use core::iter::FlatMap;
+
+/// A specialized version of `core::iter::FlatMap` for mapping over exact-sized
+/// iterators with a function that returns an array.
+///
+/// `ArrayFlatMap` differs from `FlatMap` in that `ArrayFlatMap` implements
+/// `ExactSizeIterator`. Since the result of `F` always has `LEN` elements, if
+/// `I` is an exact-sized iterator of length `inner_len` then we know the
+/// length of the flat-mapped result is `inner_len * LEN`. (The constructor
+/// verifies that this multiplication doesn't overflow `usize`.)
+pub struct ArrayFlatMap<I, Item, F, const LEN: usize> {
+    inner: FlatMap<I, [Item; LEN], F>,
+    remaining: usize,
+}
+
+impl<I, Item, F, const LEN: usize> ArrayFlatMap<I, Item, F, LEN>
+where
+    I: ExactSizeIterator,
+    F: FnMut(I::Item) -> [Item; LEN],
+{
+    /// Constructs an `ArrayFlatMap` wrapping the given iterator, using the
+    /// given function
+    pub fn new(inner: I, f: F) -> Option<Self> {
+        let remaining = inner.len().checked_mul(LEN)?;
+        let inner = inner.flat_map(f);
+        Some(Self { inner, remaining })
+    }
+}
+
+impl<I, Item, F, const LEN: usize> Clone for ArrayFlatMap<I, Item, F, LEN>
+where
+    I: Iterator,
+    F: FnMut(I::Item) -> [Item; LEN],
+    FlatMap<I, [Item; LEN], F>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            remaining: self.remaining,
+        }
+    }
+}
+
+impl<I, Item, F, const LEN: usize> Iterator for ArrayFlatMap<I, Item, F, LEN>
+where
+    I: Iterator,
+    F: FnMut(I::Item) -> [Item; LEN],
+{
+    type Item = Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = self.inner.next();
+        if result.is_some() {
+            self.remaining -= 1;
+        }
+        result
+    }
+
+    /// Required for implementing `ExactSizeIterator`.
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<I, Item, F, const LEN: usize> ExactSizeIterator for ArrayFlatMap<I, Item, F, LEN>
+where
+    I: Iterator,
+    F: FnMut(I::Item) -> [Item; LEN],
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_array_flat_map() {
+        static TEST_CASES: &[(&[u16], fn(u16) -> [u8; 2], &[u8])] = &[
+            // Empty input
+            (&[], u16::to_be_bytes, &[]),
+            // Non-empty input.
+            (
+                &[0x0102, 0x0304, 0x0506],
+                u16::to_be_bytes,
+                &[1, 2, 3, 4, 5, 6],
+            ),
+            // Test with a different mapping function.
+            (
+                &[0x0102, 0x0304, 0x0506],
+                u16::to_le_bytes,
+                &[2, 1, 4, 3, 6, 5],
+            ),
+        ];
+        TEST_CASES.iter().copied().for_each(|(input, f, expected)| {
+            let mut mapped = ArrayFlatMap::new(input.iter().copied(), f).unwrap();
+            assert_eq!(&mapped.clone().collect::<Vec<_>>(), expected);
+            for i in 0..expected.len() {
+                let len = mapped.len();
+                assert_eq!(len, expected.len() - i);
+                assert_eq!(mapped.size_hint(), (len, Some(len)));
+                assert_eq!(mapped.next().unwrap(), expected[i]);
+            }
+            assert_eq!(mapped.len(), 0);
+            assert_eq!(mapped.next(), None);
+        });
+    }
+
+    // Does ArrayFlatMap::new() handle overflow correctly?
+    #[test]
+    fn test_array_flat_map_len_overflow() {
+        struct DownwardCounter {
+            remaining: usize,
+        }
+        impl Iterator for DownwardCounter {
+            type Item = usize;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                if self.remaining > 0 {
+                    let result = self.remaining;
+                    self.remaining -= 1;
+                    Some(result)
+                } else {
+                    None
+                }
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                (self.remaining, Some(self.remaining))
+            }
+        }
+        impl ExactSizeIterator for DownwardCounter {}
+
+        const MAX: usize = usize::MAX / core::mem::size_of::<usize>();
+
+        static TEST_CASES: &[(usize, bool)] = &[(MAX, true), (MAX + 1, false)];
+        TEST_CASES.iter().copied().for_each(|(input_len, is_some)| {
+            let inner = DownwardCounter {
+                remaining: input_len,
+            };
+            let mapped = ArrayFlatMap::new(inner, usize::to_be_bytes);
+            assert_eq!(mapped.is_some(), is_some);
+            if let Some(mapped) = mapped {
+                assert_eq!(mapped.len(), input_len * core::mem::size_of::<usize>());
+            }
+        });
+    }
+}


### PR DESCRIPTION
Refactor `limb::big_endian_from_limbs` to use an approach based on
iterators. We will be then be able to use the new `limb::be_bytes`
to implement `rsa::public::Exponent::be_bytes()` and
`rsa::public::Modulus::be_bytes()` and eventually other similar functions.
We want those functions to return `ExactSizeIterator`s.

This is also part of an ongoing process to eliminate replace all the
big-endian/little-endian encoding logic in *ring* w/ use of core APIs.