### PR TITLE
Bump dependency requirements to what's been tested.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ libc = { version = "0.2.148", default-features = false }
 windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "0.3.37", default-features = false }
 
 [target.'cfg(any(unix, windows))'.dev-dependencies]
 libc = { version = "0.2.148", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ wasm-bindgen-test = { version = "0.3.26", default-features = false }
 libc = { version = "0.2.148", default-features = false }
 
 [build-dependencies]
-cc = { version = "1.0.69", default-features = false }
+cc = { version = "1.0.83", default-features = false }
 
 [features]
 # These features are documented in the top-level module's documentation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ getrandom = { version = "0.2.8" }
 untrusted = { version = "0.9" }
 
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
-spin = { version = "0.9.2", default-features = false, features = ["once"] }
+spin = { version = "0.9.8", default-features = false, features = ["once"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 libc = { version = "0.2.148", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ all-features = true
 name = "ring"
 
 [dependencies]
-getrandom = { version = "0.2.8" }
+getrandom = { version = "0.2.10" }
 untrusted = { version = "0.9" }
 
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ untrusted = { version = "0.9" }
 spin = { version = "0.9.2", default-features = false, features = ["once"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-libc = { version = "0.2.100", default-features = false }
+libc = { version = "0.2.148", default-features = false }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
 windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
@@ -187,7 +187,7 @@ windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_
 wasm-bindgen-test = { version = "0.3.26", default-features = false }
 
 [target.'cfg(any(unix, windows))'.dev-dependencies]
-libc = { version = "0.2.100", default-features = false }
+libc = { version = "0.2.148", default-features = false }
 
 [build-dependencies]
 cc = { version = "1.0.69", default-features = false }


### PR DESCRIPTION
Older versions may work but we've not been testing those old versions.