### PR TITLE
cpu: Move some of the CPUID logic to Rust.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -926,7 +926,7 @@ fn prefix_all_symbols(pp: char, prefix_prefix: &str, prefix: &str) -> String {
         "LIMBS_window5_unsplit_window",
         "LIMB_shr",
         "OPENSSL_armcap_P",
-        "OPENSSL_cpuid_setup",
+        "OPENSSL_ia32cap_init",
         "OPENSSL_ia32cap_P",
         "OPENSSL_memcmp",
         "aes_hw_ctr32_encrypt_blocks",

--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -34,5 +34,9 @@
 // archive, linking on OS X will fail to resolve common symbols. By
 // initialising it to zero, it becomes a "data symbol", which isn't so
 // affected.
+//
+// TODO: Define this in src/cpu/intel.rs and remove this file. This may depend
+// on https://github.com/rust-lang/rust/issues/73958; see the comments on
+// `HIDDEN` above.
 HIDDEN uint32_t OPENSSL_ia32cap_P[4] = {0};
 #endif

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -44,12 +44,7 @@ pub(crate) fn features() -> Features {
         let () = INIT.call_once(|| {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {
-                prefixed_extern! {
-                    fn OPENSSL_cpuid_setup();
-                }
-                unsafe {
-                    OPENSSL_cpuid_setup();
-                }
+                intel::setup();
             }
 
             #[cfg(all(


### PR DESCRIPTION
Separate the generic CPUID logic from the OpenSSL-specific logic for constructing `OPENSSL_ia32cap_P`. Rewrite the generic logic in Rust.