### PR TITLE
MSRV 1.60: cpu: Use std::arch::is_aarch64_feature_detected on AArch64.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ name = "ring"
 getrandom = { version = "0.2.8" }
 untrusted = { version = "0.9" }
 
-[target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
+[target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(target_arch = "aarch64", any(target_family = "unix", target_family = "windows")), all(target_arch = "arm", any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.2", default-features = false, features = ["once"] }
 
 [target.'cfg(all(target_arch = "arm", any(target_os = "android", target_os = "linux")))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,11 +170,8 @@ untrusted = { version = "0.9" }
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.2", default-features = false, features = ["once"] }
 
-[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
+[target.'cfg(all(target_arch = "arm", any(target_os = "android", target_os = "linux")))'.dependencies]
 libc = { version = "0.2.100", default-features = false }
-
-[target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
-windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -24,13 +24,30 @@ pub(crate) struct Features(());
 
 #[inline(always)]
 pub(crate) fn features() -> Features {
-    // We don't do runtime feature detection on aarch64-apple-* as all AAarch64
-    // features we use are available on every device since the first devices.
+    // TODO: The list of operating systems for `aarch64` should really be
+    // "whatever has `std::arch::is_aarch64_feature_detected`".
     #[cfg(any(
         target_arch = "x86",
         target_arch = "x86_64",
         all(
-            any(target_arch = "aarch64", target_arch = "arm"),
+            target_arch = "aarch64",
+            any(
+                target_os = "android",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "illumos",
+                target_os = "ios",
+                target_os = "linux",
+                target_os = "macos",
+                target_os = "netbsd",
+                target_os = "openbsd",
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "windows",
+            )
+        ),
+        all(
+            target_arch = "arm",
             any(
                 target_os = "android",
                 target_os = "fuchsia",
@@ -52,15 +69,7 @@ pub(crate) fn features() -> Features {
                 }
             }
 
-            #[cfg(all(
-                any(target_arch = "aarch64", target_arch = "arm"),
-                any(
-                    target_os = "android",
-                    target_os = "fuchsia",
-                    target_os = "linux",
-                    target_os = "windows"
-                )
-            ))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
             {
                 arm::setup();
             }

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -137,17 +137,8 @@ pub fn setup() {
 macro_rules! features {
     {
         $(
-            $name:ident {
+            $target_feature_name:expr => $name:ident {
                 mask: $mask:expr,
-
-                // Should we assume that the feature is always available
-                // for aarch64-apple-* targets? The first AArch64 iOS
-                // device used the Apple A7 chip.
-                // TODO: When we can use `if` in const expressions:
-                // ```
-                // aarch64_apple: $aarch64_apple,
-                // ```
-                aarch64_apple: true,
             }
         ),+
         , // trailing comma is required.
@@ -159,30 +150,17 @@ macro_rules! features {
             };
         )+
 
-        // TODO: When we can use `if` in const expressions, do this:
-        // ```
-        // const ARMCAP_STATIC: u32 = 0
-        //    $(
-        //        | ( if $aarch64_apple &&
-        //               cfg!(all(target_arch = "aarch64",
-        //                        target_vendor = "apple")) {
-        //                $name.mask
-        //            } else {
-        //                0
-        //            }
-        //          )
-        //    )+;
-        // ```
-        //
-        // TODO: Add static feature detection to other targets.
-        // TODO: Combine static feature detection with runtime feature
-        //       detection.
-        #[cfg(all(target_arch = "aarch64", target_vendor = "apple"))]
-        const ARMCAP_STATIC: u32 = 0
-            $(  | $name.mask
+        const ARMCAP_STATIC: u32 = ARMCAP_STATIC_OVERRIDE
+            $(
+                | (
+                    if cfg!(all(any(target_arch = "aarch64", target_arch = "arm"),
+                                target_feature = $target_feature_name)) {
+                        $name.mask
+                    } else {
+                        0
+                    }
+                )
             )+;
-        #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
-        const ARMCAP_STATIC: u32 = 0;
 
         const _ALL_FEATURES_MASK: u32 = 0
             $(  | $name.mask
@@ -196,6 +174,21 @@ macro_rules! features {
         ];
     }
 }
+
+// TODO(MSRV 1.61.0): `cfg!(target_feature = X)` is false for many
+// AArch64 targets prior to Rust 1.61.0. Since we don't support dynamic
+// detection for Apple targets, implement a special workaround for them.
+// See https://github.com/rust-lang/rust/pull/91608 for background.
+//
+// In the case of non-Apple targets, presently we do assume that NEON
+// is present (e.g. see the Windows logic above).
+const ARMCAP_STATIC_OVERRIDE: u32 = if cfg!(all(target_arch = "aarch64", target_vendor = "apple")) {
+    NEON.mask | AES.mask | PMULL.mask | SHA256.mask
+} else if cfg!(target_arch = "aarch64") {
+    NEON.mask
+} else {
+    0
+};
 
 pub(crate) struct Feature {
     mask: u32,
@@ -227,29 +220,28 @@ impl Feature {
     }
 }
 
+// Assumes all target feature names are the same for ARM and AAarch64.
 features! {
-    // Keep in sync with `ARMV7_NEON`.
-    NEON {
+    "neon" => NEON {
         mask: 1 << 0,
-        aarch64_apple: true,
     },
 
-    // Keep in sync with `ARMV8_AES`.
-    AES {
+    "aes" => AES {
         mask: 1 << 2,
-        aarch64_apple: true,
     },
 
-    // Keep in sync with `ARMV8_SHA256`.
-    SHA256 {
+    "sha2" => SHA256 {
         mask: 1 << 4,
-        aarch64_apple: true,
     },
 
-    // Keep in sync with `ARMV8_PMULL`.
-    PMULL {
+    // TODO(MSRV): There is no "pmull" feature listed from
+    // `rustc --print cfg --target=aarch64-apple-darwin`. Originally ARMv8 tied
+    // PMULL detection into AES detection, but later versions split it; see
+    // https://developer.arm.com/downloads/-/exploration-tools/feature-names-for-a-profile
+    // "Features introduced prior to 2020." Change this to use "pmull" when
+    // that is supported.
+    "aes" => PMULL {
         mask: 1 << 5,
-        aarch64_apple: true,
     },
 }
 

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -67,7 +67,7 @@ macro_rules! features {
             };
         )+
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", any(target_family = "unix", target_family = "windows")))]
         pub fn setup() {
             extern crate std;
             use std::arch::is_aarch64_feature_detected;

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -116,7 +116,8 @@ pub fn setup() {
 #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
 pub fn setup() {
     // We do not need to check for the presence of NEON, as Armv8-A always has it
-    let mut features = NEON.mask;
+    const _ASSERT_NEON_DETECTED: () = assert!((ARMCAP_STATIC & NEON.mask) == NEON.mask);
+    let mut features = ARMCAP_STATIC;
 
     let result = unsafe {
         windows_sys::Win32::System::Threading::IsProcessorFeaturePresent(


### PR DESCRIPTION
Switch to `std::arch::is_aarch64_feature_detected` on AArch64 to support more operating systems and environments without having to add new OS- specific code. This requires bumping the MSRV for AAarch64 targets to 1.60.0.
