### PR TITLE
Remove `LittleEndian` usage from Poly1305 and delete `LittleEndian`.

### DIFF
--- a/src/endian.rs
+++ b/src/endian.rs
@@ -121,11 +121,8 @@ macro_rules! impl_endian {
 }
 
 define_endian!(BigEndian);
-define_endian!(LittleEndian);
 impl_endian!(BigEndian, u32, to_be, from_be, 4);
 impl_endian!(BigEndian, u64, to_be, from_be, 8);
-impl_endian!(LittleEndian, u32, to_le, from_le, 4);
-impl_endian!(LittleEndian, u64, to_le, from_le, 8);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This is a step towards eliminating `unsafe` usage in `ring::endian` by eliminating one use of `FromByteArray::from_byte_array` which contains one line of `unsafe` code.

Since this is the only usage of `LittleEndian`, it is removed completely.