### PR TITLE
Allow accessing signature::UnparsedPublicKey bytes

### DIFF
--- a/src/agreement.rs
+++ b/src/agreement.rs
@@ -184,6 +184,15 @@ pub struct UnparsedPublicKey<B> {
     bytes: B,
 }
 
+impl<B> AsRef<[u8]> for UnparsedPublicKey<B>
+where
+    B: AsRef<[u8]>,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
 impl<B: core::fmt::Debug> core::fmt::Debug for UnparsedPublicKey<B>
 where
     B: AsRef<[u8]>,
@@ -202,7 +211,7 @@ impl<B> UnparsedPublicKey<B> {
         Self { algorithm, bytes }
     }
 
-    /// TODO: doc
+    /// The algorithm for the public key.
     #[inline]
     pub fn algorithm(&self) -> &'static Algorithm {
         self.algorithm

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -255,7 +255,7 @@
 //! # }
 //! ```
 
-use crate::{cpu, ec, error, sealed};
+use crate::{cpu, debug, ec, error, sealed};
 
 pub use crate::ec::{
     curve25519::ed25519::{
@@ -359,6 +359,27 @@ pub trait VerificationAlgorithm: core::fmt::Debug + Sync + sealed::Sealed {
 pub struct UnparsedPublicKey<B> {
     algorithm: &'static dyn VerificationAlgorithm,
     bytes: B,
+}
+
+impl<B> AsRef<[u8]> for UnparsedPublicKey<B>
+where
+    B: AsRef<[u8]>,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl<B: core::fmt::Debug> core::fmt::Debug for UnparsedPublicKey<B>
+where
+    B: AsRef<[u8]>,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+        f.debug_struct("UnparsedPublicKey")
+            .field("algorithm", &self.algorithm)
+            .field("bytes", &debug::HexStr(self.bytes.as_ref()))
+            .finish()
+    }
 }
 
 impl<B> UnparsedPublicKey<B> {

--- a/tests/agreement_tests.rs
+++ b/tests/agreement_tests.rs
@@ -59,6 +59,9 @@ fn agreement_traits() {
         format!("{:?}", unparsed_public_key),
         r#"UnparsedPublicKey { algorithm: Algorithm { curve: Curve25519 }, bytes: "010203" }"#
     );
+
+    // Test `AsRef<[u8]>`
+    assert_eq!(unparsed_public_key.as_ref(), &[0x01, 0x02, 0x03]);
 }
 
 #[test]

--- a/tests/signature_tests.rs
+++ b/tests/signature_tests.rs
@@ -12,4 +12,15 @@ fn signature_impl_test() {
     test::compile_time_assert_copy::<signature::Signature>();
     test::compile_time_assert_send::<signature::Signature>();
     test::compile_time_assert_sync::<signature::Signature>();
+
+    let unparsed_public_key =
+        signature::UnparsedPublicKey::new(&signature::ED25519, &[0x01, 0x02, 0x03]);
+
+    assert_eq!(
+        format!("{:?}", unparsed_public_key),
+        r#"UnparsedPublicKey { algorithm: ring::signature::ED25519, bytes: "010203" }"#
+    );
+
+    // Test `AsRef<[u8]>`
+    assert_eq!(unparsed_public_key.as_ref(), &[0x01, 0x02, 0x03]);
 }


### PR DESCRIPTION
Implement `AsRef<[u8]>` for `signature::UnparsedPublicKey`, making it
possible to access the bytes of the public key. For consistency, I did
the same for `agreement::UnparsedPublicKey`, although it already has a
`bytes` method. `agreement::PublicKey` already uses the `AsRef<[u8]>`
approach.

Also, add missing `Debug` implementation ~and `algorithm` method~ for
`signature::UnparsedPublicKey`.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.