### PR TITLE
fix dead link for AEAD

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -18,7 +18,7 @@
 //! generic composition paradigm][AEAD] for an introduction to the concept of
 //! AEADs.
 //!
-//! [AEAD]: http://www-cse.ucsd.edu/~mihir/papers/oem.html
+//! [AEAD]: https://eprint.iacr.org/2000/025.pdf
 //! [`crypto.cipher.AEAD`]: https://golang.org/pkg/crypto/cipher/#AEAD
 
 use crate::{cpu, error, hkdf, polyfill};

--- a/src/aead/opening_key.rs
+++ b/src/aead/opening_key.rs
@@ -18,7 +18,7 @@
 //! generic composition paradigm][AEAD] for an introduction to the concept of
 //! AEADs.
 //!
-//! [AEAD]: http://www-cse.ucsd.edu/~mihir/papers/oem.html
+//! [AEAD]: https://eprint.iacr.org/2000/025.pdf
 //! [`crypto.cipher.AEAD`]: https://golang.org/pkg/crypto/cipher/#AEAD
 
 use super::{Aad, Algorithm, BoundKey, LessSafeKey, NonceSequence, UnboundKey};

--- a/src/aead/sealing_key.rs
+++ b/src/aead/sealing_key.rs
@@ -18,7 +18,7 @@
 //! generic composition paradigm][AEAD] for an introduction to the concept of
 //! AEADs.
 //!
-//! [AEAD]: http://www-cse.ucsd.edu/~mihir/papers/oem.html
+//! [AEAD]: https://eprint.iacr.org/2000/025.pdf
 //! [`crypto.cipher.AEAD`]: https://golang.org/pkg/crypto/cipher/#AEAD
 
 use super::{Aad, Algorithm, BoundKey, LessSafeKey, NonceSequence, Tag, UnboundKey};

--- a/src/aead/unbound_key.rs
+++ b/src/aead/unbound_key.rs
@@ -18,7 +18,7 @@
 //! generic composition paradigm][AEAD] for an introduction to the concept of
 //! AEADs.
 //!
-//! [AEAD]: http://www-cse.ucsd.edu/~mihir/papers/oem.html
+//! [AEAD]: https://eprint.iacr.org/2000/025.pdf
 //! [`crypto.cipher.AEAD`]: https://golang.org/pkg/crypto/cipher/#AEAD
 
 use super::{Algorithm, LessSafeKey, MAX_KEY_LEN};


### PR DESCRIPTION
The [original link to AEAD Paper](http://www-cse.ucsd.edu/~mihir/papers/oem.html) is dead.
According to https://cseweb.ucsd.edu//~mihir/pubs.html we can find the new link is [here](https://eprint.iacr.org/2000/025.pdf).