### PR TITLE
NFC: Reduce clippy lint overrides.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -751,7 +751,7 @@ fn asm_srcs(perlasm_src_dsts: Vec<(PathBuf, PathBuf)>) -> Vec<PathBuf> {
         .collect::<Vec<_>>()
 }
 
-fn is_perlasm(path: &PathBuf) -> bool {
+fn is_perlasm(path: &Path) -> bool {
     path.extension().unwrap().to_str().unwrap() == "pl"
 }
 

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -25,15 +25,12 @@ cargo clippy \
   --deny missing_docs \
   --deny warnings \
   --allow clippy::collapsible_if \
-  --allow clippy::derive_partial_eq_without_eq \
   --allow clippy::identity_op \
   --allow clippy::len_without_is_empty \
   --allow clippy::let_unit_value \
-  --allow clippy::many_single_char_names \
   --allow clippy::new_without_default \
   --allow clippy::neg_cmp_op_on_partial_ord \
   --allow clippy::too_many_arguments \
   --allow clippy::type_complexity \
-  --allow clippy::unreadable_literal \
   --allow clippy::upper_case_acronyms \
   $NULL

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -32,5 +32,4 @@ cargo clippy \
   --allow clippy::neg_cmp_op_on_partial_ord \
   --allow clippy::too_many_arguments \
   --allow clippy::type_complexity \
-  --allow clippy::upper_case_acronyms \
   $NULL

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -28,7 +28,6 @@ cargo clippy \
   --allow clippy::derive_partial_eq_without_eq \
   --allow clippy::identity_op \
   --allow clippy::len_without_is_empty \
-  --allow clippy::ptr_arg \
   --allow clippy::let_unit_value \
   --allow clippy::many_single_char_names \
   --allow clippy::new_without_default \

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -366,6 +366,7 @@ impl Iv {
 
 #[repr(C)] // Only so `Key` can be `#[repr(C)]`
 #[derive(Clone, Copy)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Implementation {
     #[cfg(any(
         target_arch = "aarch64",

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -294,6 +294,7 @@ struct ContextInner {
     Htable: HTable,
 }
 
+#[allow(clippy::upper_case_acronyms)]
 enum Implementation {
     #[cfg(any(
         target_arch = "aarch64",

--- a/src/rsa/padding/pss.rs
+++ b/src/rsa/padding/pss.rs
@@ -21,6 +21,7 @@ use crate::{bits, digest, error, rand};
 /// documentation for more details.
 ///
 /// [RFC 3447 Section 8.1]: https://tools.ietf.org/html/rfc3447#section-8.1
+#[allow(clippy::upper_case_acronyms)] // TODO: Until we implement cargo-semver-checks
 #[derive(Debug)]
 pub struct PSS {
     digest_alg: &'static digest::Algorithm,


### PR DESCRIPTION
See individual commits. This is a step towards moving Clippy configuration to clippy.toml.