### PR TITLE
RSA/bigint: Thread proof of CPU feature detection through bigint.

### DIFF
--- a/src/rsa/public/key.rs
+++ b/src/rsa/public/key.rs
@@ -14,7 +14,7 @@
 
 use super::{Exponent, Modulus};
 use crate::{
-    bits, error,
+    bits, cpu, error,
     io::{self, der, der_writer},
 };
 use alloc::boxed::Box;
@@ -36,6 +36,7 @@ impl Key {
         n_min_bits: bits::BitLength,
         n_max_bits: bits::BitLength,
         e_min_value: Exponent,
+        cpu_features: cpu::Features,
     ) -> Result<Self, error::KeyRejected> {
         let n_bytes = n;
         let e_bytes = e;
@@ -49,7 +50,7 @@ impl Key {
         // and one set lettered. TODO: Document this in the end-user
         // documentation for RSA keys.
 
-        let n = Modulus::from_be_bytes(n, n_min_bits..=n_max_bits)?;
+        let n = Modulus::from_be_bytes(n, n_min_bits..=n_max_bits, cpu_features)?;
 
         let e = Exponent::from_be_bytes(e, e_min_value)?;
 

--- a/src/rsa/public/modulus.rs
+++ b/src/rsa/public/modulus.rs
@@ -1,4 +1,4 @@
-use crate::{arithmetic::bigint, bits, error, rsa::N};
+use crate::{arithmetic::bigint, bits, cpu, error, rsa::N};
 use core::ops::RangeInclusive;
 
 /// The modulus (n) of an RSA public key.
@@ -18,6 +18,7 @@ impl Modulus {
     pub(super) fn from_be_bytes(
         n: untrusted::Input,
         allowed_bit_lengths: RangeInclusive<bits::BitLength>,
+        cpu_features: cpu::Features,
     ) -> Result<Self, error::KeyRejected> {
         // See `public::Key::from_modulus_and_exponent` for background on the step
         // numbering.
@@ -31,7 +32,7 @@ impl Modulus {
         const MIN_BITS: bits::BitLength = bits::BitLength::from_usize_bits(1024);
 
         // Step 3 / Step c for `n` (out of order).
-        let (value, bits) = bigint::Modulus::from_be_bytes_with_bit_length(n)?;
+        let (value, bits) = bigint::Modulus::from_be_bytes_with_bit_length(n, cpu_features)?;
 
         // Step 1 / Step a. XXX: SP800-56Br1 and SP800-89 require the length of
         // the public modulus to be exactly 2048 or 3072 bits, but we are more

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -210,6 +210,7 @@ pub(crate) fn verify_rsa_(
         params.min_bits,
         max_bits,
         public::Exponent::_3,
+        cpu::features(),
     )?;
 
     let n = key.n();


### PR DESCRIPTION
The tests of `bigint` were not doing CPU feature detection themselves.
Thus they were depending on some other tests that run before them to do
it, or else they were not making use of all the CPU optimizations
possible, and thus not testing all the interesting code paths.

Also, as we are expanding the functionality of the RSA module, it has
become more difficult to track where CPU feature detection has been done
and where it needs to be done. Move the proof that the CPU feature
detection has been done down into the callers of the `bn_` functions
that need CPU feature detection to have been done.

This will also be helpful if/when we expand the use of the `bigint`
module beyond RSA.