### PR TITLE
Enable `build.rs` to build each source file in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ wasm-bindgen-test = { version = "0.3.26", default-features = false }
 libc = { version = "0.2.100", default-features = false }
 
 [build-dependencies]
-cc = { version = "1.0.69", default-features = false }
+cc = { version = "1.0.69", default-features = false, features = ["parallel"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -530,14 +530,8 @@ fn build_library(
         let _ = c.flag(f);
     }
 
-    match target.os.as_str() {
-        "macos" => {
-            let _ = c.flag("-fPIC");
-            let _ = c.flag("-Wl,-dead_strip");
-        }
-        _ => {
-            let _ = c.flag("-Wl,--gc-sections");
-        }
+    if target.os.as_str() == "macos" {
+        c.flag("-fPIC");
     }
 
     // Handled below.

--- a/build.rs
+++ b/build.rs
@@ -814,10 +814,12 @@ fn asm_path(out_dir: &Path, src: &Path, asm_target: &AsmTarget) -> PathBuf {
 }
 
 fn perlasm(src_dst: &[(PathBuf, PathBuf)], asm_target: &AsmTarget) {
+    let perl = get_command("PERL_EXECUTABLE", "perl");
+
     let children = src_dst
         .iter()
         .map(|(src, dst)| {
-            let mut cmd = Command::new(get_command("PERL_EXECUTABLE", "perl"));
+            let mut cmd = Command::new(&perl);
 
             cmd.arg(src).arg(asm_target.perlasm_format);
 

--- a/build.rs
+++ b/build.rs
@@ -481,7 +481,7 @@ fn build_c_code(
 
     // XXX: Ideally, ring-test would only be built for `cargo test`, but Cargo
     // can't do that yet.
-    let _res: Vec<_> = libs
+    let tasks: Vec<_> = libs
         .into_iter()
         .map(|(lib_name_suffix, srcs, additional_srcs)| {
             let lib_name = format!("{}{}", ring_core_prefix, lib_name_suffix);
@@ -491,9 +491,13 @@ fn build_c_code(
                 build_library(&target, &out_dir, &lib_name, srcs, additional_srcs)
             })
         })
+        .collect::<Vec<_>>();
+
+    tasks
+        .into_iter()
         .map(thread::JoinHandle::join)
         .map(Result::unwrap)
-        .collect::<Vec<_>>();
+        .for_each(|()| ());
 
     println!(
         "cargo:rustc-link-search=native={}",

--- a/build.rs
+++ b/build.rs
@@ -505,7 +505,7 @@ fn build_c_code(
 
 fn build_library(
     target: &Target,
-    out_dir: &PathBuf,
+    out_dir: &Path,
     lib_name: &str,
     c_srcs: Vec<PathBuf>,
     asm_srcs: Vec<PathBuf>,
@@ -556,7 +556,7 @@ fn build_library(
     // Rebuild the library if necessary.
     let lib_filename = format!("lib{}.a", lib_name);
 
-    c.out_dir(&**out_dir);
+    c.out_dir(out_dir);
     c.compile(&lib_filename);
 
     // Link the library. This works even when the library doesn't need to be

--- a/build.rs
+++ b/build.rs
@@ -504,8 +504,8 @@ fn build_c_code(
 }
 
 fn build_library(
-    target: &Arc<Target>,
-    out_dir: &Arc<PathBuf>,
+    target: &Target,
+    out_dir: &PathBuf,
     lib_name: &str,
     c_srcs: Vec<PathBuf>,
     asm_srcs: Vec<PathBuf>,


### PR DESCRIPTION
This PR enables `build.rs` to run `perl` and `nasm` and `cc` in parallel to speedup compilation.
Parallel execution of `perl` and `nasm` is done manually while parallel execution of `cc` is done using `cc::Build`.

This PR also builds src and test in parallel.