### PR TITLE
Tests: Remove superfluous uses of `libstd` in tests.

### DIFF
--- a/bench/aead.rs
+++ b/bench/aead.rs
@@ -120,7 +120,7 @@ macro_rules! bench {
                     in_out
                 };
 
-                let num_batches = (std::cmp::max(1, 8192 / ciphertext.len()) * 10) as u64;
+                let num_batches = (core::cmp::max(1, 8192 / ciphertext.len()) * 10) as u64;
 
                 c.bench_function(
                     &function_bench_name!($benchmark_name, $algorithm, open),

--- a/src/arithmetic/montgomery.rs
+++ b/src/arithmetic/montgomery.rs
@@ -226,12 +226,16 @@ mod tests {
         ];
 
         for (i, (r_input, a, w, expected_retval, expected_r)) in TEST_CASES.iter().enumerate() {
-            extern crate std;
-            let mut r = std::vec::Vec::from(*r_input);
+            let mut r = [0; super::super::BIGINT_MODULUS_MAX_LIMBS];
+            let r = {
+                let r = &mut r[..r_input.len()];
+                r.copy_from_slice(r_input);
+                r
+            };
             assert_eq!(r.len(), a.len()); // Sanity check
             let actual_retval =
                 unsafe { limbs_mul_add_limb(r.as_mut_ptr(), a.as_ptr(), *w, a.len()) };
-            assert_eq!(&r, expected_r, "{}: {:x?} != {:x?}", i, &r[..], expected_r);
+            assert_eq!(&r, expected_r, "{}: {:x?} != {:x?}", i, r, expected_r);
             assert_eq!(
                 actual_retval, *expected_retval,
                 "{}: {:x?} != {:x?}",


### PR DESCRIPTION
These tests don't require libstd functionality, so don't use libstd.