### PR TITLE
Add i686-apple-darwin target to asm matcher in 0.16 branch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -223,6 +223,7 @@ const ASM_TARGETS: &[(&str, Option<&str>, Option<&str>)] = &[
     ("aarch64", None, Some("linux64")),
     ("x86", Some(WINDOWS), Some("win32n")),
     ("x86", Some("ios"), Some("macosx")),
+    ("x86", Some("macos"), Some("macosx")),
     ("x86", None, Some("elf")),
     ("arm", Some("ios"), Some("ios32")),
     ("arm", None, Some("linux32")),


### PR DESCRIPTION
The 0.17 branch & pre-releases have fixed this somewhere in their overhaul, but haven't been released yet. Until the 0.17 series is released, this patch is useful for projects relying on stable _ring_ versions.

Tested in a macOS 10.14 VM.