### PR TITLE
Automatically install build tools on Windows without pre-compiled assembly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -676,7 +676,19 @@ fn nasm(file: &Path, arch: &str, include_dir: &Path, out_file: &Path) -> Command
         std::path::MAIN_SEPARATOR,
     )));
 
-    let mut c = Command::new("./target/tools/windows/nasm/nasm");
+    let nasm_path = "./target/tools/windows/nasm/nasm";
+    if !Path::new(nasm_path).exists() {
+        println!("No 'nasm' executable found, downloading automatically...");
+        let mut install_cmd = Command::new("powershell");
+        install_cmd
+            .arg("-ExecutionPolicy")
+            .arg("Bypass")
+            .arg("./mk/install-build-tools.ps1");
+
+        run_command(install_cmd);
+    }
+
+    let mut c = Command::new(nasm_path);
     let _ = c
         .arg("-o")
         .arg(out_file.to_str().expect("Invalid path"))


### PR DESCRIPTION
`ring` right now expects the developer to manually use the `install-build-tools.ps1` script when using this library. This isn't that feasible for when you want to include `ring` as a git dependency rather than from crates.io. Specifically, we wanted to use the latest version from main, but couldn't compile on Windows because `nasm` was missing.

This PR makes it so whenever an assembly file is compiled, it checks for the presence of the compiler or otherwise runs the install script.