### PR TITLE
Add apple tvos support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -279,7 +279,7 @@ const LINUX_ABI: &[&str] = &[
 
 /// Operating systems that have the same ABI as macOS on every architecture
 /// mentioned in `ASM_TARGETS`.
-const MACOS_ABI: &[&str] = &["ios", "macos"];
+const MACOS_ABI: &[&str] = &["ios", "macos", "tvos"];
 
 const WINDOWS: &str = "windows";
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -131,6 +131,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "haiku",
     target_os = "illumos",
     target_os = "ios",
+    target_os = "tvos",
     target_os = "linux",
     target_os = "macos",
     target_os = "netbsd",


### PR DESCRIPTION
This PR allows using ring lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):

- Apple tvOS on aarch64
- Apple tvOS Simulator on x86_64