### PR TITLE
Bump MSRV to 1.57 as `os_str_bytes` (used by criterion.rs 0.4.0) requires it.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
         rust_channel:
           - stable
           - nightly
-          - 1.56.1 # MSRV
+          - 1.57 # MSRV
           - beta
 
         include:
@@ -346,7 +346,7 @@ jobs:
         rust_channel:
           - stable
           - nightly
-          - 1.56.1 # MSRV
+          - 1.57 # MSRV
           - beta
 
         include:


### PR DESCRIPTION
Commit 7386436fb78cdc18b9e5016676a1db8653c06df1 upgraded criterion.rs to 0.4.0 but didn't bump the MSRV. Do that bump.