### PR TITLE
Bring back the `RsaKeyPair` name.

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -296,7 +296,6 @@ pub use crate::rsa::{
 
 /// An RSA key pair, used for signing.
 #[cfg(feature = "alloc")]
-#[deprecated = "Use `rsa::KeyPair`"]
 pub type RsaKeyPair = crate::rsa::KeyPair;
 
 /// A public key signature returned from a signing operation.


### PR DESCRIPTION
The original plan was to add RSA encryption/decryption to the next release but that plan has changed. To make it easier for people to upgrade, and to be consistent with the current state of the other signature algorithm keypair names, bring back the old name.