### PR TITLE
Fix powerpc64 detection

### DIFF
--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -43,11 +43,10 @@
 #elif defined(__MIPSEL__) && defined(__LP64__)
 #define OPENSSL_64_BIT
 #define OPENSSL_MIPS64
+#elif defined(__PPC64__) || defined(__powerpc64__)
+#define OPENSSL_64_BIT
 #elif (defined(__PPC__) || defined(__powerpc__)) && defined(_BIG_ENDIAN)
 #define OPENSSL_32_BIT
-#elif (defined(__PPC64__) || defined(__powerpc64__)) && \
-      (defined(_LITTLE_ENDIAN) || defined(_BIG_ENDIAN))
-#define OPENSSL_64_BIT
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 8
 #define OPENSSL_64_BIT
 #define OPENSSL_RISCV64


### PR DESCRIPTION
Both powerpc64 and powerpc define `__powerpc__`. Also remove endianness check for powerpc64* since it's not necessary.