### PR TITLE
Enable Windows on ARM builds for 0.16.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,33 +301,33 @@ all-features = true
 name = "ring"
 
 [dependencies]
-untrusted = { version = "0.7.1" }
+untrusted = { version = "0.7" }
 
-[target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux"))))'.dependencies]
-spin = { version = "0.5.2", default-features = false }
+[target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
+spin = { version = "0.9.4", default-features = false, features = ["once"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-libc = { version = "0.2.69", default-features = false }
-once_cell = { version = "1.5.2", default-features = false, features=["std"], optional = true }
+libc = { version = "0.2.135", default-features = false }
+once_cell = { version = "1.15.0", default-features = false, features=["std"], optional = true }
 
-[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
-once_cell = { version = "1.5.2", default-features = false, features=["std"] }
+[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "netbsd", target_os = "openbsd", target_os = "redox", target_os = "solaris"))'.dependencies]
+once_cell = { version = "1.15.0", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
-web-sys = { version = "0.3.37", default-features = false, features = ["Crypto", "Window"] }
+web-sys = { version = "0.3.60", default-features = false, features = ["Crypto", "Window"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.8", default-features = false, features = ["ntsecapi", "wtypesbase"] }
+winapi = { version = "0.3.9", default-features = false, features = ["ntsecapi", "wtypesbase", "processthreadsapi"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.18", default-features = false }
+wasm-bindgen-test = { version = "0.3.33", default-features = false }
 
 [target.'cfg(any(unix, windows))'.dev-dependencies]
-libc = { version = "0.2.80", default-features = false }
+libc = { version = "0.2.135", default-features = false }
 
 # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
 [build-dependencies]
-cc = { version = "1.0.62", default-features = false }
+cc = { version = "1.0.73", default-features = false }
 
 [features]
 # These features are documented in the top-level module's documentation.

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,6 @@ use std::{
     fs::{self, DirEntry},
     path::{Path, PathBuf},
     process::Command,
-    time::SystemTime,
 };
 
 const X86: &str = "x86";
@@ -137,27 +136,79 @@ const RING_PERL_INCLUDES: &[&str] =
       "crypto/perlasm/x86asm.pl",
       "crypto/perlasm/x86_64-xlate.pl"];
 
-const RING_BUILD_FILE: &[&str] = &["build.rs"];
-
 const PREGENERATED: &str = "pregenerated";
 
-fn c_flags(target: &Target) -> &'static [&'static str] {
-    if target.env != MSVC {
-        static NON_MSVC_FLAGS: &[&str] = &[
+fn c_flags(compiler: &cc::Tool) -> &'static [&'static str] {
+    if compiler.is_like_msvc() {
+        &[]
+    } else if compiler.is_like_clang() {
+        &[
+            "-std=c11",
+            "-Wbad-function-cast",
+            "-Wnested-externs",
+            "-Wstrict-prototypes",
+            "-Wno-error=unused-command-line-argument",
+        ]
+    } else {
+        &[
             "-std=c1x", // GCC 4.6 requires "c1x" instead of "c11"
             "-Wbad-function-cast",
             "-Wnested-externs",
             "-Wstrict-prototypes",
-        ];
-        NON_MSVC_FLAGS
-    } else {
-        &[]
+        ]
     }
 }
 
-fn cpp_flags(target: &Target) -> &'static [&'static str] {
-    if target.env != MSVC {
-        static NON_MSVC_FLAGS: &[&str] = &[
+fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
+    if compiler.is_like_msvc() {
+        &[
+            "/GS",   // Buffer security checks.
+            "/Gy",   // Enable function-level linking.
+            "/EHsc", // C++ exceptions only, only in C++.
+            "/GR-",  // Disable RTTI.
+            "/Zc:wchar_t",
+            "/Zc:forScope",
+            "/Zc:inline",
+            "/Zc:rvalueCast",
+            // Warnings.
+            "/sdl",
+            "/Wall",
+            "/wd4127", // C4127: conditional expression is constant
+            "/wd4464", // C4464: relative include path contains '..'
+            "/wd4514", // C4514: <name>: unreferenced inline function has be
+            "/wd4710", // C4710: function not inlined
+            "/wd4711", // C4711: function 'function' selected for inline expansion
+            "/wd4820", // C4820: <struct>: <n> bytes padding added after <name>
+            "/wd5045", /* C5045: Compiler will insert Spectre mitigation for memory load if
+                        * /Qspectre switch specified */
+        ]
+    } else if compiler.is_like_clang() {
+        &[
+            "-pedantic",
+            "-pedantic-errors",
+            "-Wall",
+            "-Wextra",
+            "-Wcast-align",
+            "-Wcast-qual",
+            "-Wenum-compare",
+            "-Wfloat-equal",
+            "-Wformat=2",
+            "-Winline",
+            "-Winvalid-pch",
+            "-Wmissing-field-initializers",
+            "-Wmissing-include-dirs",
+            "-Wredundant-decls",
+            "-Wshadow",
+            "-Wsign-compare",
+            "-Wundef",
+            "-Wuninitialized",
+            "-Wwrite-strings",
+            "-fno-strict-aliasing",
+            "-fvisibility=hidden",
+            "-Wno-error=unused-command-line-argument",
+        ]
+    } else {
+        &[
             "-pedantic",
             "-pedantic-errors",
             "-Wall",
@@ -181,31 +232,7 @@ fn cpp_flags(target: &Target) -> &'static [&'static str] {
             "-Wwrite-strings",
             "-fno-strict-aliasing",
             "-fvisibility=hidden",
-        ];
-        NON_MSVC_FLAGS
-    } else {
-        static MSVC_FLAGS: &[&str] = &[
-            "/GS",   // Buffer security checks.
-            "/Gy",   // Enable function-level linking.
-            "/EHsc", // C++ exceptions only, only in C++.
-            "/GR-",  // Disable RTTI.
-            "/Zc:wchar_t",
-            "/Zc:forScope",
-            "/Zc:inline",
-            "/Zc:rvalueCast",
-            // Warnings.
-            "/sdl",
-            "/Wall",
-            "/wd4127", // C4127: conditional expression is constant
-            "/wd4464", // C4464: relative include path contains '..'
-            "/wd4514", // C4514: <name>: unreferenced inline function has be
-            "/wd4710", // C4710: function not inlined
-            "/wd4711", // C4711: function 'function' selected for inline expansion
-            "/wd4820", // C4820: <struct>: <n> bytes padding added after <name>
-            "/wd5045", /* C5045: Compiler will insert Spectre mitigation for memory load if
-                        * /Qspectre switch specified */
-        ];
-        MSVC_FLAGS
+        ]
     }
 }
 
@@ -213,36 +240,137 @@ const LD_FLAGS: &[&str] = &[];
 
 // None means "any OS" or "any target". The first match in sequence order is
 // taken.
-const ASM_TARGETS: &[(&str, Option<&str>, Option<&str>)] = &[
-    ("x86_64", Some("ios"), Some("macosx")),
-    ("x86_64", Some("macos"), Some("macosx")),
-    ("x86_64", Some(WINDOWS), Some("nasm")),
-    ("x86_64", None, Some("elf")),
-    ("aarch64", Some("ios"), Some("ios64")),
-    ("aarch64", Some("macos"), Some("ios64")),
-    ("aarch64", None, Some("linux64")),
-    ("x86", Some(WINDOWS), Some("win32n")),
-    ("x86", Some("ios"), Some("macosx")),
-    ("x86", None, Some("elf")),
-    ("arm", Some("ios"), Some("ios32")),
-    ("arm", None, Some("linux32")),
-    ("wasm32", None, None),
+const ASM_TARGETS: &[AsmTarget] = &[
+    AsmTarget {
+        oss: LINUX_ABI,
+        arch: "aarch64",
+        perlasm_format: "linux64",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
+        oss: LINUX_ABI,
+        arch: "arm",
+        perlasm_format: "linux32",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
+        oss: LINUX_ABI,
+        arch: "x86",
+        perlasm_format: "elf",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
+        oss: LINUX_ABI,
+        arch: "x86_64",
+        perlasm_format: "elf",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
+        oss: MACOS_ABI,
+        arch: "aarch64",
+        perlasm_format: "ios64",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
+        oss: MACOS_ABI,
+        arch: "x86_64",
+        perlasm_format: "macosx",
+        asm_extension: "S",
+        preassemble: false,
+    },
+    AsmTarget {
+        oss: &[WINDOWS],
+        arch: "x86",
+        perlasm_format: "win32n",
+        asm_extension: "asm",
+        preassemble: true,
+    },
+    AsmTarget {
+        oss: &[WINDOWS],
+        arch: "x86_64",
+        perlasm_format: "nasm",
+        asm_extension: "asm",
+        preassemble: true,
+    },
+    AsmTarget {
+        oss: &[WINDOWS],
+        arch: "aarch64",
+        perlasm_format: "win64",
+        asm_extension: "S",
+        preassemble: true,
+    },
 ];
 
+struct AsmTarget {
+    /// Operating systems.
+    oss: &'static [&'static str],
+
+    /// Architectures.
+    arch: &'static str,
+
+    /// The PerlAsm format name.
+    perlasm_format: &'static str,
+
+    /// The filename extension for assembly files.
+    asm_extension: &'static str,
+
+    /// Whether pre-assembled object files should be included in the Cargo
+    /// package instead of the asm sources. This way, the user doesn't need
+    /// to install an assembler for the target. This is particularly important
+    /// for x86/x86_64 Windows since an assembler doesn't come with the C
+    /// compiler.
+    preassemble: bool,
+}
+
+/// Operating systems that have the same ABI as Linux on every architecture
+/// mentioned in `ASM_TARGETS`.
+const LINUX_ABI: &[&str] = &[
+    "android",
+    "dragonfly",
+    "freebsd",
+    "fuchsia",
+    "illumos",
+    "netbsd",
+    "openbsd",
+    "linux",
+    "redox",
+    "solaris",
+];
+
+/// Operating systems that have the same ABI as macOS on every architecture
+/// mentioned in `ASM_TARGETS`.
+const MACOS_ABI: &[&str] = &["ios", "macos"];
+
 const WINDOWS: &str = "windows";
-const MSVC: &str = "msvc";
-const MSVC_OBJ_OPT: &str = "/Fo";
-const MSVC_OBJ_EXT: &str = "obj";
+
+/// Read an environment variable and tell Cargo that we depend on it.
+///
+/// This needs to be used for any environment variable that isn't a standard
+/// Cargo-supplied variable.
+///
+/// The name is static since we intend to only read a static set of environment
+/// variables.
+fn read_env_var(name: &'static str) -> Result<String, std::env::VarError> {
+    println!("cargo:rerun-if-env-changed={}", name);
+    std::env::var(name)
+}
 
 fn main() {
-    if let Ok(package_name) = std::env::var("CARGO_PKG_NAME") {
-        if package_name == "ring" {
-            ring_build_rs_main();
-            return;
+    const RING_PREGENERATE_ASM: &str = "RING_PREGENERATE_ASM";
+    match read_env_var(RING_PREGENERATE_ASM).as_deref() {
+        Ok("1") => {
+            pregenerate_asm_main();
+        }
+        Err(std::env::VarError::NotPresent) => ring_build_rs_main(),
+        _ => {
+            panic!("${} has an invalid value", RING_PREGENERATE_ASM);
         }
     }
-
-    pregenerate_asm_main();
 }
 
 fn ring_build_rs_main() {
@@ -254,11 +382,6 @@ fn ring_build_rs_main() {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    let (obj_ext, obj_opt) = if env == MSVC {
-        (MSVC_OBJ_EXT, MSVC_OBJ_OPT)
-    } else {
-        ("o", "-o")
-    };
 
     let is_git = std::fs::metadata(".git").is_ok();
 
@@ -269,8 +392,6 @@ fn ring_build_rs_main() {
         arch,
         os,
         env,
-        obj_ext,
-        obj_opt,
         is_git,
         is_debug,
     };
@@ -286,27 +407,24 @@ fn pregenerate_asm_main() {
     let pregenerated_tmp = pregenerated.join("tmp");
     std::fs::create_dir(&pregenerated_tmp).unwrap();
 
-    for &(target_arch, target_os, perlasm_format) in ASM_TARGETS {
+    for asm_target in ASM_TARGETS {
         // For Windows, package pregenerated object files instead of
         // pregenerated assembly language source files, so that the user
         // doesn't need to install the assembler.
-        let asm_dir = if target_os == Some(WINDOWS) {
+        let asm_dir = if asm_target.preassemble {
             &pregenerated_tmp
         } else {
             &pregenerated
         };
 
-        if let Some(perlasm_format) = perlasm_format {
-            let perlasm_src_dsts =
-                perlasm_src_dsts(&asm_dir, target_arch, target_os, perlasm_format);
-            perlasm(&perlasm_src_dsts, target_arch, perlasm_format, None);
+        let perlasm_src_dsts = perlasm_src_dsts(asm_dir, asm_target);
+        perlasm(&perlasm_src_dsts, asm_target);
 
-            if target_os == Some(WINDOWS) {
-                let srcs = asm_srcs(perlasm_src_dsts);
-                for src in srcs {
-                    let obj_path = obj_path(&pregenerated, &src, MSVC_OBJ_EXT);
-                    run_command(nasm(&src, target_arch, &obj_path));
-                }
+        if asm_target.preassemble {
+            let srcs = asm_srcs(perlasm_src_dsts);
+            for src in srcs {
+                let obj_path = obj_path(&pregenerated, &src);
+                run_command(nasm(&src, asm_target.arch, &obj_path));
             }
         }
     }
@@ -316,8 +434,6 @@ struct Target {
     arch: String,
     os: String,
     env: String,
-    obj_ext: &'static str,
-    obj_opt: &'static str,
     is_git: bool,
     is_debug: bool,
 }
@@ -330,32 +446,9 @@ fn build_c_code(target: &Target, pregenerated: PathBuf, out_dir: &Path) {
         }
     }
 
-    let includes_modified = RING_INCLUDES
-        .iter()
-        .chain(RING_BUILD_FILE.iter())
-        .chain(RING_PERL_INCLUDES.iter())
-        .map(|f| file_modified(Path::new(*f)))
-        .max()
-        .unwrap();
-
-    fn is_none_or_equals<T>(opt: Option<T>, other: T) -> bool
-    where
-        T: PartialEq,
-    {
-        if let Some(value) = opt {
-            value == other
-        } else {
-            true
-        }
-    }
-
-    let (_, _, perlasm_format) = ASM_TARGETS
-        .iter()
-        .find(|entry| {
-            let &(entry_arch, entry_os, _) = *entry;
-            entry_arch == target.arch && is_none_or_equals(entry_os, &target.os)
-        })
-        .unwrap();
+    let asm_target = ASM_TARGETS.iter().find(|asm_target| {
+        asm_target.arch == target.arch && asm_target.oss.contains(&target.os.as_ref())
+    });
 
     let use_pregenerated = !target.is_git;
     let warnings_are_errors = target.is_git;
@@ -366,30 +459,21 @@ fn build_c_code(target: &Target, pregenerated: PathBuf, out_dir: &Path) {
         out_dir
     };
 
-    let asm_srcs = if let Some(perlasm_format) = perlasm_format {
-        let perlasm_src_dsts =
-            perlasm_src_dsts(asm_dir, &target.arch, Some(&target.os), perlasm_format);
+    let asm_srcs = if let Some(asm_target) = asm_target {
+        let perlasm_src_dsts = perlasm_src_dsts(asm_dir, asm_target);
 
         if !use_pregenerated {
-            perlasm(
-                &perlasm_src_dsts[..],
-                &target.arch,
-                perlasm_format,
-                Some(includes_modified),
-            );
+            perlasm(&perlasm_src_dsts[..], asm_target);
         }
 
         let mut asm_srcs = asm_srcs(perlasm_src_dsts);
 
         // For Windows we also pregenerate the object files for non-Git builds so
-        // the user doesn't need to install the assembler. On other platforms we
-        // assume the C compiler also assembles.
+        // the user doesn't need to install the assembler.
         if use_pregenerated && target.os == WINDOWS {
-            // The pregenerated object files always use ".obj" as the extension,
-            // even when the C/C++ compiler outputs files with the ".o" extension.
             asm_srcs = asm_srcs
                 .iter()
-                .map(|src| obj_path(&pregenerated, src.as_path(), "obj"))
+                .map(|src| obj_path(&pregenerated, src.as_path()))
                 .collect::<Vec<_>>();
         }
 
@@ -420,7 +504,6 @@ fn build_c_code(target: &Target, pregenerated: PathBuf, out_dir: &Path) {
             srcs,
             additional_srcs,
             warnings_are_errors,
-            includes_modified,
         )
     });
 
@@ -437,52 +520,44 @@ fn build_library(
     srcs: &[PathBuf],
     additional_srcs: &[PathBuf],
     warnings_are_errors: bool,
-    includes_modified: SystemTime,
 ) {
     // Compile all the (dirty) source files into object files.
     let objs = additional_srcs
         .iter()
         .chain(srcs.iter())
-        .filter(|f| &target.env != "msvc" || f.extension().unwrap().to_str().unwrap() != "S")
-        .map(|f| compile(f, target, warnings_are_errors, out_dir, includes_modified))
+        .map(|f| compile(f, target, warnings_are_errors, out_dir))
         .collect::<Vec<_>>();
 
     // Rebuild the library if necessary.
     let lib_path = PathBuf::from(out_dir).join(format!("lib{}.a", lib_name));
 
-    if objs
-        .iter()
-        .map(Path::new)
-        .any(|p| need_run(&p, &lib_path, includes_modified))
-    {
-        let mut c = cc::Build::new();
+    let mut c = cc::Build::new();
 
-        for f in LD_FLAGS {
-            let _ = c.flag(&f);
-        }
-        match target.os.as_str() {
-            "macos" => {
-                let _ = c.flag("-fPIC");
-                let _ = c.flag("-Wl,-dead_strip");
-            }
-            _ => {
-                let _ = c.flag("-Wl,--gc-sections");
-            }
-        }
-        for o in objs {
-            let _ = c.object(o);
-        }
-
-        // Handled below.
-        let _ = c.cargo_metadata(false);
-
-        c.compile(
-            lib_path
-                .file_name()
-                .and_then(|f| f.to_str())
-                .expect("No filename"),
-        );
+    for f in LD_FLAGS {
+        let _ = c.flag(&f);
     }
+    match target.os.as_str() {
+        "macos" => {
+            let _ = c.flag("-fPIC");
+            let _ = c.flag("-Wl,-dead_strip");
+        }
+        _ => {
+            let _ = c.flag("-Wl,--gc-sections");
+        }
+    }
+    for o in objs {
+        let _ = c.object(o);
+    }
+
+    // Handled below.
+    let _ = c.cargo_metadata(false);
+
+    c.compile(
+        lib_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .expect("No filename"),
+    );
 
     // Link the library. This works even when the library doesn't need to be
     // rebuilt.
@@ -493,31 +568,30 @@ fn compile(
     p: &Path,
     target: &Target,
     warnings_are_errors: bool,
-    out_dir: &Path,
-    includes_modified: SystemTime,
+    out_dir: &Path
 ) -> String {
     let ext = p.extension().unwrap().to_str().unwrap();
-    if ext == "obj" {
+    if ext == "o" {
         p.to_str().expect("Invalid path").into()
     } else {
-        let mut out_path = out_dir.join(p.file_name().unwrap());
-        assert!(out_path.set_extension(target.obj_ext));
-        if need_run(&p, &out_path, includes_modified) {
-            let cmd = if target.os != WINDOWS || ext != "asm" {
-                cc(p, ext, target, warnings_are_errors, &out_path)
-            } else {
-                nasm(p, &target.arch, &out_path)
-            };
+        let out_path = obj_path(out_dir, p);
+        let cmd = if target.os != WINDOWS || ext != "asm" {
+            cc(p, ext, target, warnings_are_errors, &out_path)
+        } else {
+            nasm(p, &target.arch, &out_path)
+        };
 
-            run_command(cmd);
-        }
+        run_command(cmd);
         out_path.to_str().expect("Invalid path").into()
     }
 }
 
-fn obj_path(out_dir: &Path, src: &Path, obj_ext: &str) -> PathBuf {
+fn obj_path(out_dir: &Path, src: &Path) -> PathBuf {
     let mut out_path = out_dir.join(src.file_name().unwrap());
-    assert!(out_path.set_extension(obj_ext));
+    // To eliminate unnecessary conditional logic, use ".o" as the extension,
+    // even when the compiler (e.g. MSVC) would normally use something else
+    // (e.g. ".obj"). cc-rs seems to do the same.
+    assert!(out_path.set_extension("o"));
     out_path
 }
 
@@ -531,18 +605,24 @@ fn cc(
     let is_musl = target.env.starts_with("musl");
 
     let mut c = cc::Build::new();
+
+    // FIXME: On Windows AArch64 we currently must use Clang to compile C code
+    if target.os == WINDOWS && target.arch == AARCH64 && !c.get_compiler().is_like_clang() {
+        let _ = c.compiler("clang");
+    }
+    let compiler = c.get_compiler();
     let _ = c.include("include");
     match ext {
         "c" => {
-            for f in c_flags(target) {
+            for f in c_flags(&compiler) {
                 let _ = c.flag(f);
             }
         }
         "S" => (),
         e => panic!("Unsupported file extension: {:?}", e),
     };
-    for f in cpp_flags(target) {
-        let _ = c.flag(&f);
+    for f in cpp_flags(&compiler) {
+        let _ = c.flag(f);
     }
     if target.os != "none"
         && target.os != "redox"
@@ -552,21 +632,18 @@ fn cc(
         let _ = c.flag("-fstack-protector");
     }
 
-    match (target.os.as_str(), target.env.as_str()) {
+    if target.os.as_str() == "macos" {
         // ``-gfull`` is required for Darwin's |-dead_strip|.
-        ("macos", _) => {
-            let _ = c.flag("-gfull");
-        }
-        (_, "msvc") => (),
-        _ => {
-            let _ = c.flag("-g3");
-        }
+        let _ = c.flag("-gfull");
+    } else if !compiler.is_like_msvc() {
+        let _ = c.flag("-g3");
     };
+
     if !target.is_debug {
         let _ = c.define("NDEBUG", None);
     }
 
-    if &target.env == "msvc" {
+    if compiler.is_like_msvc() {
         if std::env::var("OPT_LEVEL").unwrap() == "0" {
             let _ = c.flag("/Od"); // Disable optimization for debug builds.
                                    // run-time checking: (s)tack frame, (u)ninitialized variables
@@ -592,12 +669,7 @@ fn cc(
     }
 
     if warnings_are_errors {
-        let flag = if &target.env != "msvc" {
-            "-Werror"
-        } else {
-            "/WX"
-        };
-        let _ = c.flag(flag);
+        c.warnings_into_errors(true);
     }
     if is_musl {
         // Some platforms enable _FORTIFY_SOURCE by default, but musl
@@ -608,22 +680,22 @@ fn cc(
         let _ = c.flag("-U_FORTIFY_SOURCE");
     }
 
+    let obj_opt = if compiler.is_like_msvc() { "/Fo" } else { "-o" };
     let mut c = c.get_compiler().to_command();
     let _ = c
         .arg("-c")
         .arg(format!(
             "{}{}",
-            target.obj_opt,
+            obj_opt,
             out_dir.to_str().expect("Invalid path")
         ))
         .arg(file);
     c
 }
-
 fn nasm(file: &Path, arch: &str, out_file: &Path) -> Command {
     let oformat = match arch {
-        "x86_64" => ("win64"),
-        "x86" => ("win32"),
+        "x86_64" => "win64",
+        "x86" => "win32",
         _ => panic!("unsupported arch: {}", arch),
     };
     let mut c = Command::new("./target/tools/nasm");
@@ -665,17 +737,12 @@ fn sources_for_arch(arch: &str) -> Vec<PathBuf> {
         .collect::<Vec<_>>()
 }
 
-fn perlasm_src_dsts(
-    out_dir: &Path,
-    arch: &str,
-    os: Option<&str>,
-    perlasm_format: &str,
-) -> Vec<(PathBuf, PathBuf)> {
-    let srcs = sources_for_arch(arch);
+fn perlasm_src_dsts(out_dir: &Path, asm_target: &AsmTarget) -> Vec<(PathBuf, PathBuf)> {
+    let srcs = sources_for_arch(asm_target.arch);
     let mut src_dsts = srcs
         .iter()
         .filter(|p| is_perlasm(p))
-        .map(|src| (src.clone(), asm_path(out_dir, src, os, perlasm_format)))
+        .map(|src| (src.clone(), asm_path(out_dir, src, asm_target)))
         .collect::<Vec<_>>();
 
     // Some PerlAsm source files need to be run multiple times with different
@@ -688,7 +755,7 @@ fn perlasm_src_dsts(
                 let synthesized_path = PathBuf::from(synthesized);
                 src_dsts.push((
                     concrete_path,
-                    asm_path(out_dir, &synthesized_path, os, perlasm_format),
+                    asm_path(out_dir, &synthesized_path, asm_target),
                 ))
             }
         };
@@ -710,32 +777,24 @@ fn is_perlasm(path: &PathBuf) -> bool {
     path.extension().unwrap().to_str().unwrap() == "pl"
 }
 
-fn asm_path(out_dir: &Path, src: &Path, os: Option<&str>, perlasm_format: &str) -> PathBuf {
+fn asm_path(out_dir: &Path, src: &Path, asm_target: &AsmTarget) -> PathBuf {
     let src_stem = src.file_stem().expect("source file without basename");
 
     let dst_stem = src_stem.to_str().unwrap();
-    let dst_extension = if os == Some("windows") { "asm" } else { "S" };
-    let dst_filename = format!("{}-{}.{}", dst_stem, perlasm_format, dst_extension);
+    let dst_filename = format!(
+        "{}-{}.{}",
+        dst_stem, asm_target.perlasm_format, asm_target.asm_extension
+    );
     out_dir.join(dst_filename)
 }
 
-fn perlasm(
-    src_dst: &[(PathBuf, PathBuf)],
-    arch: &str,
-    perlasm_format: &str,
-    includes_modified: Option<SystemTime>,
-) {
+fn perlasm(src_dst: &[(PathBuf, PathBuf)], asm_target: &AsmTarget) {
     for (src, dst) in src_dst {
-        if let Some(includes_modified) = includes_modified {
-            if !need_run(src, dst, includes_modified) {
-                continue;
-            }
-        }
-
-        let mut args = Vec::<String>::new();
-        args.push(src.to_string_lossy().into_owned());
-        args.push(perlasm_format.to_owned());
-        if arch == "x86" {
+        let mut args = vec![
+            src.to_string_lossy().into_owned(),
+            asm_target.perlasm_format.to_owned(),
+        ];
+        if asm_target.arch == "x86" {
             args.push("-fPIC".into());
             args.push("-DOPENSSL_IA32_SSE2".into());
         }
@@ -744,31 +803,10 @@ fn perlasm(
         let dst = dst
             .to_str()
             .expect("Could not convert path")
-            .replace("\\", "/");
+            .replace('\\', "/");
         args.push(dst);
         run_command_with_args(&get_command("PERL_EXECUTABLE", "perl"), &args);
     }
-}
-
-fn need_run(source: &Path, target: &Path, includes_modified: SystemTime) -> bool {
-    let s_modified = file_modified(source);
-    if let Ok(target_metadata) = std::fs::metadata(target) {
-        let target_modified = target_metadata.modified().unwrap();
-        s_modified >= target_modified || includes_modified >= target_modified
-    } else {
-        // On error fetching metadata for the target file, assume the target
-        // doesn't exist.
-        true
-    }
-}
-
-fn file_modified(path: &Path) -> SystemTime {
-    let path = Path::new(path);
-    let path_as_str = format!("{:?}", path);
-    std::fs::metadata(path)
-        .expect(&path_as_str)
-        .modified()
-        .expect("nah")
 }
 
 fn get_command(var: &str, default: &str) -> String {

--- a/build.rs
+++ b/build.rs
@@ -698,7 +698,11 @@ fn nasm(file: &Path, arch: &str, out_file: &Path) -> Command {
         "x86" => "win32",
         _ => panic!("unsupported arch: {}", arch),
     };
-    let mut c = Command::new("./target/tools/nasm");
+    let mut c = Command::new(if fs::metadata("./target/tools/nasm").is_ok() {
+        "./target/tools/nasm"
+    } else {
+        "nasm"
+    });
     let _ = c
         .arg("-o")
         .arg(out_file.to_str().expect("Invalid path"))

--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -15,6 +15,7 @@
 #include <GFp/cpu.h>
 #include "internal.h"
 
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 // Our assembly does not use the GOT to reference symbols, which means
 // references to visible symbols will often require a TEXTREL. This is
 // undesirable, so all assembly-referenced symbols should be hidden. CPU
@@ -26,7 +27,6 @@
 #define HIDDEN __attribute__((visibility("hidden")))
 #endif
 
-#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 // This value must be explicitly initialised to zero in order to work around a
 // bug in libtool or the linker on OS X.
 //

--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -558,6 +558,9 @@ if ($flavour =~ /64/) {			######## 64-bit code
 	s/\.[ui]?64//o and s/\.16b/\.2d/go;
 	s/\.[42]([sd])\[([0-3])\]/\.$1\[$2\]/o;
 
+	# Switch preprocessor checks to aarch64 versions.
+	s/__ARME([BL])__/__AARCH64E$1__/go;
+
 	print $_,"\n";
     }
 } else {				######## 32-bit code

--- a/crypto/fipsmodule/ec/ecp_nistz384.inl
+++ b/crypto/fipsmodule/ec/ecp_nistz384.inl
@@ -23,7 +23,7 @@
 
 #include "ecp_nistz.h"
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
@@ -252,6 +252,6 @@ void GFp_nistz384_point_mul(P384_POINT *r, const BN_ULONG p_scalar[P384_LIMBS],
   add_precomputed_w5(r, wvalue, table);
 }
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/crypto/perlasm/arm-xlate.pl
+++ b/crypto/perlasm/arm-xlate.pl
@@ -22,6 +22,7 @@ my $dotinlocallabels=($flavour=~/linux/)?1:0;
 ################################################################
 my $arch = sub {
     if ($flavour =~ /linux/)	{ ".arch\t".join(',',@_); }
+    elsif ($flavour =~ /win64/) { ".arch\t".join(',',@_); }
     else			{ ""; }
 };
 my $fpu = sub {
@@ -30,6 +31,7 @@ my $fpu = sub {
 };
 my $hidden = sub {
     if ($flavour =~ /ios/)	{ ".private_extern\t".join(',',@_); }
+    elsif ($flavour =~ /win64/) { ""; }
     else			{ ".hidden\t".join(',',@_); }
 };
 my $comm = sub {
@@ -80,6 +82,15 @@ my $type = sub {
 					"#endif";
 				  }
 			        }
+    elsif ($flavour =~ /win64/) { if (join(',',@_) =~ /(\w+),%function/) {
+                # See https://sourceware.org/binutils/docs/as/Pseudo-Ops.html
+                # Per https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#coff-symbol-table,
+                # the type for functions is 0x20, or 32.
+                ".def $1\n".
+                "   .type 32\n".
+                ".endef";
+            }
+        }
     else			{ ""; }
 };
 my $size = sub {
@@ -155,7 +166,7 @@ print <<___;
 ___
 
 print "#if defined(__arm__)\n" if ($flavour eq "linux32");
-print "#if defined(__aarch64__)\n" if ($flavour eq "linux64");
+print "#if defined(__aarch64__)\n" if ($flavour eq "linux64" || $flavour eq "win64");
 
 while(my $line=<>) {
 
@@ -224,7 +235,7 @@ while(my $line=<>) {
     print "\n";
 }
 
-print "#endif\n" if ($flavour eq "linux32" || $flavour eq "linux64");
+print "#endif\n" if ($flavour eq "linux32" || $flavour eq "linux64" || $flavour eq "win64");
 print "#endif  // !OPENSSL_NO_ASM\n";
 
 # See https://www.airs.com/blog/archives/518.

--- a/crypto/poly1305/poly1305.c
+++ b/crypto/poly1305/poly1305.c
@@ -24,7 +24,7 @@
 
 #if !defined(BORINGSSL_HAS_UINT128) || !defined(OPENSSL_X86_64)
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif

--- a/pregenerate_asm/Cargo.toml
+++ b/pregenerate_asm/Cargo.toml
@@ -9,4 +9,4 @@ path = "../build.rs"
 
 # Keep this in sync with `[build-dependencies]` in ../Cargo.toml.
 [dependencies]
-cc = { version = "1.0.62", default-features = false }
+cc = { version = "1.0.73", default-features = false }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -31,7 +31,12 @@ pub(crate) fn features() -> Features {
         target_arch = "x86_64",
         all(
             any(target_arch = "aarch64", target_arch = "arm"),
-            any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+            any(
+                target_os = "android",
+                target_os = "fuchsia",
+                target_os = "linux",
+                target_os = "windows"
+            )
         )
     ))]
     {
@@ -49,7 +54,12 @@ pub(crate) fn features() -> Features {
 
             #[cfg(all(
                 any(target_arch = "aarch64", target_arch = "arm"),
-                any(target_os = "android", target_os = "fuchsia", target_os = "linux")
+                any(
+                    target_os = "android",
+                    target_os = "fuchsia",
+                    target_os = "linux",
+                    target_os = "windows"
+                )
             ))]
             {
                 arm::setup();
@@ -162,6 +172,27 @@ pub(crate) mod arm {
         }
     }
 
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    pub fn setup() {
+        // We do not need to check for the presence of NEON, as Armv8-A always has it
+        let mut features = NEON.mask;
+
+        let result = unsafe {
+            winapi::um::processthreadsapi::IsProcessorFeaturePresent(
+                winapi::um::winnt::PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE,
+            )
+        };
+
+        if result != 0 {
+            // These are all covered by one call in Windows
+            features |= AES.mask;
+            features |= PMULL.mask;
+            features |= SHA256.mask;
+        }
+
+        unsafe { GFp_armcap_P = features };
+    }
+
     macro_rules! features {
         {
             $(
@@ -238,6 +269,12 @@ pub(crate) mod arm {
 
             #[cfg(all(
                 any(target_os = "android", target_os = "fuchsia", target_os = "linux"),
+                any(
+                    target_os = "android",
+                    target_os = "fuchsia",
+                    target_os = "linux",
+                    target_os = "windows"
+                ),
                 any(target_arch = "arm", target_arch = "aarch64")
             ))]
             {


### PR DESCRIPTION
Here's a PR to enable building 0.16.20 for Windows on ARM as requested in #1551.

**Prerequisites to build from source:**

1. Download and install [LLVM](https://github.com/llvm/llvm-project/releases)
2. Download and install [Perl](https://strawberryperl.com)
3. Download and install [NASM](https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D)