### PR TITLE
Add support for ESP32 and RISC-V

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ untrusted = { version = "0.9" }
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.2", default-features = false, features = ["once"] }
 
-[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "espidf"))'.dependencies]
 libc = { version = "0.2.100", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features=["std"], optional = true }
 
@@ -201,6 +201,7 @@ slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_unknown_unknown_js = ["web-sys"]
+size_optimized = []
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/build.rs
+++ b/build.rs
@@ -40,12 +40,12 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[], "crypto/mem.c"),
     (&[], "crypto/poly1305/poly1305.c"),
 
-    (&[AARCH64, ARM, X86_64, X86], "crypto/crypto.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/curve25519/curve25519.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/ecp_nistz.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p256.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p384.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/p256.c"),
+    (&[], "crypto/crypto.c"),
+    (&[], "crypto/curve25519/curve25519.c"),
+    (&[], "crypto/fipsmodule/ec/ecp_nistz.c"),
+    (&[], "crypto/fipsmodule/ec/gfp_p256.c"),
+    (&[], "crypto/fipsmodule/ec/gfp_p384.c"),
+    (&[], "crypto/fipsmodule/ec/p256.c"),
 
     (&[X86_64, X86], "crypto/cpu-intel.c"),
 
@@ -126,6 +126,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "-Wenum-compare",
             "-Wfloat-equal",
             "-Wformat=2",
+            #[cfg(not(feature = "size_optimized"))]
             "-Winline",
             "-Winvalid-pch",
             "-Wmissing-field-initializers",

--- a/crypto/fipsmodule/bn/montgomery.c
+++ b/crypto/fipsmodule/bn/montgomery.c
@@ -156,3 +156,17 @@ int bn_from_montgomery_in_place(BN_ULONG r[], size_t num_r, BN_ULONG a[],
   }
   return 1;
 }
+
+#if !defined(OPENSSL_X86) && !defined(OPENSSL_X86_64) && \
+    !defined(OPENSSL_ARM) && !defined(OPENSSL_AARCH64)
+void bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                 const BN_ULONG *np, const BN_ULONG *n0, size_t num) {
+  Limb tmp[2 * num];
+  for (size_t i = 0; i < num; i++)
+    tmp[i] = 0;
+  for (size_t i = 0; i < num; i++)
+    tmp[num + i] = limbs_mul_add_limb(tmp + i, ap, bp[i], num);
+
+  bn_from_montgomery_in_place(rp, num, tmp, 2 * num, np, num, n0);
+}
+#endif

--- a/include/ring-core/base.h
+++ b/include/ring-core/base.h
@@ -91,6 +91,12 @@
 #define OPENSSL_MIPS64
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
+#elif defined(__xtensa__)
+#define OPENSSL_32_BIT
+#elif defined(__riscv) && __riscv_xlen == 64
+#define OPENSSL_64_BIT
+#elif defined(__riscv) && __riscv_xlen == 32
+#define OPENSSL_32_BIT
 #else
 // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
 // little-endian architectures. Functions will not produce the correct answer


### PR DESCRIPTION
Related to #1436 and #1297 

Fixes #1455
Will likely address #1419 but I don't know for sure.

A few points:
* The code for bn_mult_mont is from #1297
* I know you expressed [reluctance to accepting variable-length arrays](https://github.com/briansmith/ring/pull/1297/files#r657301788) in the past, so let me know if you want that changed to something else.
* Embedded targets are usually compiled with size-optimization so the compiler is very, very reluctant to inline things like the value barrier code in `crypto/internal.h`. Since we treat warnings as errors I needed to add a way to disable the `-Winline` flag.
* I'm adding architecture support here, and also adding support for the ESP-IDF RTOS. Architecture support seems fairly uncontroversial if the code meets standards, but I understand if you're reluctant to add support for a new OS target for maintenance burden reasons. Just let me know and I can yank that part and maintain it myself as a patch. I'd obviously prefer it we could upstream it though.
* This has been lightly tested through rustls on both xtensa based ESP32 micros and RISC-V based ESP32's, but we haven't been able to run a full test suite on them on account of not having a full general purpose OS, so no `cargo test`. Let me know if this is a blocker and I'll figure out how to at least make the tests work on RISC-V. I think linux on RISC-V would work in qemu or something.