### PR TITLE
cpu: Expand scope of ARM feature detection tests

### DIFF
--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -264,12 +264,12 @@ prefixed_export! {
     static mut OPENSSL_armcap_P: u32 = ARMCAP_STATIC;
 }
 
-#[cfg(all(
-    any(target_arch = "arm", target_arch = "aarch64"),
-    target_vendor = "apple"
-))]
-#[test]
-fn test_armcap_static_matches_armcap_dynamic() {
-    assert_eq!(ARMCAP_STATIC, 1 | 4 | 16 | 32);
-    assert_eq!(ARMCAP_STATIC, unsafe { OPENSSL_armcap_P });
+#[cfg(all(test, any(target_arch = "arm", target_arch = "aarch64")))]
+mod tests {
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn test_armcap_static_matches_armcap_dynamic() {
+        assert_eq!(ARMCAP_STATIC, 1 | 4 | 16 | 32);
+        assert_eq!(ARMCAP_STATIC, unsafe { OPENSSL_armcap_P });
+    }
 }

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -184,6 +184,10 @@ macro_rules! features {
         #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
         const ARMCAP_STATIC: u32 = 0;
 
+        const _ALL_FEATURES_MASK: u32 = 0
+            $(  | $name.mask
+            )+;
+
         #[cfg(all(test, any(target_arch = "arm", target_arch = "aarch64")))]
         const ALL_FEATURES: [Feature; 4] = [
             $(
@@ -261,6 +265,11 @@ prefixed_export! {
     #[allow(non_upper_case_globals)]
     static mut OPENSSL_armcap_P: u32 = ARMCAP_STATIC;
 }
+
+const _APPLE_TARGETS_HAVE_ALL_FEATURES: () = assert!(
+    (ARMCAP_STATIC == _ALL_FEATURES_MASK)
+        || !cfg!(all(target_arch = "aarch64", target_vendor = "apple"))
+);
 
 #[cfg(all(test, any(target_arch = "arm", target_arch = "aarch64")))]
 mod tests {


### PR DESCRIPTION
Generalize the tests to make sense on non-Apple targets and run them on all targets.