### PR TITLE
CI: (Temporarily?) remove mipsel-unknown-linux-gnu from build matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,6 @@ jobs:
           - i686-pc-windows-msvc
           - i686-unknown-linux-gnu
           - i686-unknown-linux-musl
-          - mipsel-unknown-linux-gnu
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -245,9 +244,6 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: i686-unknown-linux-musl
-            host_os: ubuntu-22.04
-
-          - target: mipsel-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: x86_64-pc-windows-gnu


### PR DESCRIPTION
The CI jobs for this target are failing with this error:
```
error: component 'rust-std' for target 'mipsel-unknown-linux-gnu' is
unavailable for download for channel 'nightly'
```

Remove the target while we investigate.