### PR TITLE
NFC: Remove unneeded `#cfg(...)` in digest_tests.rs

### DIFF
--- a/tests/digest_tests.rs
+++ b/tests/digest_tests.rs
@@ -46,8 +46,6 @@ fn digest_misc() {
     });
 }
 
-// wasm_bindgen doesn't build this correctly.
-#[cfg(not(target_arch = "wsam32"))]
 mod digest_shavs {
     use ring::{digest, test};
 


### PR DESCRIPTION
The code is always enabled since "wasm32" was spelled wrongly. Apparently the wasm-bindgen compatibility issue is no longer an issue.