### PR TITLE
deps: Move from `winapi` to `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ spin = { version = "0.9.2", default-features = false, features = ["once"] }
 libc = { version = "0.2.100", default-features = false }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
-winapi = { version = "0.3.9", default-features = false, features = ["ntsecapi", "wtypesbase", "processthreadsapi"] }
+windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -119,8 +119,8 @@ pub fn setup() {
     let mut features = NEON.mask;
 
     let result = unsafe {
-        winapi::um::processthreadsapi::IsProcessorFeaturePresent(
-            winapi::um::winnt::PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE,
+        windows_sys::Win32::System::Threading::IsProcessorFeaturePresent(
+            windows_sys::Win32::System::Threading::PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE,
         )
     };
 


### PR DESCRIPTION
`winapi` is in maintenance mode and the new blessed way to access Windows APIs are the `windows`
and `windows-sys` crates. I don't think any types of `winapi` were exposed in the public API so
I used `windows-sys` since it has much faster compile times.
