### PR TITLE
Add support for RISC-V

### DIFF
--- a/include/ring-core/base.h
+++ b/include/ring-core/base.h
@@ -89,6 +89,10 @@
 #elif defined(__MIPSEL__) && defined(__LP64__)
 #define OPENSSL_64_BIT
 #define OPENSSL_MIPS64
+#elif defined(__riscv) && __riscv_xlen == 64
+#define OPENSSL_64_BIT
+#elif defined(__riscv) && __riscv_xlen == 32
+#define OPENSSL_32_BIT
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
 #else


### PR DESCRIPTION
Only tested on riscv64, because openSUSE does not support riscv32.