### PR TITLE
CI: Remove s390x and powerpc64le from `test` matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,9 +181,7 @@ jobs:
           - i686-unknown-linux-gnu
           - i686-unknown-linux-musl
           - powerpc-unknown-linux-gnu
-          - powerpc64le-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
-          - s390x-unknown-linux-gnu
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -254,13 +252,7 @@ jobs:
           - target: powerpc-unknown-linux-gnu
             host_os: ubuntu-22.04
 
-          - target: powerpc64le-unknown-linux-gnu
-            host_os: ubuntu-22.04
-
           - target: riscv64gc-unknown-linux-gnu
-            host_os: ubuntu-22.04
-
-          - target: s390x-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: x86_64-pc-windows-gnu


### PR DESCRIPTION
They are still in `coverage`.