### PR TITLE
CI: Use `fail-fast: false` for coverage jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,7 @@ jobs:
     runs-on: ${{ matrix.host_os }}
 
     strategy:
+      fail-fast: false
       matrix:
         features:
           # Enable all the library features so we can measure all the coverage.


### PR DESCRIPTION
Frequently lately one coverage job has been failing per job. Instead of re-running the whole matrix again, make it so we just need to run the (usually) one job that failed.