### PR TITLE
Let cc-rs choose the correct optimization flags for MSVC (`/O2` instead of `/Ox`)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -613,14 +613,9 @@ fn cc(file: &Path, ext: &str, target: &Target, include_dir: &Path, out_file: &Pa
         let _ = c.define("NDEBUG", None);
     }
 
-    if compiler.is_like_msvc() {
-        if std::env::var("OPT_LEVEL").unwrap() == "0" {
-            let _ = c.flag("/Od"); // Disable optimization for debug builds.
-                                   // run-time checking: (s)tack frame, (u)ninitialized variables
-            let _ = c.flag("/RTCsu");
-        } else {
-            let _ = c.flag("/Ox"); // Enable full optimization.
-        }
+    if compiler.is_like_msvc() && std::env::var("OPT_LEVEL").unwrap() == "0" {
+        // run-time checking: (s)tack frame, (u)ninitialized variables
+        let _ = c.flag("/RTCsu");
     }
 
     // Allow cross-compiling without a target sysroot for these targets.


### PR DESCRIPTION
`/Ox` is widely misunderstood to be the flag to enable maximum optimization with MSVC, partly because it used to be called "Full optimzation" in the Visual Studio GUI (it has been changed and now it's called "Optimizations" or "Enable Most Speed Optimizations" which describes it better). The flag to enable maximum optimizaitions however is actually `/O2` ("Maximize Speed"), which was and still is the default flag for release builds in Visual Studio.

https://learn.microsoft.com/en-us/cpp/build/reference/ox-full-optimization?view=msvc-170
https://stackoverflow.com/questions/5063334/what-is-the-difference-between-the-ox-and-o2-compiler-options

If the intention was indeed to have `/O2` minus the flags `/Ox` is missing I would suggest adding a comment