### PR TITLE
Retrieve `crypto` from global instead of Window in WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,9 @@ once_cell = { version = "1.8.0", default-features = false, features=["std"], opt
 once_cell = { version = "1.8.0", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
-web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", "Window"], optional = true }
+web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", "Window", "ServiceWorkerGlobalScope"], optional = true }
+wasm-bindgen = { version = "0.2.80" }
+js-sys = { version = "0.3.51" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", default-features = false, features = ["ntsecapi", "wtypesbase", "processthreadsapi"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ once_cell = { version = "1.8.0", default-features = false, features=["std"], opt
 once_cell = { version = "1.8.0", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
-web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", "Window", "ServiceWorkerGlobalScope"], optional = true }
+web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", "Window"], optional = true }
 wasm-bindgen = { version = "0.2.80" }
 js-sys = { version = "0.3.51" }
 


### PR DESCRIPTION
## Overview

At 1Password we use _ring_ in our WebExtension, and extensions are currently moving to [Manifest V3](https://developer.chrome.com/docs/extensions/mv3/intro/), where extension code will be run within a service worker. To continue using _ring_, I developed this patch which allows the WASM code to access `crypto` from the global without panicking if `window` is missing (like in a worker).

## How to test

1. Clone https://github.com/oliverdunk/wasm-worker (which uses the current version of ring)
2. Run `make`
3. Open http://localhost:8080/, and see that there is an error in the console
4. Checkout the `update-test` branch
5. Run `make` again
6. Open http://localhost:8080/ and see that things ran successfully

## Notes

There are a couple of related things that may be worth looking in to in place of this PR as is:

- `get_crypto` could be cached in a thread_local if that's a performance win. I haven't done any benchmarking there yet but am happy to do so.
- https://github.com/briansmith/ring/pull/1486 is a super interesting PR and could potentially solve the same problem. We could just provide a custom implementation there.