### PR TITLE
all: convert uses of static to const

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -21,7 +21,7 @@ use crate::{aead, cpu, error, polyfill};
 use core::ops::RangeFrom;
 
 /// AES-128 in GCM mode with 128-bit tags and 96 bit nonces.
-pub static AES_128_GCM: aead::Algorithm = aead::Algorithm {
+pub const AES_128_GCM: aead::Algorithm = aead::Algorithm {
     key_len: 16,
     init: init_128,
     seal: aes_gcm_seal,
@@ -31,7 +31,7 @@ pub static AES_128_GCM: aead::Algorithm = aead::Algorithm {
 };
 
 /// AES-256 in GCM mode with 128-bit tags and 96 bit nonces.
-pub static AES_256_GCM: aead::Algorithm = aead::Algorithm {
+pub const AES_256_GCM: aead::Algorithm = aead::Algorithm {
     key_len: 32,
     init: init_256,
     seal: aes_gcm_seal,

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -24,7 +24,7 @@ use core::{convert::TryInto, ops::RangeFrom};
 /// The keys are 256 bits long and the nonces are 96 bits long.
 ///
 /// [RFC 8439]: https://tools.ietf.org/html/rfc8439
-pub static CHACHA20_POLY1305: aead::Algorithm = aead::Algorithm {
+pub const CHACHA20_POLY1305: aead::Algorithm = aead::Algorithm {
     key_len: chacha::KEY_LEN,
     init: chacha20_poly1305_init,
     seal: chacha20_poly1305_seal,

--- a/src/aead/quic.rs
+++ b/src/aead/quic.rs
@@ -129,7 +129,7 @@ impl PartialEq for Algorithm {
 impl Eq for Algorithm {}
 
 /// AES-128.
-pub static AES_128: Algorithm = Algorithm {
+pub const AES_128: Algorithm = Algorithm {
     key_len: 16,
     init: aes_init_128,
     new_mask: aes_new_mask,
@@ -137,7 +137,7 @@ pub static AES_128: Algorithm = Algorithm {
 };
 
 /// AES-256.
-pub static AES_256: Algorithm = Algorithm {
+pub const AES_256: Algorithm = Algorithm {
     key_len: 32,
     init: aes_init_256,
     new_mask: aes_new_mask,
@@ -164,7 +164,7 @@ fn aes_new_mask(key: &KeyInner, sample: Sample) -> [u8; 5] {
 }
 
 /// ChaCha20.
-pub static CHACHA20: Algorithm = Algorithm {
+pub const CHACHA20: Algorithm = Algorithm {
     key_len: chacha::KEY_LEN,
     init: chacha20_init,
     new_mask: chacha20_new_mask,

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -321,7 +321,7 @@ impl Algorithm {
 /// SHA-1 as specified in [FIPS 180-4]. Deprecated.
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
+pub const SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
     output_len: sha1::OUTPUT_LEN,
     chaining_len: sha1::CHAINING_LEN,
     block_len: sha1::BLOCK_LEN,
@@ -346,7 +346,7 @@ pub static SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
 /// SHA-256 as specified in [FIPS 180-4].
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA256: Algorithm = Algorithm {
+pub const SHA256: Algorithm = Algorithm {
     output_len: SHA256_OUTPUT_LEN,
     chaining_len: SHA256_OUTPUT_LEN,
     block_len: 512 / 8,
@@ -371,7 +371,7 @@ pub static SHA256: Algorithm = Algorithm {
 /// SHA-384 as specified in [FIPS 180-4].
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA384: Algorithm = Algorithm {
+pub const SHA384: Algorithm = Algorithm {
     output_len: SHA384_OUTPUT_LEN,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,
@@ -396,7 +396,7 @@ pub static SHA384: Algorithm = Algorithm {
 /// SHA-512 as specified in [FIPS 180-4].
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA512: Algorithm = Algorithm {
+pub const SHA512: Algorithm = Algorithm {
     output_len: SHA512_OUTPUT_LEN,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,
@@ -425,7 +425,7 @@ pub static SHA512: Algorithm = Algorithm {
 /// state.
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-pub static SHA512_256: Algorithm = Algorithm {
+pub const SHA512_256: Algorithm = Algorithm {
     output_len: SHA512_256_OUTPUT_LEN,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -33,17 +33,16 @@ impl Algorithm {
 }
 
 /// HKDF using HMAC-SHA-1. Obsolete.
-pub static HKDF_SHA1_FOR_LEGACY_USE_ONLY: Algorithm =
-    Algorithm(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY);
+pub const HKDF_SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY);
 
 /// HKDF using HMAC-SHA-256.
-pub static HKDF_SHA256: Algorithm = Algorithm(hmac::HMAC_SHA256);
+pub const HKDF_SHA256: Algorithm = Algorithm(hmac::HMAC_SHA256);
 
 /// HKDF using HMAC-SHA-384.
-pub static HKDF_SHA384: Algorithm = Algorithm(hmac::HMAC_SHA384);
+pub const HKDF_SHA384: Algorithm = Algorithm(hmac::HMAC_SHA384);
 
 /// HKDF using HMAC-SHA-512.
-pub static HKDF_SHA512: Algorithm = Algorithm(hmac::HMAC_SHA512);
+pub const HKDF_SHA512: Algorithm = Algorithm(hmac::HMAC_SHA512);
 
 impl KeyType for Algorithm {
     fn len(&self) -> usize {

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -124,16 +124,16 @@ impl Algorithm {
 }
 
 /// HMAC using SHA-1. Obsolete.
-pub static HMAC_SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm(&digest::SHA1_FOR_LEGACY_USE_ONLY);
+pub const HMAC_SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm(&digest::SHA1_FOR_LEGACY_USE_ONLY);
 
 /// HMAC using SHA-256.
-pub static HMAC_SHA256: Algorithm = Algorithm(&digest::SHA256);
+pub const HMAC_SHA256: Algorithm = Algorithm(&digest::SHA256);
 
 /// HMAC using SHA-384.
-pub static HMAC_SHA384: Algorithm = Algorithm(&digest::SHA384);
+pub const HMAC_SHA384: Algorithm = Algorithm(&digest::SHA384);
 
 /// HMAC using SHA-512.
-pub static HMAC_SHA512: Algorithm = Algorithm(&digest::SHA512);
+pub const HMAC_SHA512: Algorithm = Algorithm(&digest::SHA512);
 
 /// An HMAC tag.
 ///

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -120,16 +120,16 @@ use core::num::NonZeroU32;
 pub struct Algorithm(hmac::Algorithm);
 
 /// PBKDF2 using HMAC-SHA1.
-pub static PBKDF2_HMAC_SHA1: Algorithm = Algorithm(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY);
+pub const PBKDF2_HMAC_SHA1: Algorithm = Algorithm(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY);
 
 /// PBKDF2 using HMAC-SHA256.
-pub static PBKDF2_HMAC_SHA256: Algorithm = Algorithm(hmac::HMAC_SHA256);
+pub const PBKDF2_HMAC_SHA256: Algorithm = Algorithm(hmac::HMAC_SHA256);
 
 /// PBKDF2 using HMAC-SHA384.
-pub static PBKDF2_HMAC_SHA384: Algorithm = Algorithm(hmac::HMAC_SHA384);
+pub const PBKDF2_HMAC_SHA384: Algorithm = Algorithm(hmac::HMAC_SHA384);
 
 /// PBKDF2 using HMAC-SHA512.
-pub static PBKDF2_HMAC_SHA512: Algorithm = Algorithm(hmac::HMAC_SHA512);
+pub const PBKDF2_HMAC_SHA512: Algorithm = Algorithm(hmac::HMAC_SHA512);
 
 /// Fills `out` with the key derived using PBKDF2 with the given inputs.
 ///


### PR DESCRIPTION
It may not have been possible to do this when this code was written,
but it should be possible now.

Fixes #1427.