### PR TITLE
AEAD: Remove all use of `ring::endian` and u64 from `Block`.

### DIFF
--- a/src/endian.rs
+++ b/src/endian.rs
@@ -22,16 +22,6 @@ macro_rules! define_endian {
         #[derive(Clone, Copy)]
         #[repr(transparent)]
         pub struct $endian<T>(T);
-
-        impl<T> core::ops::BitXorAssign for $endian<T>
-        where
-            T: core::ops::BitXorAssign,
-        {
-            #[inline(always)]
-            fn bitxor_assign(&mut self, a: Self) {
-                self.0 ^= a.0;
-            }
-        }
     };
 }
 


### PR DESCRIPTION
In particular, eliminate the use of `ArrayEncoding::as_byte_array` as we work towards removing that function because it uses `unsafe`.

 Where `Block` is used in parameters to C/assembly code, I verified that the C/assembly code uses `uint8_t *` as the function type (meaning `uint8_t[16]`) in the BoringSSL headers. Until recently the stuff in GCM was using `uint64_t` or a union containing `uint64_t`, which is why block was previously defined in terms of `BigEndian<u64>`.