### PR TITLE
RSA: Remove `From<Exponent> for NonZeroU64` implementation.

### DIFF
--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -64,7 +64,7 @@ fn elem_exp_vartime(
     // 65537 (0b10000000000000001) or 3 (0b11), both of which have a Hamming
     // weight of 2. The maximum bit length and maximum hamming weight of the
     // exponent is bounded by the value of `public::Exponent::MAX`.
-    bigint::elem_exp_vartime(base, exponent.into(), &n.as_partial()).into_unencoded(n)
+    bigint::elem_exp_vartime(base, exponent.value(), &n.as_partial()).into_unencoded(n)
 }
 
 // Type-level representation of an RSA public modulus *n*. See

--- a/src/rsa/public/exponent.rs
+++ b/src/rsa/public/exponent.rs
@@ -90,11 +90,9 @@ impl Exponent {
         .unwrap();
         LeadingZerosStripped::new(bytes)
     }
-}
 
-impl From<Exponent> for NonZeroU64 {
-    fn from(Exponent(value): Exponent) -> Self {
-        value
+    pub(in super::super) fn value(self) -> NonZeroU64 {
+        self.0
     }
 }
 


### PR DESCRIPTION
We shouldn't promise to external users that the exponent will always
fit in a 64-bit integer as in the future we may need to allow larger
exponents.