### PR TITLE
Add optional wasm32_unknown_unknown_getrandom feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ once_cell = { version = "1.8.0", default-features = false, features=["std"], opt
 once_cell = { version = "1.8.0", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
+getrandom = { version = "0.2", default-features = false, optional = true }
 web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", "Window"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -200,6 +201,7 @@ dev_urandom_fallback = ["once_cell"]
 slow_tests = []
 std = ["alloc"]
 test_logging = []
+wasm32_unknown_unknown_getrandom = ["getrandom"]
 wasm32_unknown_unknown_js = ["web-sys"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -258,6 +258,22 @@ mod sysrand_chunk {
     }
 }
 
+#[cfg(all(
+    feature = "wasm32_unknown_unknown_getrandom",
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown",
+    target_env = "",
+))]
+mod sysrand_chunk {
+    use crate::error;
+
+    pub fn chunk(mut dest: &mut [u8]) -> Result<usize, error::Unspecified> {
+        getrandom::getrandom(dest).map_err(|_| error::Unspecified)?;
+        Ok(dest.len())
+    }
+}
+
 #[cfg(windows)]
 mod sysrand_chunk {
     use crate::{error, polyfill};


### PR DESCRIPTION
(Feel free to merge as-is, but I'm happy to work on other solutions too. This is intended mostly as a starting point for discussing how this could be solved.)

We'd like to compile `ring` to a custom `wasm32-unknown-unknown` target. I see that there is already a `wasm32_unknown_unknown_js` target on the `main` branch, but our target environment doesn't have a JavaScript interface.

Some of the solutions we considered:

- Move the `ring::rand` module behind an optional (enabled by default) `rand` feature. This would work for us because the functions we call don't need RNG. However, it is not a very general solution, and adding `#[cfg(rand)]` everywhere would probably be undesirable in a cryptographic library.
- Optionally allow using `getrandom` (this PR). `getrandom` has a `custom` feature that allows users to [register their own getrandom implementation](https://docs.rs/getrandom/0.2.6/getrandom/macro.register_custom_getrandom.html) to be used on targets without a default implementation. We have a few other dependencies that depend on `getrandom`, so we already do this.
- Borrow getrandom's `register_custom_getrandom` macro and add it to this crate.
- Something else?

I used the `getrandom` approach (behind an opt-in feature) here because I thought it was the simplest solution, but I would love to hear what everyone thinks. Thanks a lot for this crate!