### PR TITLE
Don't run `test` jobs on Beta or Nightly channels.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,10 +192,11 @@ jobs:
 
         rust_channel:
           - stable
-          - nightly
           # Some benchmarking dependencies require 1.60.
           - 1.60.0 # MSRV
-          - beta
+          # TODO: Move these to a daily/pre-release job.
+          # - nightly
+          # - beta
 
         include:
           - target: aarch64-apple-darwin


### PR DESCRIPTION
These are duplicated by `coverage` (temporarily) and the `features` tests. Do this to reduce the latency between submitting a PR and it passing CI. Right now we have so many jobs with the huge matrix and CI takes too long.