### PR TITLE
Fix `build.rs`: Use `env::var_os` to retrieve `Path`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -338,7 +338,7 @@ fn ring_build_rs_main() {
         is_debug,
         force_warnings_into_errors,
     };
-    let pregenerated = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join(PREGENERATED);
+    let pregenerated = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap()).join(PREGENERATED);
 
     build_c_code(
         &target,

--- a/build.rs
+++ b/build.rs
@@ -642,11 +642,7 @@ fn cc(b: &cc::Build, file: &Path, ext: &str, out_file: &Path) -> Command {
     let mut c = cc.to_command();
     let _ = c
         .arg("-c")
-        .arg(format!(
-            "{}{}",
-            obj_opt,
-            out_file.to_str().expect("Invalid path")
-        ))
+        .arg(format!("{}{}", obj_opt, out_file.display()))
         .arg(file);
     c
 }

--- a/build.rs
+++ b/build.rs
@@ -639,11 +639,11 @@ fn cc(b: &cc::Build, file: &Path, ext: &str, out_file: &Path) -> Command {
 
     let cc = b.get_compiler();
     let obj_opt = if cc.is_like_msvc() { "/Fo" } else { "-o" };
+    let mut arg = OsString::from(obj_opt);
+    arg.push(out_file);
+
     let mut c = cc.to_command();
-    let _ = c
-        .arg("-c")
-        .arg(format!("{}{}", obj_opt, out_file.display()))
-        .arg(file);
+    let _ = c.arg("-c").arg(arg).arg(file);
     c
 }
 

--- a/build.rs
+++ b/build.rs
@@ -529,10 +529,16 @@ fn build_library(
     println!("cargo:rustc-link-lib=static={}", lib_name);
 }
 
-fn compile(b: &cc::Build, p: &Path, target: &Target, include_dir: &Path, out_dir: &Path) -> String {
+fn compile(
+    b: &cc::Build,
+    p: &Path,
+    target: &Target,
+    include_dir: &Path,
+    out_dir: &Path,
+) -> PathBuf {
     let ext = p.extension().unwrap().to_str().unwrap();
     if ext == "o" {
-        p.to_str().expect("Invalid path").into()
+        p.into()
     } else {
         let out_file = obj_path(out_dir, p);
         let cmd = if target.os != WINDOWS || ext != "asm" {
@@ -542,7 +548,7 @@ fn compile(b: &cc::Build, p: &Path, target: &Target, include_dir: &Path, out_dir
         };
 
         run_command(cmd);
-        out_file.to_str().expect("Invalid path").into()
+        out_file
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -300,7 +300,7 @@ fn main() {
 fn ring_build_rs_main() {
     use std::env;
 
-    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_dir = env::var_os("OUT_DIR").unwrap();
     let out_dir = PathBuf::from(out_dir);
 
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();


### PR DESCRIPTION
 - Fix retrieveing `OUT_DIR` in `build.rs`
 - Fix getting `CARGO_MANIFEST_DIR`: Use `env::var_os`
 - Modify `run_command_with_args` to take `OsStr` instead of `String` for args
 - Call `env::var_os` in `read_env_var`
 - Change return type to `PathBuf` instead of `String` for fn `compile`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>