### PR TITLE
Add rdrand feature to enable getrandom/rdrand feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,7 @@ slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_unknown_unknown_js = ["getrandom/js"]
+rdrand = ["getrandom/rdrand"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,10 @@
 //!         require an operating environment of some kind. This has no effect
 //!         for any other target. This enables the `getrandom` crate's `js`
 //!         feature.
+//! <tr><td><code>rdrand </code>
+//!     <td>Enable getrandom/rdrand feature.
+//!         When this feature is enabled, getrandom will fallback RDRAND-based
+//!         implementation for those x86/x86_64 targets getrandom not supported.
 //! </table>
 
 // When running mk/package.sh, don't actually build any code.


### PR DESCRIPTION
The default features of getrandom does not support some targets, such as x86_64-unknown-uefi x86_64-unknown-none.

This patch enable getrandom/rdrand feature for those targets.
