### PR TITLE
bigint: Provide a fallback implementation for `bn_mul_mont`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
           - i686-pc-windows-msvc
           - i686-unknown-linux-gnu
           - i686-unknown-linux-musl
+          - mipsel-unknown-linux-gnu
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -244,6 +245,9 @@ jobs:
 
           - target: i686-unknown-linux-musl
             host_os: ubuntu-22.04
+
+          - target: mipsel-unknown-linux-gnu
+            host_os: ubuntu-18.04
 
           - target: x86_64-pc-windows-gnu
             host_os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: mipsel-unknown-linux-gnu
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
           - target: x86_64-pc-windows-gnu
             host_os: windows-latest

--- a/build.rs
+++ b/build.rs
@@ -37,15 +37,15 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[], "crypto/fipsmodule/aes/aes_nohw.c"),
     (&[], "crypto/fipsmodule/bn/montgomery.c"),
     (&[], "crypto/fipsmodule/bn/montgomery_inv.c"),
+    (&[], "crypto/fipsmodule/ec/ecp_nistz.c"),
+    (&[], "crypto/fipsmodule/ec/gfp_p256.c"),
+    (&[], "crypto/fipsmodule/ec/gfp_p384.c"),
+    (&[], "crypto/fipsmodule/ec/p256.c"),
     (&[], "crypto/limbs/limbs.c"),
     (&[], "crypto/mem.c"),
     (&[], "crypto/poly1305/poly1305.c"),
 
     (&[AARCH64, ARM, X86_64, X86], "crypto/crypto.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/ecp_nistz.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p256.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/gfp_p384.c"),
-    (&[AARCH64, ARM, X86_64, X86], "crypto/fipsmodule/ec/p256.c"),
 
     (&[X86_64, X86], "crypto/cpu_intel.c"),
 

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -20,6 +20,7 @@ IFS=$'\n\t'
 rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
 qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
+qemu_mipsel="qemu-system-mipsel -L /usr/mipsel-linux-gnu"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may
@@ -90,6 +91,12 @@ case $target in
     export CC_i686_unknown_linux_musl=clang-$llvm_version
     export AR_i686_unknown_linux_musl=llvm-ar-$llvm_version
     export CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_RUSTFLAGS="$rustflags_self_contained"
+    ;;
+  mipsel-unknown-linux-gnu)
+    export CC_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc
+    export AR_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc-ar
+    export CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc
+    export CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER="$qemu_mipsel"
     ;;
   x86_64-unknown-linux-musl)
     export CC_x86_64_unknown_linux_musl=clang-$llvm_version

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -20,7 +20,7 @@ IFS=$'\n\t'
 rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
 qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
-qemu_mipsel="qemu-system-mipsel -L /usr/mipsel-linux-gnu"
+qemu_mipsel="qemu-mipsel -L /usr/mipsel-linux-gnu"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -74,9 +74,9 @@ case $target in
   ;;
 --target=mipsel-unknown-linux-gnu)
   install_packages \
-    qemu-user \
     gcc-mipsel-linux-gnu \
-    libc6-dev-mipsel-cross
+    libc6-dev-mipsel-cross \
+    qemu-user
   ;;
 --target=wasm32-unknown-unknown)
   cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -72,6 +72,12 @@ case $target in
 --target=i686-unknown-linux-musl|--target=x86_64-unknown-linux-musl)
   use_clang=1
   ;;
+--target=mipsel-unknown-linux-gnu)
+  install_packages \
+    qemu-user \
+    gcc-mipsel-linux-gnu \
+    libc6-dev-mipsel-cross
+  ;;
 --target=wasm32-unknown-unknown)
   cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner
   use_clang=1

--- a/src/arithmetic/bigint/bn_mul_mont_fallback.rs
+++ b/src/arithmetic/bigint/bn_mul_mont_fallback.rs
@@ -1,0 +1,51 @@
+// Copyright 2015-2022 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg(not(any(
+    target_arch = "aarch64",
+    target_arch = "arm",
+    target_arch = "x86",
+    target_arch = "x86_64"
+)))]
+
+use super::{limbs_from_mont_in_place, limbs_mul, Limb, MODULUS_MAX_LIMBS, N0};
+use crate::c;
+
+prefixed_export! {
+    unsafe fn bn_mul_mont(
+        r: *mut Limb,
+        a: *const Limb,
+        b: *const Limb,
+        n: *const Limb,
+        n0: &N0,
+        num_limbs: c::size_t,
+    ) {
+        // The mutable pointer `r` may alias `a` and/or `b`, so the lifetimes of
+        // any slices for `a` or `b` must not overlap with the lifetime of any
+        // mutable for `r`.
+
+        // Nothing aliases `n`
+        let n = unsafe { core::slice::from_raw_parts(n, num_limbs) };
+
+        let mut tmp = [0; 2 * MODULUS_MAX_LIMBS];
+        let tmp = &mut tmp[..(2 * num_limbs)];
+        {
+            let a: &[Limb] = unsafe { core::slice::from_raw_parts(a, num_limbs) };
+            let b: &[Limb] = unsafe { core::slice::from_raw_parts(b, num_limbs) };
+            limbs_mul(tmp, a, b);
+        }
+        let r: &mut [Limb] = unsafe { core::slice::from_raw_parts_mut(r, num_limbs) };
+        limbs_from_mont_in_place(r, tmp, n, n0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,3 +114,6 @@ mod sealed {
     // ```
     pub trait Sealed {}
 }
+
+// TODO: https://github.com/briansmith/ring/issues/1555.
+const _LITTLE_ENDIAN_ONLY: () = assert!(cfg!(target_endian = "little"));

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -14,7 +14,7 @@ macro_rules! prefixed_extern {
                     $name
                     {
                         $( #[$meta] )*
-                        $vis fn $name ( $( $arg_pat : $arg_ty ),* ) $( -> $ret_ty )?
+                        $vis fn $name ( $( $arg_pat : $arg_ty ),* ) $( -> $ret_ty )?;
                     }
 
                 }
@@ -33,15 +33,31 @@ macro_rules! prefixed_extern {
                 $name
                 {
                     $( #[$meta] )*
-                    $vis static mut $name: $typ
+                    $vis static mut $name: $typ;
                 }
             }
         }
     };
 }
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 macro_rules! prefixed_export {
+    // A function.
+    {
+        $( #[$meta:meta] )*
+        $vis:vis unsafe fn $name:ident ( $( $arg_pat:ident : $arg_ty:ty ),* $(,)? ) $body:block
+    } => {
+        prefixed_item! {
+            export_name
+            $name
+            {
+                $( #[$meta] )*
+                $vis unsafe fn $name ( $( $arg_pat : $arg_ty ),* ) $body
+            }
+        }
+    };
+
+    // A global variable.
     {
         $( #[$meta:meta] )*
         $vis:vis static mut $name:ident: $typ:ty = $initial_value:expr;
@@ -51,10 +67,10 @@ macro_rules! prefixed_export {
             $name
             {
                 $( #[$meta] )*
-                $vis static mut $name: $typ = $initial_value
+                $vis static mut $name: $typ = $initial_value;
             }
         }
-    }
+    };
 }
 
 macro_rules! prefixed_item {
@@ -80,6 +96,6 @@ macro_rules! prefixed_item {
         { $( $item:tt )+ }
     } => {
         #[$attr = $prefixed_name]
-        $( $item )+;
+        $( $item )+
     };
 }


### PR DESCRIPTION
Add an implementation of `bn_mul_mont`. Intentionally break the build on big-endian targets so they don't accidentally build/run with incorrect logic. See the individual commit messages for more details. Add mipsel-unknown-linux-gnu to the GitHub Actions test matrix.