### PR TITLE
CI: Improve feature testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,9 +357,7 @@ jobs:
       matrix:
         features:
           - --no-default-features
-          - --no-default-features --features=alloc
-          - --no-default-features --features=dev_urandom_fallback
-          - --all-features
+          - --features=std,slow_tests
 
         target:
           - aarch64-unknown-linux-musl
@@ -509,7 +507,7 @@ jobs:
           # unuseful, or even counterproductive, for coverage testing.
           # `slow_tests` is slow and it is running code that is already intended
           # to be covered without it being enabled.
-          - --features=alloc,dev_urandom_fallback,std
+          - --features=std
 
         # TODO: targets
         target:


### PR DESCRIPTION
`dev_urandom_fallback` presently does nothing, so don't bother adding it as a matrix dimension.

Because `dev_urandom_fallback` does nothing,
`--no-default-features --features=alloc` is effectively the same as the default feature set, so don't add it as a matrix dimension.

`--all-features` is no longer appropriate after the ARM hardware feature disabling features were added, so replace it with what we really want, `--features=std,slow_tests`.

In the coverage section, `--features=alloc,dev_urandom_fallback,std` is the same as `--features=std` since `alloc and `urandom_fallback` are default features.