### PR TITLE
signature: Enable Ed25519 support for wasm32 targets.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,7 @@ const ARM: &str = "arm";
 
 #[rustfmt::skip]
 const RING_SRCS: &[(&[&str], &str)] = &[
+    (&[], "crypto/curve25519/curve25519.c"),
     (&[], "crypto/fipsmodule/aes/aes_nohw.c"),
     (&[], "crypto/fipsmodule/bn/montgomery.c"),
     (&[], "crypto/fipsmodule/bn/montgomery_inv.c"),
@@ -41,7 +42,6 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[], "crypto/poly1305/poly1305.c"),
 
     (&[AARCH64, ARM, X86_64, X86], "crypto/crypto.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/curve25519/curve25519.c"),
     (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/ecp_nistz.c"),
     (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p256.c"),
     (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p384.c"),

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -36,6 +36,7 @@ derive_debug_via_id!(Curve);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CurveID {
+    #[cfg(not(target_arch = "wasm32"))]
     Curve25519,
     P256,
     P384,

--- a/src/ec/curve25519.rs
+++ b/src/ec/curve25519.rs
@@ -15,6 +15,8 @@
 //! Elliptic curve operations and schemes using Curve25519.
 
 pub mod ed25519;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub mod x25519;
 
 mod ops;

--- a/src/ec/keys.rs
+++ b/src/ec/keys.rs
@@ -23,6 +23,7 @@ impl KeyPair {
 pub struct Seed {
     bytes: [u8; SEED_MAX_BYTES],
     curve: &'static Curve,
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     pub(crate) cpu_features: cpu::Features,
 }
 

--- a/src/ec/suite_b.rs
+++ b/src/ec/suite_b.rs
@@ -228,7 +228,10 @@ pub(crate) fn key_pair_from_bytes(
 }
 
 pub mod curve;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub mod ecdh;
+
 pub mod ecdsa;
 
 mod ops;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,8 @@ mod bssl;
 mod polyfill;
 
 pub mod aead;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub mod agreement;
 
 mod bits;

--- a/tests/agreement_tests.rs
+++ b/tests/agreement_tests.rs
@@ -12,6 +12,8 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 extern crate alloc;
 
 use ring::{agreement, error, rand, test, test_file};

--- a/tests/ed25519_tests.rs
+++ b/tests/ed25519_tests.rs
@@ -18,6 +18,12 @@ use ring::{
     test, test_file,
 };
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test_configure!(run_in_browser);
+
 /// Test vectors from BoringSSL.
 #[test]
 fn test_signature_ed25519() {


### PR DESCRIPTION
Ed25519 was disabled for WebAssembly due to some unrelated issues with
getting the X25519 code working in WebAssembly. Temporarily remove the
`agreement` API when targetting WebAssembly to work around those issues
in a way that lets us enabled Ed25519.