### PR TITLE
CI: Fix Android builds in GitHub Actions.

### DIFF
--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -35,7 +35,6 @@ case $target in
     || echo $accept_android_license  >> "$android_license_file"
   "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" "ndk;$ndk_version"
 
-  ANDROID_NDK_ROOT=
   # XXX: Older Rust toolchain versions link with `-lgcc` instead of `-lunwind`;
   # see https://github.com/rust-lang/rust/pull/85806.
   find -L ${ANDROID_NDK_ROOT:-${ANDROID_HOME}/ndk/$ndk_version} -name libunwind.a \


### PR DESCRIPTION
When `$ANDROID_NDK_HOME` is set, `mk/cargo.sh` will use it to locate the NDK tools. Thus, we need to ensure that the hack is applied to `$ANDROID_NDK_HOME` when that is set.

I am not sure why I added this line; perhaps it was unintentially left in when the script was being debugged.