### PR TITLE
AES-GCM: Move `u64` <-> `Block` conversions out of `Block` and into callers

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -17,7 +17,10 @@ use super::{
     block::{Block, BLOCK_LEN},
     gcm, shift, Aad, Nonce, Tag,
 };
-use crate::{aead, cpu, error, polyfill};
+use crate::{
+    aead, cpu, error,
+    polyfill::{self, array_flatten},
+};
 use core::ops::RangeFrom;
 
 /// AES-128 in GCM mode with 128-bit tags and 96 bit nonces.
@@ -242,7 +245,9 @@ fn finish(
     // Authenticate the final block containing the input lengths.
     let aad_bits = polyfill::u64_from_usize(aad_len) << 3;
     let ciphertext_bits = polyfill::u64_from_usize(in_out_len) << 3;
-    gcm_ctx.update_block(Block::from([aad_bits, ciphertext_bits]));
+    gcm_ctx.update_block(Block::from(&array_flatten(
+        [aad_bits, ciphertext_bits].map(u64::to_be_bytes),
+    )));
 
     // Finalize the tag and return it.
     gcm_ctx.pre_finish(|pre_tag| {

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -49,13 +49,6 @@ impl From<[u64; 2]> for Block {
     }
 }
 
-impl From<Block> for [u64; 2] {
-    #[inline]
-    fn from(Block(components): Block) -> Self {
-        components.map(Into::into)
-    }
-}
-
 impl BitXorAssign for Block {
     #[inline]
     fn bitxor_assign(&mut self, a: Self) {

--- a/src/aead/block.rs
+++ b/src/aead/block.rs
@@ -42,13 +42,6 @@ impl Block {
     }
 }
 
-impl From<[u64; 2]> for Block {
-    #[inline]
-    fn from(other: [u64; 2]) -> Self {
-        Self([other[0].into(), other[1].into()])
-    }
-}
-
 impl BitXorAssign for Block {
     #[inline]
     fn bitxor_assign(&mut self, a: Self) {

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -16,7 +16,7 @@ use super::{
     block::{Block, BLOCK_LEN},
     Aad,
 };
-use crate::cpu;
+use crate::{cpu, polyfill::ChunksFixed};
 use core::ops::BitXorAssign;
 
 #[cfg(not(target_arch = "aarch64"))]
@@ -30,7 +30,8 @@ pub struct Key {
 
 impl Key {
     pub(super) fn new(h_be: Block, cpu_features: cpu::Features) -> Self {
-        let h: [u64; 2] = h_be.into();
+        let h_be: &[[u8; 8]; 2] = h_be.as_ref().chunks_fixed();
+        let h: [u64; 2] = h_be.map(u64::from_be_bytes);
 
         let mut key = Self {
             h_table: HTable {

--- a/src/aead/gcm/gcm_nohw.rs
+++ b/src/aead/gcm/gcm_nohw.rs
@@ -23,7 +23,7 @@
 // Unlike the BearSSL notes, we use u128 in the 64-bit implementation.
 
 use super::{Block, Xi, BLOCK_LEN};
-use crate::polyfill::ChunksFixed;
+use crate::polyfill::{array_flatten, ChunksFixed};
 
 #[cfg(target_pointer_width = "64")]
 fn gcm_mul64_nohw(a: u64, b: u64) -> (u64, u64) {
@@ -241,5 +241,6 @@ fn with_swapped_xi(Xi(xi): &mut Xi, f: impl FnOnce(&mut [u64; 2])) {
     };
     let mut swapped: [u64; 2] = [unswapped[1], unswapped[0]];
     f(&mut swapped);
-    *xi = Block::from([swapped[1], swapped[0]])
+    let reswapped = [swapped[1], swapped[0]];
+    *xi = Block::from(&array_flatten(reswapped.map(u64::to_be_bytes)))
 }

--- a/src/aead/gcm/gcm_nohw.rs
+++ b/src/aead/gcm/gcm_nohw.rs
@@ -235,7 +235,10 @@ pub(super) fn ghash(xi: &mut Xi, h: super::u128, input: &[[u8; BLOCK_LEN]]) {
 
 #[inline]
 fn with_swapped_xi(Xi(xi): &mut Xi, f: impl FnOnce(&mut [u64; 2])) {
-    let unswapped: [u64; 2] = (*xi).into();
+    let unswapped: [u64; 2] = {
+        let xi: &[[u8; 8]; 2] = xi.as_ref().chunks_fixed();
+        xi.map(u64::from_be_bytes)
+    };
     let mut swapped: [u64; 2] = [unswapped[1], unswapped[0]];
     f(&mut swapped);
     *xi = Block::from([swapped[1], swapped[0]])


### PR DESCRIPTION
These are all steps towards removing the use of `BigEndian<u64>` within `Block`, and thus removing the use of `ring::endian` from `Block`. The new code doesn't use `ring::endian`.