### PR TITLE
build.rs: Remove `-pedantic-errors` from compiler configuration.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -111,7 +111,6 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
         static NON_MSVC_FLAGS: &[&str] = &[
             "-std=c1x", // GCC 4.6 requires "c1x" instead of "c11"
             "-pedantic",
-            "-pedantic-errors",
             "-Wall",
             "-Wextra",
             "-Wbad-function-cast",


### PR DESCRIPTION
Our policy is to set warnings-as-errors only when buildingt from Git, not when building from a packaged release. This flag is another aspect of warnings-as-errors.