### PR TITLE
NFC: Safety: Remove `endian::FromByteArray`.

### DIFF
--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use crate::endian::*;
+use crate::{endian::*, polyfill::ChunksFixed};
 use core::ops::{BitXor, BitXorAssign};
 
 #[repr(transparent)]
@@ -79,7 +79,8 @@ impl BitXor for Block {
 impl From<&'_ [u8; BLOCK_LEN]> for Block {
     #[inline]
     fn from(bytes: &[u8; BLOCK_LEN]) -> Self {
-        Self(FromByteArray::from_byte_array(bytes))
+        let bytes: &[[u8; BLOCK_LEN / 2]; 2] = bytes.chunks_fixed();
+        Self(bytes.map(Into::into))
     }
 }
 

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -17,12 +17,6 @@ pub trait ArrayEncoding<T> {
     fn as_byte_array(&self) -> &T;
 }
 
-/// Work around the inability to implement `from` for arrays of `Encoding`s
-/// due to the coherence rules.
-pub trait FromByteArray<T> {
-    fn from_byte_array(a: &T) -> Self;
-}
-
 macro_rules! define_endian {
     ($endian:ident) => {
         #[derive(Clone, Copy)]
@@ -41,19 +35,6 @@ macro_rules! define_endian {
     };
 }
 
-macro_rules! impl_from_byte_array {
-    ($endian:ident, $base:ident, $elems:expr) => {
-        impl FromByteArray<[u8; $elems * core::mem::size_of::<$base>()]>
-            for [$endian<$base>; $elems]
-        {
-            #[inline]
-            fn from_byte_array(a: &[u8; $elems * core::mem::size_of::<$base>()]) -> Self {
-                unsafe { core::mem::transmute_copy(a) }
-            }
-        }
-    };
-}
-
 macro_rules! impl_array_encoding {
     ($endian:ident, $base:ident, $elems:expr) => {
         impl ArrayEncoding<[u8; $elems * core::mem::size_of::<$base>()]>
@@ -66,8 +47,6 @@ macro_rules! impl_array_encoding {
                 unsafe { &*as_bytes_ptr }
             }
         }
-
-        impl_from_byte_array!($endian, $base, $elems);
     };
 }
 


### PR DESCRIPTION
Remove one `unsafe` from `ring::endian` by completely removing `FromByteArray`.