### PR TITLE
Always use `llvm-nm` in mk/check-symbol-prefixes.sh.

### DIFF
--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -82,12 +82,17 @@ case $target in
   ;;
 esac
 
-if [ -n "$use_clang" ]; then
-  # https://github.com/rustls/rustls/pull/1009 upgraded Rust's LLVM version to
-  # 14
+case "$OSTYPE" in
+linux*)
+  ubuntu_codename=$(lsb_release --codename --short)
   llvm_version=15
   sudo apt-key add mk/llvm-snapshot.gpg.key
-  sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-$llvm_version main"
+  sudo add-apt-repository "deb http://apt.llvm.org/$ubuntu_codename/ llvm-toolchain-$ubuntu_codename-$llvm_version main"
   sudo apt-get update
-  install_packages clang-$llvm_version llvm-$llvm_version
-fi
+  # We need to use `llvm-nm` in `mk/check-symbol-prefixes.sh`.
+  install_packages llvm-$llvm_version
+  if [ -n "$use_clang" ]; then
+    install_packages clang-$llvm_version
+  fi
+  ;;
+esac


### PR DESCRIPTION
Don't try to use binutils `nm` or the Android SDK `llvm-nm`, since they don't support LLVM's "opaque pointers".