### PR TITLE
Add support for PS Vita (armv7-sony-vita-newlibeabihf)

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -137,6 +137,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "redox",
     target_os = "solaris",
     target_os = "windows",
+    target_os = "vita",
     all(
         feature = "wasm32_unknown_unknown_js",
         target_arch = "wasm32",


### PR DESCRIPTION
Fixes compilation for the target, random is provided by rust-random/getrandom#359