### PR TITLE
Remove `LittleEndian` usage from Poly1305 and delete `LittleEndian`.

### DIFF
--- a/src/endian.rs
+++ b/src/endian.rs
@@ -121,11 +121,8 @@ macro_rules! impl_endian {
 }
 
 define_endian!(BigEndian);
-define_endian!(LittleEndian);
 impl_endian!(BigEndian, u32, to_be, from_be, 4);
 impl_endian!(BigEndian, u64, to_be, from_be, 8);
-impl_endian!(LittleEndian, u32, to_le, from_le, 4);
-impl_endian!(LittleEndian, u64, to_le, from_le, 8);
 
 #[cfg(test)]
 mod tests {

--- a/src/polyfill/array_flatten.rs
+++ b/src/polyfill/array_flatten.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Brian Smith.
+// Copyright 2023 Brian Smith.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,36 +12,11 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-//! Polyfills for functionality that will (hopefully) be added to Rust's
-//! standard library soon.
-
+/// Returns the flattened form of `a`
 #[inline(always)]
-pub const fn u64_from_usize(x: usize) -> u64 {
-    x as u64
+pub fn array_flatten<T>(a: [[T; 8]; 2]) -> [T; 16] {
+    let [[a0, a1, a2, a3, a4, a5, a6, a7], [b0, b1, b2, b3, b4, b5, b6, b7]] = a;
+    [
+        a0, a1, a2, a3, a4, a5, a6, a7, b0, b1, b2, b3, b4, b5, b6, b7,
+    ]
 }
-
-pub fn usize_from_u32(x: u32) -> usize {
-    x as usize
-}
-
-#[macro_use]
-mod chunks_fixed;
-
-mod array_flat_map;
-mod array_flatten;
-
-#[cfg(feature = "alloc")]
-mod leading_zeros_skipped;
-
-#[cfg(test)]
-mod test;
-
-mod unwrap_const;
-
-pub use self::{
-    array_flat_map::ArrayFlatMap, array_flatten::array_flatten, chunks_fixed::*,
-    unwrap_const::unwrap_const,
-};
-
-#[cfg(feature = "alloc")]
-pub use leading_zeros_skipped::LeadingZerosStripped;


### PR DESCRIPTION
This is a step towards eliminating `unsafe` usage in `ring::endian` by eliminating one use of `ArrayEncoding::as_byte_array`.

Since this is the only usage of `LittleEndian`, it is removed completely.

This simple `array_flatten` polyfill will be useful for multiple improvements towards eliminating the unsafe code in `endian`.