### PR TITLE
Add support for 64-bit big-endian PowerPC.

### DIFF
--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -42,9 +42,9 @@
 #define OPENSSL_MIPS64
 #elif (defined(__PPC__) || defined(__powerpc__)) && defined(_BIG_ENDIAN)
 #define OPENSSL_32_BIT
-#elif (defined(__PPC64__) || defined(__powerpc64__)) && defined(_LITTLE_ENDIAN)
+#elif (defined(__PPC64__) || defined(__powerpc64__)) && \
+      (defined(_LITTLE_ENDIAN) || defined(_BIG_ENDIAN))
 #define OPENSSL_64_BIT
-#define OPENSSL_PPC64LE
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 8
 #define OPENSSL_64_BIT
 #define OPENSSL_RISCV64

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -22,6 +22,7 @@ qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
 qemu_mipsel="qemu-mipsel -L /usr/mipsel-linux-gnu"
 qemu_powerpc="qemu-ppc -L /usr/powerpc-linux-gnu"
+qemu_powerpc64="qemu-ppc64 -L /usr/powerpc64-linux-gnu"
 qemu_powerpc64le="qemu-ppc64le -L /usr/powerpc64le-linux-gnu"
 qemu_riscv64="qemu-riscv64 -L /usr/riscv64-linux-gnu"
 qemu_s390x="qemu-s390x -L /usr/s390x-linux-gnu"
@@ -109,6 +110,13 @@ case $target in
     export CFLAGS_powerpc_unknown_linux_gnu="--sysroot=/usr/powerpc-linux-gnu"
     export CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc
     export CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER="$qemu_powerpc"
+    ;;
+  powerpc64-unknown-linux-gnu)
+    export CC_powerpc64_unknown_linux_gnu=clang-$llvm_version
+    export AR_powerpc64_unknown_linux_gnu=llvm-ar-$llvm_version
+    export CFLAGS_powerpc64_unknown_linux_gnu="--sysroot=/usr/powerpc64-linux-gnu"
+    export CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-linux-gnu-gcc
+    export CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER="$qemu_powerpc64"
     ;;
   powerpc64le-unknown-linux-gnu)
     export CC_powerpc64le_unknown_linux_gnu=clang-$llvm_version

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -98,6 +98,13 @@ case $target in
     libc6-dev-powerpc-cross \
     qemu-user
   ;;
+--target=powerpc64-unknown-linux-gnu)
+  use_clang=1
+  install_packages \
+    gcc-powerpc64-linux-gnu \
+    libc6-dev-ppc64-cross \
+    qemu-user
+  ;;
 --target=powerpc64le-unknown-linux-gnu)
   use_clang=1
   install_packages \


### PR DESCRIPTION
Not added to CI. We need to find a better solution for supporting PowerPC (and s390x and other less-common archs) in CI.