### PR TITLE
Use `CRYPTO_memcmp` name the same as BoringSSL.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -915,6 +915,7 @@ fn prefix_all_symbols(pp: char, prefix_prefix: &str, prefix: &str) -> String {
     ];
 
     static SYMBOLS_TO_PREFIX: &[&str] = &[
+        "CRYPTO_memcmp",
         "CRYPTO_poly1305_finish",
         "CRYPTO_poly1305_finish_neon",
         "CRYPTO_poly1305_init",
@@ -939,7 +940,6 @@ fn prefix_all_symbols(pp: char, prefix_prefix: &str, prefix: &str) -> String {
         "OPENSSL_armcap_P",
         "OPENSSL_cpuid_setup",
         "OPENSSL_ia32cap_P",
-        "OPENSSL_memcmp",
         "aes_hw_ctr32_encrypt_blocks",
         "aes_hw_encrypt",
         "aes_hw_set_encrypt_key",

--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -401,7 +401,7 @@ static int fe_isnonzero(const fe_loose *f) {
   fe_tobytes(s, &tight);
 
   static const uint8_t zero[32] = {0};
-  return OPENSSL_memcmp(s, zero, sizeof(zero)) != 0;
+  return CRYPTO_memcmp(s, zero, sizeof(zero)) != 0;
 }
 
 // return 1 if f is in {1,3,5,...,q-2}

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -57,10 +57,11 @@
 #include <ring-core/mem.h>
 #include "internal.h"
 
-int OPENSSL_memcmp(const void *av, const void *bv, size_t len) {
+int CRYPTO_memcmp(const void *in_a, const void *in_b, size_t len) {
+  const aliasing_uint8_t *a = in_a;
+  const aliasing_uint8_t *b = in_b;
   uint8_t x = 0;
-  const aliasing_uint8_t *a = av;
-  const aliasing_uint8_t *b = bv;
+
   for (size_t i = 0; i < len; i++) {
     x |= a[i] ^ b[i];
   }

--- a/include/ring-core/mem.h
+++ b/include/ring-core/mem.h
@@ -59,11 +59,11 @@
 
 #include <ring-core/base.h>
 
-// OPENSSL_memcmp returns zero iff the |len| bytes at |a| and |b| are equal. It
+// CRYPTO_memcmp returns zero iff the |len| bytes at |a| and |b| are equal. It
 // takes an amount of time dependent on |len|, but independent of the contents
 // of |a| and |b|. Unlike memcmp, it cannot be used to put elements into a
 // defined order as the return value when a != b is undefined, other than to be
 // non-zero.
-OPENSSL_EXPORT int OPENSSL_memcmp(const void *a, const void *b, size_t len);
+OPENSSL_EXPORT int CRYPTO_memcmp(const void *a, const void *b, size_t len);
 
 #endif  // OPENSSL_HEADER_MEM_H

--- a/src/constant_time.rs
+++ b/src/constant_time.rs
@@ -24,7 +24,7 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<(), error::Unspecif
     if a.len() != b.len() {
         return Err(error::Unspecified);
     }
-    let result = unsafe { OPENSSL_memcmp(a.as_ptr(), b.as_ptr(), a.len()) };
+    let result = unsafe { CRYPTO_memcmp(a.as_ptr(), b.as_ptr(), a.len()) };
     match result {
         0 => Ok(()),
         _ => Err(error::Unspecified),
@@ -32,7 +32,7 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<(), error::Unspecif
 }
 
 prefixed_extern! {
-    fn OPENSSL_memcmp(a: *const u8, b: *const u8, len: c::size_t) -> c::int;
+    fn CRYPTO_memcmp(a: *const u8, b: *const u8, len: c::size_t) -> c::int;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
*ring* defined a function named `OPENSSL_memcmp` that did what `CRYPTO_memcmp` does in BoringSSL, and BoringSSL has a different function called `OPENSSL_memcmp`. *ring* doesn't need `OPENSSL_memcmp` so sync the `CRYPTO_memcmp` stuff with BoringSSL.

This eliminates unnecessary differences from BoringSSL.