### PR TITLE
Hacks taken from @amock to make RISC-V build.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,8 @@ const X86: &str = "x86";
 const X86_64: &str = "x86_64";
 const AARCH64: &str = "aarch64";
 const ARM: &str = "arm";
+const RISCV64: &str = "riscv64";
+const RISCV32: &str = "riscv32";
 
 #[rustfmt::skip]
 const RING_SRCS: &[(&[&str], &str)] = &[
@@ -40,12 +42,12 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[], "crypto/mem.c"),
     (&[], "crypto/poly1305/poly1305.c"),
 
-    (&[AARCH64, ARM, X86_64, X86], "crypto/crypto.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/curve25519/curve25519.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/ecp_nistz.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p256.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p384.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/p256.c"),
+    (&[AARCH64, ARM, X86_64, X86, RISCV64, RISCV32], "crypto/crypto.c"),
+    (&[AARCH64, ARM, X86_64, X86, RISCV64, RISCV32], "crypto/curve25519/curve25519.c"),
+    (&[AARCH64, ARM, X86_64, X86, RISCV64, RISCV32], "crypto/fipsmodule/ec/ecp_nistz.c"),
+    (&[AARCH64, ARM, X86_64, X86, RISCV64, RISCV32], "crypto/fipsmodule/ec/gfp_p256.c"),
+    (&[AARCH64, ARM, X86_64, X86, RISCV64, RISCV32], "crypto/fipsmodule/ec/gfp_p384.c"),
+    (&[AARCH64, ARM, X86_64, X86, RISCV64, RISCV32], "crypto/fipsmodule/ec/p256.c"),
 
     (&[X86_64, X86], "crypto/cpu-intel.c"),
 

--- a/include/ring-core/base.h
+++ b/include/ring-core/base.h
@@ -89,6 +89,14 @@
 #elif defined(__MIPSEL__) && defined(__LP64__)
 #define OPENSSL_64_BIT
 #define OPENSSL_MIPS64
+#elif defined(__riscv) && __riscv_xlen == 64
+#define OPENSSL_64_BIT
+#define OPENSSL_RISCV64
+#define OPENSSL_NO_ASM
+#elif defined(__riscv) && __riscv_xlen == 32
+#define OPENSSL_32_BIT
+#define OPENSSL_RISCV32
+#define OPENSSL_NO_ASM
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
 #else


### PR DESCRIPTION
As stated in #1419, trying to get RISC-V to build. This uses generic C code for montomery multiplication taken from @amock. But it builds and tests successfully like this.