### PR TITLE
Take some steps toward eliminating the last `unsafe` in `ring::polyfill`

### DIFF
--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -22,7 +22,7 @@ use crate::{
     c, cpu,
     endian::BigEndian,
     error,
-    polyfill::{self, ChunksFixed},
+    polyfill::{self, ArraySplitMap},
 };
 use core::ops::RangeFrom;
 
@@ -327,8 +327,8 @@ pub(super) struct Counter([BigEndian<u32>; 4]);
 
 impl Counter {
     pub fn one(nonce: Nonce) -> Self {
-        let nonce = nonce.as_ref().chunks_fixed();
-        Self([nonce[0].into(), nonce[1].into(), nonce[2].into(), 1.into()])
+        let [n0, n1, n2] = nonce.as_ref().array_split_map(BigEndian::<u32>::from);
+        Self([n0, n1, n2, 1.into()])
     }
 
     pub fn increment(&mut self) -> Iv {

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -193,8 +193,7 @@ pub struct Iv([u32; 4]);
 
 impl Iv {
     fn assume_unique_for_key(value: [u8; 16]) -> Self {
-        let value: &[[u8; 4]; 4] = value.chunks_fixed();
-        Self(value.map(u32::from_le_bytes))
+        Self(value.array_split_map(u32::from_le_bytes))
     }
 
     fn into_counter_for_single_block_less_safe(self) -> Counter {

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -27,6 +27,7 @@ use crate::{cpu, polyfill::ChunksFixed};
 ))]
 mod fallback;
 
+use crate::polyfill::ArraySplitMap;
 use core::ops::RangeFrom;
 
 #[derive(Clone)]
@@ -159,13 +160,8 @@ impl Counter {
     }
 
     fn from_nonce_and_ctr(nonce: Nonce, ctr: u32) -> Self {
-        let nonce = nonce.as_ref().chunks_fixed();
-        Self([
-            ctr,
-            u32::from_le_bytes(nonce[0]),
-            u32::from_le_bytes(nonce[1]),
-            u32::from_le_bytes(nonce[2]),
-        ])
+        let [n0, n1, n2] = nonce.as_ref().array_split_map(u32::from_le_bytes);
+        Self([ctr, n0, n1, n2])
     }
 
     pub fn increment(&mut self) -> Iv {

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -14,7 +14,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{quic::Sample, Nonce};
-use crate::{cpu, polyfill::ChunksFixed};
+use crate::cpu;
 
 #[cfg(any(
     test,
@@ -38,9 +38,8 @@ pub struct Key {
 
 impl Key {
     pub(super) fn new(value: [u8; KEY_LEN], cpu_features: cpu::Features) -> Self {
-        let value: &[[u8; 4]; KEY_LEN / 4] = value.chunks_fixed();
         Self {
-            words: value.map(u32::from_le_bytes),
+            words: value.array_split_map(u32::from_le_bytes),
             cpu_features,
         }
     }

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -16,7 +16,7 @@ use super::{
     block::{Block, BLOCK_LEN},
     Aad,
 };
-use crate::{cpu, polyfill::ChunksFixed};
+use crate::{cpu, polyfill::ArraySplitMap};
 use core::ops::BitXorAssign;
 
 #[cfg(not(target_arch = "aarch64"))]
@@ -30,8 +30,7 @@ pub struct Key {
 
 impl Key {
     pub(super) fn new(h_be: Block, cpu_features: cpu::Features) -> Self {
-        let h_be: &[[u8; 8]; 2] = h_be.as_ref().chunks_fixed();
-        let h: [u64; 2] = h_be.map(u64::from_be_bytes);
+        let h: [u64; 2] = h_be.as_ref().array_split_map(u64::from_be_bytes);
 
         let mut key = Self {
             h_table: HTable {

--- a/src/polyfill/array_split_map.rs
+++ b/src/polyfill/array_split_map.rs
@@ -27,3 +27,16 @@ impl<I, O> ArraySplitMap<I, O, 4, 3> for [I; 12] {
         ]
     }
 }
+
+impl<I, O> ArraySplitMap<I, O, 4, 4> for [I; 16] {
+    #[inline]
+    fn array_split_map(self, f: impl Fn([I; 4]) -> O) -> [O; 4] {
+        let [a0, a1, a2, a3, b0, b1, b2, b3, c0, c1, c2, c3, d0, d1, d2, d3] = self;
+        [
+            f([a0, a1, a2, a3]),
+            f([b0, b1, b2, b3]),
+            f([c0, c1, c2, c3]),
+            f([d0, d1, d2, d3]),
+        ]
+    }
+}

--- a/src/polyfill/array_split_map.rs
+++ b/src/polyfill/array_split_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Brian Smith.
+// Copyright 2023 Brian Smith.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,37 +12,18 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-//! Polyfills for functionality that will (hopefully) be added to Rust's
-//! standard library soon.
-
-#[inline(always)]
-pub const fn u64_from_usize(x: usize) -> u64 {
-    x as u64
+pub trait ArraySplitMap<I, O, const CN: usize, const ON: usize> {
+    fn array_split_map(self, f: impl Fn([I; CN]) -> O) -> [O; ON];
 }
 
-pub fn usize_from_u32(x: u32) -> usize {
-    x as usize
+impl<I, O> ArraySplitMap<I, O, 4, 3> for [I; 12] {
+    #[inline]
+    fn array_split_map(self, f: impl Fn([I; 4]) -> O) -> [O; 3] {
+        let [a0, a1, a2, a3, b0, b1, b2, b3, c0, c1, c2, c3] = self;
+        [
+            f([a0, a1, a2, a3]),
+            f([b0, b1, b2, b3]),
+            f([c0, c1, c2, c3]),
+        ]
+    }
 }
-
-#[macro_use]
-mod chunks_fixed;
-
-mod array_flat_map;
-mod array_flatten;
-mod array_split_map;
-
-#[cfg(feature = "alloc")]
-mod leading_zeros_skipped;
-
-#[cfg(test)]
-mod test;
-
-mod unwrap_const;
-
-pub use self::{
-    array_flat_map::ArrayFlatMap, array_flatten::ArrayFlatten, array_split_map::ArraySplitMap,
-    chunks_fixed::*, unwrap_const::unwrap_const,
-};
-
-#[cfg(feature = "alloc")]
-pub use leading_zeros_skipped::LeadingZerosStripped;

--- a/src/polyfill/array_split_map.rs
+++ b/src/polyfill/array_split_map.rs
@@ -40,3 +40,32 @@ impl<I, O> ArraySplitMap<I, O, 4, 4> for [I; 16] {
         ]
     }
 }
+
+impl<I, O> ArraySplitMap<I, O, 4, 8> for [I; 32] {
+    #[inline]
+    fn array_split_map(self, f: impl Fn([I; 4]) -> O) -> [O; 8] {
+        let [a0, a1, a2, a3, b0, b1, b2, b3, c0, c1, c2, c3, d0, d1, d2, d3, e0, e1, e2, e3, f0, f1, f2, f3, g0, g1, g2, g3, h0, h1, h2, h3] =
+            self;
+        [
+            f([a0, a1, a2, a3]),
+            f([b0, b1, b2, b3]),
+            f([c0, c1, c2, c3]),
+            f([d0, d1, d2, d3]),
+            f([e0, e1, e2, e3]),
+            f([f0, f1, f2, f3]),
+            f([g0, g1, g2, g3]),
+            f([h0, h1, h2, h3]),
+        ]
+    }
+}
+
+impl<I, O> ArraySplitMap<I, O, 8, 2> for [I; 16] {
+    #[inline]
+    fn array_split_map(self, f: impl Fn([I; 8]) -> O) -> [O; 2] {
+        let [a0, a1, a2, a3, a4, a5, a6, a7, b0, b1, b2, b3, b4, b5, b6, b7] = self;
+        [
+            f([a0, a1, a2, a3, a4, a5, a6, a7]),
+            f([b0, b1, b2, b3, b4, b5, b6, b7]),
+        ]
+    }
+}

--- a/src/polyfill/chunks_fixed.rs
+++ b/src/polyfill/chunks_fixed.rs
@@ -27,7 +27,5 @@ macro_rules! define_chunks_fixed {
 }
 
 // Sorted by the first value, then the second value.
-define_chunks_fixed!(16, 8);
-define_chunks_fixed!(32, 4);
 define_chunks_fixed!(64, 32);
 define_chunks_fixed!(80, 20);

--- a/src/polyfill/chunks_fixed.rs
+++ b/src/polyfill/chunks_fixed.rs
@@ -27,7 +27,6 @@ macro_rules! define_chunks_fixed {
 }
 
 // Sorted by the first value, then the second value.
-define_chunks_fixed!(12, 4);
 define_chunks_fixed!(16, 4);
 define_chunks_fixed!(16, 8);
 define_chunks_fixed!(32, 4);

--- a/src/polyfill/chunks_fixed.rs
+++ b/src/polyfill/chunks_fixed.rs
@@ -27,7 +27,6 @@ macro_rules! define_chunks_fixed {
 }
 
 // Sorted by the first value, then the second value.
-define_chunks_fixed!(16, 4);
 define_chunks_fixed!(16, 8);
 define_chunks_fixed!(32, 4);
 define_chunks_fixed!(64, 32);


### PR DESCRIPTION
Replace a few uses of `ChunksFixed` with a new `ArraySplitMap`. `ArraySplitMap` avoids the need to construct an intermediate array; we would hope the optimizer would handle that, but at least in the past it did not always do so.

The approach here isn't very scalable since the source code of each implementation of `ArraySplitMap`  grows twice as fast as the size of the input array. Maybe we can find a cleverer solution, at least for the larger ones.