### PR TITLE
OpenBSD: Use getentropy(2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,8 +171,11 @@ spin = { version = "0.9.2", default-features = false, features = ["once"] }
 libc = { version = "0.2.100", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features=["std"], optional = true }
 
-[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "openbsd", target_os = "redox", target_os = "solaris"))'.dependencies]
+[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "redox", target_os = "solaris"))'.dependencies]
 once_cell = { version = "1.8.0", default-features = false, features=["std"] }
+
+[target.'cfg(target_os = "openbsd")'.dependencies]
+libc = { version = "0.2.100", default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
 web-sys = { version = "0.3.51", default-features = false, features = ["Crypto", "Window"], optional = true }


### PR DESCRIPTION
Unconditionally use `getentropy(2)` on OpenBSD. The syscall was introduced in OpenBSD 5.6 released about 8 years ago. Since only the two latest releases are supported, the last release to not have getentropy has been unsupported for about 7.5 years.

`cargo test` and `cargo test --no-default-features` pass on OpenBSD-current.

Related #797.

I agree to license my contributions to each file under the terms given at the top of each file I changed.