### PR TITLE
Remove `target-dir` workaround for Clippy cache issues.

### DIFF
--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -19,7 +19,6 @@ IFS=$'\n\t'
 
 export NULL=""
 cargo clippy \
-  --target-dir=target/clippy \
   --all-features --all-targets \
   -- \
   --deny missing_docs \


### PR DESCRIPTION
For a long while this hasn't been needed. See
https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-152