### PR TITLE
0.16: Update CI configuration so that CI jobs pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,13 +211,12 @@ jobs:
 
         include:
           - target: aarch64-apple-darwin
-            # macos-latest didn't work.
-            host_os: macos-11.0
+            host_os: macos-12
             # GitHub Actions doesn't have a way to run this target yet.
             cargo_options: --no-run
 
           - target: aarch64-apple-ios
-            host_os: macos-latest
+            host_os: macos-12
             # GitHub Actions doesn't have a way to run this target yet.
             cargo_options: --no-run
 
@@ -261,7 +260,7 @@ jobs:
             host_os: windows-latest
 
           - target: x86_64-apple-darwin
-            host_os: macos-latest
+            host_os: macos-12
 
           - target: x86_64-unknown-linux-musl
             host_os: ubuntu-18.04
@@ -288,9 +287,6 @@ jobs:
           override: true
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust_channel }}
-
-      - if: ${{ matrix.target == 'aarch64-apple-darwin' }}
-        run: echo "DEVELOPER_DIR=/Applications/Xcode_12.2.app/Contents/Developer" >> $GITHUB_ENV
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |
@@ -407,9 +403,6 @@ jobs:
           override: true
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust_channel }}
-
-      - if: ${{ matrix.target == 'aarch64-apple-darwin' }}
-        run: echo "DEVELOPER_DIR=/Applications/Xcode_12.2.app/Contents/Developer" >> $GITHUB_ENV
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,41 +173,8 @@ jobs:
         rust_channel:
           - stable
           - nightly
-          - 1.37.0 # MSRV
+          - 1.56 # MSRV
           - beta
-
-        exclude:
-          # The stable channel doesn't have aarch64-apple-darwin support yet.
-          - target: aarch64-apple-darwin
-            rust_channel: stable
-
-          # The MSRV channel doesn't have aarch64-apple-darwin support yet.
-          - target: aarch64-apple-darwin
-            rust_channel: 1.37.0
-
-          # Only do MSRV testing on release builds.
-          - mode: # debug
-            rust_channel: 1.37.0
-
-          # 1.37.0 doesn't support `-Clink-self-contained`.
-          - target: aarch64-unknown-linux-musl
-            rust_channel: 1.37.0
-
-          # 1.37.0 doesn't support `-Clink-self-contained`.
-          - target: armv7-unknown-linux-musleabihf
-            rust_channel: 1.37.0
-
-          # 1.37.0 doesn't support `-Clink-self-contained`.
-          - target: i686-unknown-linux-musl
-            rust_channel: 1.37.0
-
-          # 1.37.0 doesn't support `-Clink-self-contained`.
-          - target: x86_64-unknown-linux-musl
-            rust_channel: 1.37.0
-
-          # https://github.com/rust-lang/rust/pull/67429
-          - target: x86_64-pc-windows-gnu
-            rust_channel: 1.37.0
 
         include:
           - target: aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: briansmith/actions-checkout@v2
 
-      - run: cargo clippy --all-features ---all-targets -- --deny warnings
+      - run: cargo clippy --all-features --all-targets -- --deny warnings
 
   audit:
     # Don't run duplicate `push` jobs for the repo owner's PRs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           components: rustfmt
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           components: clippy
 
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
 
       - run: cargo clippy --all-features ---all-targets -- --deny warnings
 
@@ -42,12 +42,12 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           toolchain: stable
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: briansmith/actions-cache@v2
         with:
           path: |
             ~/.cargo/bin/cargo-audit
@@ -57,7 +57,7 @@ jobs:
 
       - run: cargo install cargo-audit --vers "0.13.1"
 
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
 
       - run: cargo generate-lockfile
 
@@ -70,12 +70,12 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           toolchain: stable
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: briansmith/actions-cache@v2
         with:
           path: |
             ~/.cargo/bin/cargo-deny
@@ -85,7 +85,7 @@ jobs:
 
       - run: cargo install cargo-deny --vers "0.8.4"
 
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
 
       - run: cargo deny check
 
@@ -107,13 +107,13 @@ jobs:
           - target: x86_64-unknown-linux-gnu
 
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           override: true
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust_channel }}
 
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
 
       - run: |
           cargo doc --all-features
@@ -125,11 +125,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
 
       - run: powershell -ExecutionPolicy Bypass ./mk/install-build-tools.ps1
 
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           toolchain: stable
           profile: minimal
@@ -273,7 +273,7 @@ jobs:
       - if: ${{ contains(matrix.host_os, 'ubuntu') }}
         run: sudo apt-get update -y
 
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
@@ -283,7 +283,7 @@ jobs:
           (powershell -ExecutionPolicy Bypass ./mk/install-build-tools.ps1) -and
           ("$pwd\target\tools" >> $env:GITHUB_PATH)
 
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           override: true
           target: ${{ matrix.target }}
@@ -332,13 +332,13 @@ jobs:
       - if: ${{ contains(matrix.host_os, 'ubuntu') }}
         run: sudo apt-get update -y
 
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
 
       - run: cargo generate-lockfile
 
       - run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           override: true
           target: ${{ matrix.target }}
@@ -397,12 +397,12 @@ jobs:
       - if: ${{ contains(matrix.host_os, 'ubuntu') }}
         run: sudo apt-get update -y
 
-      - uses: actions/checkout@v2
+      - uses: briansmith/actions-checkout@v2
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: RING_COVERAGE=1 mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
           override: true
           target: ${{ matrix.target }}
@@ -415,7 +415,7 @@ jobs:
         run: |
           RING_COVERAGE=1 mk/cargo.sh +${{ matrix.rust_channel }} test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
 
-      - uses: codecov/codecov-action@v1
+      - uses: briansmith/codecov-codecov-action@v3
         with:
           directory: ./target/${{ matrix.target }}/debug/coverage/reports
           fail_ci_if_error: true

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -71,12 +71,6 @@ Note in particular that if you are cross-compiling an x86 build on a 64-bit
 version of Linux, then you need to have the proper gcc-multilibs and
 g++-multilibs packages or equivalent installed.
 
-If you generate a standalone NDK toolchain in order to compile your project,
-the wrapper automatically passes flags to the actual compiler to define the
-`__ANDROID_API__` macro. Otherwise, the macro `__ANDROID_API__` must be
-defined with a value of at least 21 on 64-bit targets or 18 on 32-bit targets;
-e.g. export `CFLAGS=-D__ANDROID_API__=21`.
-
 
 Additional Features that are Useful for Development
 ---------------------------------------------------

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ allow = [
     "ISC",
     "LicenseRef-ring",
     "MIT",
+    "Unicode-DFS-2016",
 ]
 confidence-threshold = 1.0
 

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -24,8 +24,12 @@ qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may
 # be needed to compile the build script, or to compile for other targets.
-if [ -n "${ANDROID_SDK_ROOT-}" ]; then
-  android_tools=$ANDROID_SDK_ROOT/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin
+if [ -n "${ANDROID_HOME-}" ]; then
+  ndk_version=25.1.8937393
+  ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-${ANDROID_HOME}/ndk/$ndk_version}
+fi
+if [ -n "${ANDROID_NDK_ROOT-}" ]; then
+  android_tools=${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin
 fi
 
 for arg in $*; do
@@ -43,7 +47,7 @@ llvm_version=15
 case $target in
    aarch64-linux-android)
     export CC_aarch64_linux_android=$android_tools/aarch64-linux-android21-clang
-    export AR_aarch64_linux_android=$android_tools/aarch64-linux-android-ar
+    export AR_aarch64_linux_android=$android_tools/llvm-ar
     export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$android_tools/aarch64-linux-android21-clang
     ;;
   aarch64-unknown-linux-gnu)
@@ -66,9 +70,9 @@ case $target in
     export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER="$qemu_arm"
     ;;
   armv7-linux-androideabi)
-    export CC_armv7_linux_androideabi=$android_tools/armv7a-linux-androideabi18-clang
-    export AR_armv7_linux_androideabi=$android_tools/arm-linux-androideabi-ar
-    export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$android_tools/armv7a-linux-androideabi18-clang
+    export CC_armv7_linux_androideabi=$android_tools/armv7a-linux-androideabi19-clang
+    export AR_armv7_linux_androideabi=$android_tools/llvm-ar
+    export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$android_tools/armv7a-linux-androideabi19-clang
     ;;
   armv7-unknown-linux-musleabihf)
     export CC_armv7_unknown_linux_musleabihf=clang-$llvm_version

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -38,11 +38,7 @@ for arg in $*; do
   esac
 done
 
-# See comments in install-build-tools.sh.
-llvm_version=10
-if [ -n "${RING_COVERAGE-}" ]; then
-  llvm_version=11
-fi
+llvm_version=15
 
 case $target in
    aarch64-linux-android)

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -82,14 +82,9 @@ case $target in
 esac
 
 if [ -n "$use_clang" ]; then
-  llvm_version=10
-  if [ -n "${RING_COVERAGE-}" ]; then
-    # https://github.com/rust-lang/rust/pull/79365 upgraded the coverage file
-    # format to one that only LLVM 11+ can use
-    llvm_version=11
-    sudo apt-key add mk/llvm-snapshot.gpg.key
-    sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-$llvm_version main"
-    sudo apt-get update
-  fi
+  llvm_version=15
+  sudo apt-key add mk/llvm-snapshot.gpg.key
+  sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-$llvm_version main"
+  sudo apt-get update
   install_packages clang-$llvm_version llvm-$llvm_version
 fi

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -27,12 +27,19 @@ function install_packages {
 use_clang=
 case $target in
 --target*android*)
-  mkdir -p "${ANDROID_SDK_ROOT}/licenses"
-  android_license_file="${ANDROID_SDK_ROOT}/licenses/android-sdk-license"
+  mkdir -p "${ANDROID_HOME}/licenses"
+  ndk_version=25.1.8937393
+  android_license_file="${ANDROID_HOME}/licenses/android-sdk-license"
   accept_android_license=24333f8a63b6825ea9c5514f83c2829b004d1fee
   grep --quiet --no-messages "$accept_android_license" "$android_license_file" \
     || echo $accept_android_license  >> "$android_license_file"
-  sudo "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" ndk-bundle
+  "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" "ndk;$ndk_version"
+
+  ANDROID_NDK_ROOT=
+  # XXX: Older Rust toolchain versions link with `-lgcc` instead of `-lunwind`;
+  # see https://github.com/rust-lang/rust/pull/85806.
+  find -L ${ANDROID_NDK_ROOT:-${ANDROID_HOME}/ndk/$ndk_version} -name libunwind.a \
+          -execdir sh -c 'echo "INPUT(-lunwind)" > libgcc.a' \;
   ;;
 esac
 


### PR DESCRIPTION
`clippy` still fails but I'm thinking to just let it continue to fail on this branch since I don't want to risk accidentally changing the MSRV of 0.16.