### PR TITLE
Curve25519: Conservatively force noinline on ADX code paths.

### DIFF
--- a/third_party/fiat/curve25519_64_adx.h
+++ b/third_party/fiat/curve25519_64_adx.h
@@ -464,6 +464,7 @@ static void fe4_invert(fe4 out, const fe4 z) {
   fe4_mul(out, t1, t0);
 }
 
+__attribute__((noinline)) // https://github.com/rust-lang/rust/issues/116573
 __attribute__((target("adx,bmi2")))
 void x25519_scalar_mult_adx(uint8_t out[32], const uint8_t scalar[32],
                             const uint8_t point[32]) {
@@ -640,6 +641,7 @@ static inline void table_select_4(ge_precomp_4 *t, const int pos,
 //
 // Preconditions:
 //   a[31] <= 127
+__attribute__((noinline)) // https://github.com/rust-lang/rust/issues/116573
 __attribute__((target("adx,bmi2")))
 void x25519_ge_scalarmult_base_adx(uint8_t h[4][32], const uint8_t a[32]) {
   signed char e[64];


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/116573.