### PR TITLE
Support for wasm32-wasi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,11 +497,9 @@ jobs:
 
       - run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
 
-      - uses: briansmith/actions-rs-toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          override: true
           target: ${{ matrix.target }}
-          toolchain: ${{ matrix.rust_channel }}
 
       - name: Install wasi-sdk
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,7 +507,9 @@ jobs:
           wget -O ./wasi-sdk-linux.tar.gz $WASI_URL
           mkdir wasi-sdk
           tar -C ./wasi-sdk -xf wasi-sdk-linux.tar.gz --strip-components=1
-          echo "WASI_SDK_PATH=`pwd`/wasi-sdk" >> $GITHUB_ENV
+          export WASI_SDK_PATH=`pwd`/wasi-sdk
+          echo "WASI_SDK_PATH=${WASI_SDK_PATH}" >> $GITHUB_ENV
+          echo "CC=${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot" >> $GITHUB_ENV
       
       - name: Install precompiled wasmtime
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,9 +497,11 @@ jobs:
 
       - run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: briansmith/actions-rs-toolchain@v1
         with:
+          override: true
           target: ${{ matrix.target }}
+          toolchain: ${{ matrix.rust_channel }}
 
       - name: Install wasi-sdk
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,10 +513,10 @@ jobs:
       
       - name: Install precompiled wasmtime
         run: |
-          export WASMTIME_URL=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-linux.tar.xz")) | .browser_download_url')
-          wget -O /tmp/binaries.tar.xz $WASMTIME_URL
-          tar -C /tmp -xf /tmp/binaries.tar.xz --strip-components=1
-          mv /tmp/wasmtime ~/.cargo/bin
+          VERSION=v3.0.0
+          URL=https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz
+          wget -O - $URL | tar -xJ --strip-components=1 -C ~/.cargo/bin
+          wasmtime --version
 
       - run: |
           mk/cargo.sh test -vv --target=${{ matrix.target }} ${{ matrix.mode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,67 @@ jobs:
       # TODO: Do this check on Windows too.
       - run: mk/check-symbol-prefixes.sh --target=${{ matrix.target }}
 
+  # The wasm32-wasi targets have a different set of feature sets.
+  test-wasm32-wasi:
+    # Don't run duplicate `push` jobs for the repo owner's PRs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ${{ matrix.host_os }}
+
+    strategy:
+      matrix:
+        host_os:
+          - ubuntu-22.04
+        mode:
+          - # debug
+          - --release
+        rust_channel:
+          - stable
+          - beta
+          - nightly
+        target:
+          - wasm32-wasi
+
+    steps:
+      - if: ${{ contains(matrix.host_os, 'ubuntu') }}
+        run: sudo apt-get update -y
+
+      - uses: briansmith/actions-checkout@v2
+        with:
+          persist-credentials: false
+
+      - run: cargo generate-lockfile
+
+      - run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
+
+      - uses: briansmith/actions-rs-toolchain@v1
+        with:
+          override: true
+          target: ${{ matrix.target }}
+          toolchain: ${{ matrix.rust_channel }}
+
+      - name: Install wasi-sdk
+        run: |
+          export WASI_URL=$(curl -s https://api.github.com/repos/WebAssembly/wasi-sdk/releases/latest | jq -r '.assets[] | select(.name | contains("linux.tar.gz")) | .browser_download_url')
+          wget -O ./wasi-sdk-linux.tar.gz $WASI_URL
+          mkdir wasi-sdk
+          tar -C ./wasi-sdk -xf wasi-sdk-linux.tar.gz --strip-components=1
+          export WASI_SDK_PATH=`pwd`/wasi-sdk
+      
+      - name: Install precompiled wasmtime
+        run: |
+          export WASMTIME_URL=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-linux.tar.xz")) | .browser_download_url')
+          wget -O /tmp/binaries.tar.xz $WASMTIME_URL
+          tar -C /tmp -xf /tmp/binaries.tar.xz --strip-components=1
+          mv /tmp/wasmtime ~/.cargo/bin
+
+      - run: |
+          mk/cargo.sh test -vv --target=${{ matrix.target }} ${{ matrix.mode }}
+
+      # Check that all the needed symbol renaming was done.
+      # TODO: Do this check on Windows too.
+      - run: mk/check-symbol-prefixes.sh --target=${{ matrix.target }}
+
   coverage:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,7 +509,7 @@ jobs:
           wget -O ./wasi-sdk-linux.tar.gz $WASI_URL
           mkdir wasi-sdk
           tar -C ./wasi-sdk -xf wasi-sdk-linux.tar.gz --strip-components=1
-          export WASI_SDK_PATH=`pwd`/wasi-sdk
+          echo "WASI_SDK_PATH=`pwd`/wasi-sdk" >> $GITHUB_ENV
       
       - name: Install precompiled wasmtime
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ libc = { version = "0.2.100", default-features = false }
 [target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
 winapi = { version = "0.3.9", default-features = false, features = ["ntsecapi", "wtypesbase", "processthreadsapi"] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }
 
 [target.'cfg(any(unix, windows, target_os = "wasi"))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ winapi = { version = "0.3.9", default-features = false, features = ["ntsecapi", 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }
 
-[target.'cfg(any(unix, windows))'.dev-dependencies]
+[target.'cfg(any(unix, windows, target_os = "wasi"))'.dev-dependencies]
 libc = { version = "0.2.100", default-features = false }
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -501,7 +501,7 @@ fn cc_builder() -> cc::Build {
         let wasi_sdk_path =
             &std::env::var("WASI_SDK_PATH").expect("missing environment variable: WASI_SDK_PATH");
         c.compiler(format!("{}/bin/clang", wasi_sdk_path).as_str());
-        c.archiver(format!("{}/bin/ar", wasi_sdk_path).as_str());
+        c.archiver(format!("{}/bin/llvm-ar", wasi_sdk_path).as_str());
         c.flag(format!("--sysroot={}/share/wasi-sysroot", wasi_sdk_path).as_str());
     }
     c

--- a/build.rs
+++ b/build.rs
@@ -498,8 +498,6 @@ fn cc_builder() -> cc::Build {
     let mut c = cc::Build::new();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os == "wasi" {
-        // std::env::var("WASI_SDK_PATH").expect("missing environment variable: WASI_SDK_PATH");
-        // c.flag(format!("--sysroot=${{WASI_SDK_PATH}}/share/wasi-sysroot").as_str());
         let wasi_sdk_path =
             &std::env::var("WASI_SDK_PATH").expect("missing environment variable: WASI_SDK_PATH");
         c.flag(format!("--sysroot={}/share/wasi-sysroot", wasi_sdk_path).as_str());

--- a/build.rs
+++ b/build.rs
@@ -500,6 +500,8 @@ fn cc_builder() -> cc::Build {
     if target_os == "wasi" {
         let wasi_sdk_path =
             &std::env::var("WASI_SDK_PATH").expect("missing environment variable: WASI_SDK_PATH");
+        c.compiler(format!("{}/bin/clang", wasi_sdk_path).as_str());
+        c.archiver(format!("{}/bin/ar", wasi_sdk_path).as_str());
         c.flag(format!("--sysroot={}/share/wasi-sysroot", wasi_sdk_path).as_str());
     }
     c

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -116,6 +116,12 @@ case $target in
     export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner
     export WASM_BINDGEN_TEST_TIMEOUT=60
     ;;
+  wasm32-wasi)
+    # The first two are only needed for when the "wasm_c" feature is enabled.
+    export CC_wasm32_wasi=$WASI_SDK_PATH/bin/clang
+    export AR_wasm32_wasi=$WASI_SDK_PATH/bin/llvm-ar
+    export CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime
+    ;;
   *)
     ;;
 esac

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -137,6 +137,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "redox",
     target_os = "solaris",
     target_os = "windows",
+    target_os = "wasi",
     all(
         feature = "wasm32_unknown_unknown_js",
         target_arch = "wasm32",

--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -12,10 +12,10 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 use core::ops::RangeFrom;

--- a/tests/constant_time_tests.rs
+++ b/tests/constant_time_tests.rs
@@ -14,10 +14,10 @@
 
 use ring::{constant_time, error, rand};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 // This logic is loosly based on BoringSSL's `TEST(ConstantTimeTest, MemCmp)`.

--- a/tests/digest_tests.rs
+++ b/tests/digest_tests.rs
@@ -14,10 +14,10 @@
 
 use ring::{digest, test, test_file};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 /// Test vectors from BoringSSL, Go, and other sources.
@@ -47,7 +47,7 @@ fn digest_misc() {
 }
 
 // wasm_bindgen doesn't build this correctly.
-#[cfg(not(target_arch = "wsam32"))]
+#[cfg(not(target_arch = "wasm32"))]
 mod digest_shavs {
     use ring::{digest, test};
 

--- a/tests/digest_tests.rs
+++ b/tests/digest_tests.rs
@@ -81,7 +81,7 @@ mod digest_shavs {
                 use super::{run_known_answer_test, run_monte_carlo_test};
                 use ring::{digest, test_file};
 
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                 use wasm_bindgen_test::wasm_bindgen_test as test;
 
                 #[test]

--- a/tests/ed25519_tests.rs
+++ b/tests/ed25519_tests.rs
@@ -18,10 +18,10 @@ use ring::{
     test, test_file,
 };
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 /// Test vectors from BoringSSL.

--- a/tests/hkdf_tests.rs
+++ b/tests/hkdf_tests.rs
@@ -14,10 +14,10 @@
 
 use ring::{digest, error, hkdf, test, test_file};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/hmac_tests.rs
+++ b/tests/hmac_tests.rs
@@ -14,10 +14,10 @@
 
 use ring::{digest, hmac, test, test_file};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/pbkdf2_tests.rs
+++ b/tests/pbkdf2_tests.rs
@@ -15,10 +15,10 @@
 use core::num::NonZeroU32;
 use ring::{digest, error, pbkdf2, test, test_file};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 /// Test vectors from BoringSSL, Go, and other sources.

--- a/tests/rand_tests.rs
+++ b/tests/rand_tests.rs
@@ -17,10 +17,10 @@ use ring::{
     test,
 };
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/rsa_tests.rs
+++ b/tests/rsa_tests.rs
@@ -22,10 +22,10 @@ use ring::{
     test, test_file,
 };
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/signature_tests.rs
+++ b/tests/signature_tests.rs
@@ -1,9 +1,9 @@
 use ring::{signature, test};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]


### PR DESCRIPTION
This PR adds support for the wasm32-wasi target.

To get the CI working, i had to use the dtolnay/rust-toolchain@stable action. The toolchain only seems to work when it is installed with rustup, see a similar issue here: https://bugs.archlinux.org/task/75269.

Currently the clippy and audit CI runs are failing. I didn't include them in this PR because I thought it would make it more difficult to see the actual changes. If I should include the clippy and audit changes, please let me know.

I agree to license my contributions to each file under the terms given at the top of each file I changed.