### PR TITLE
Add support and CI workflow for riscv64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
           - i686-pc-windows-msvc
           - i686-unknown-linux-gnu
           - i686-unknown-linux-musl
+          - riscv64gc-unknown-linux-gnu
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -244,6 +245,9 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: i686-unknown-linux-musl
+            host_os: ubuntu-22.04
+
+          - target: riscv64gc-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: x86_64-pc-windows-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,6 +488,7 @@ jobs:
         target:
           - aarch64-unknown-linux-gnu
           - i686-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
           - x86_64-unknown-linux-musl
 
         mode:
@@ -509,6 +510,9 @@ jobs:
           # https://github.com/rust-lang/rust/issues/79556 and
           # https://github.com/rust-lang/rust/issues/79555 are fixed.
           - target: i686-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: riscv64gc-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-musl

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -40,6 +40,9 @@
 #elif defined(__MIPSEL__) && defined(__LP64__)
 #define OPENSSL_64_BIT
 #define OPENSSL_MIPS64
+#elif defined(__riscv) && __SIZEOF_POINTER__ == 8
+#define OPENSSL_64_BIT
+#define OPENSSL_RISCV64
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
 #else

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -21,6 +21,7 @@ rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
 qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
 qemu_mipsel="qemu-mipsel -L /usr/mipsel-linux-gnu"
+qemu_riscv64="qemu-riscv64 -L /usr/riscv64-linux-gnu"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may
@@ -98,6 +99,12 @@ case $target in
     export AR_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc-ar
     export CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc
     export CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER="$qemu_mipsel"
+    ;;
+  riscv64gc-unknown-linux-gnu)
+    export CC_riscv64gc_unknown_linux_gnu=clang-$llvm_version
+    export AR_riscv64gc_unknown_linux_gnu=llvm-ar-$llvm_version
+    export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=clang-$llvm_version
+    export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="$qemu_riscv64"
     ;;
   x86_64-unknown-linux-musl)
     export CC_x86_64_unknown_linux_musl=clang-$llvm_version

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -103,7 +103,7 @@ case $target in
   riscv64gc-unknown-linux-gnu)
     export CC_riscv64gc_unknown_linux_gnu=clang-$llvm_version
     export AR_riscv64gc_unknown_linux_gnu=llvm-ar-$llvm_version
-    export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=clang-$llvm_version
+    export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
     export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="$qemu_riscv64"
     ;;
   x86_64-unknown-linux-musl)

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -91,6 +91,13 @@ case $target in
     libc6-dev-mipsel-cross \
     qemu-user
   ;;
+--target=riscv64gc-unknown-linux-gnu)
+  use_clang=1
+  install_packages \
+    gcc-riscv64-linux-gnu \
+    libc6-dev-riscv64-cross \
+    qemu-user
+  ;;
 --target=wasm32-unknown-unknown)
   cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner
   use_clang=1


### PR DESCRIPTION
As there's been few recent activity on related PRs, this is #1574 rebased on latest `main` with:
* git commit-attribution to involved developers and
* sanetized commit messages to match the naming used by ring

Tested and working on Alpine Linux (riscv64 with musl libc).