### PR TITLE
Document or remove some uses of `unsafe`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ name = "ring"
 [dependencies]
 getrandom = { version = "0.2.8" }
 untrusted = { version = "0.9" }
+zerocopy = { version = "0.7.5", features = ["derive"] }
 
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.2", default-features = false, features = ["once"] }

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -126,6 +126,12 @@ impl Context {
         debug_assert!(input_bytes > 0);
 
         let input = input.as_ptr() as *const [u8; BLOCK_LEN];
+        // SAFETY:
+        // - `[[u8; BLOCK_LEN]]` has the same bit validity as `[u8]`.
+        // - `[[u8; BLOCK_LEN]]` has the same alignment requirement as `[u8]`.
+        // - `input_bytes / BLOCK_LEN` ensures that the total length in bytes of
+        //   the new `[[u8; BLOCK_LEN]]` will not be longer than the original
+        //   `[u8]`.
         let input = unsafe { core::slice::from_raw_parts(input, input_bytes / BLOCK_LEN) };
 
         // Although these functions take `Xi` and `h_table` as separate

--- a/src/rsa/public_exponent.rs
+++ b/src/rsa/public_exponent.rs
@@ -12,8 +12,14 @@ impl PublicExponent {
 
     // TODO: Use `NonZeroU64::new(...).unwrap()` when `feature(const_panic)` is
     // stable.
-    pub(super) const _3: Self = Self(unsafe { NonZeroU64::new_unchecked(3) });
-    pub(super) const _65537: Self = Self(unsafe { NonZeroU64::new_unchecked(65537) });
+    pub(super) const _3: Self = Self(match NonZeroU64::new(3) {
+        Some(nz) => nz,
+        None => unreachable!(),
+    });
+    pub(super) const _65537: Self = Self(match NonZeroU64::new(65537) {
+        Some(nz) => nz,
+        None => unreachable!(),
+    });
 
     // This limit was chosen to bound the performance of the simple
     // exponentiation-by-squaring implementation in `elem_exp_vartime`. In
@@ -29,7 +35,10 @@ impl PublicExponent {
     //
     // TODO: Use `NonZeroU64::new(...).unwrap()` when `feature(const_panic)` is
     // stable.
-    const MAX: Self = Self(unsafe { NonZeroU64::new_unchecked((1u64 << 33) - 1) });
+    const MAX: Self = Self(match NonZeroU64::new((1u64 << 33) - 1) {
+        Some(nz) => nz,
+        None => unreachable!(),
+    });
 
     pub(super) fn from_be_bytes(
         input: untrusted::Input,


### PR DESCRIPTION
Hey @briansmith, I'm happy to have this merged if it's in a state you're comfortable with, but I also know you were hesitant about taking another dependency. I'd be happy to make any changes or chat about the overall approach.

I can also remove the `derive` feature from `zerocopy` if you'd prefer; that's the bulk of the compilation time (zerocopy itself without the derive is a fairly small library). I'm not sure if compilation time is your primary concern, but I know it is for some crate authors.