### PR TITLE
Adding RISCV from #1419

### DIFF
--- a/include/ring-core/base.h
+++ b/include/ring-core/base.h
@@ -91,6 +91,10 @@
 #define OPENSSL_MIPS64
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
+#elif __riscv && __riscv_xlen == 64
+#define OPENSSL_64_BIT
+#elif __riscv && __riscv_xlen == 32
+#define OPENSSL_32_BIT
 #else
 // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
 // little-endian architectures. Functions will not produce the correct answer


### PR DESCRIPTION
Copy paste from @xfbs, to fix bug #1419.

Built on Fedora-riscv64, and run the tests. It is working fine as a dependency for sccache, and compiled without any errors at all.