### PR TITLE
CI: Use LLVM 16 tools.

### DIFF
--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -45,7 +45,7 @@ for arg in $*; do
 done
 
 # See comments in install-build-tools.sh.
-llvm_version=15
+llvm_version=16
 
 case $target in
    aarch64-linux-android)

--- a/mk/check-symbol-prefixes.sh
+++ b/mk/check-symbol-prefixes.sh
@@ -22,7 +22,7 @@ darwin*)
   nm_exe=nm
   ;;
 *)
-  llvm_version=15
+  llvm_version=16
   nm_exe=llvm-nm-$llvm_version
   ;;
 esac

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -102,7 +102,7 @@ esac
 case "$OSTYPE" in
 linux*)
   ubuntu_codename=$(lsb_release --codename --short)
-  llvm_version=15
+  llvm_version=16
   sudo apt-key add mk/llvm-snapshot.gpg.key
   sudo add-apt-repository "deb http://apt.llvm.org/$ubuntu_codename/ llvm-toolchain-$ubuntu_codename-$llvm_version main"
   sudo apt-get update


### PR DESCRIPTION
Rust now uses LLVM 16 and writes object files that LLVM 15's `nm` cannot fully understand.