### PR TITLE
Adapt tests to work for wasm32-wasi and add wasm32-wasi to CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
           - i686-unknown-linux-musl
           - powerpc-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
+          - wasm32-wasi
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -252,6 +253,9 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: wasm32-wasi
             host_os: ubuntu-22.04
 
           - target: x86_64-pc-windows-gnu
@@ -435,7 +439,7 @@ jobs:
 
   # The wasm32-unknown-unknown targets have a different set of feature sets and
   # an additional `webdriver` dimension.
-  test-wasm32:
+  test-wasm32-browser:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,10 +183,10 @@ libc = { version = "0.2.148", default-features = false }
 [target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
 windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.37", default-features = false }
 
-[target.'cfg(any(unix, windows))'.dev-dependencies]
+[target.'cfg(any(unix, windows, target_os = "wasi"))'.dev-dependencies]
 libc = { version = "0.2.148", default-features = false }
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -619,7 +619,7 @@ fn configure_cc(c: &mut cc::Build, target: &Target, include_dir: &Path) {
     // Allow cross-compiling without a target sysroot for these targets.
     //
     // poly1305_vec.c requires <emmintrin.h> which requires <stdlib.h>.
-    if (target.arch == "wasm32" && target.os == "unknown")
+    if (target.arch == "wasm32")
         || (target.os == "linux" && target.is_musl && target.arch != "x86_64")
     {
         if let Ok(compiler) = c.try_get_compiler() {

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -177,6 +177,12 @@ case $target in
     export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner
     export WASM_BINDGEN_TEST_TIMEOUT=60
     ;;
+  wasm32-wasi)
+    # The first two are only needed for when the "wasm_c" feature is enabled.
+    export CC_wasm32_wasi=$WASI_SDK_PATH/bin/clang
+    export AR_wasm32_wasi=$WASI_SDK_PATH/bin/llvm-ar
+    export CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime
+    ;;
   *)
     ;;
 esac

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -179,9 +179,9 @@ case $target in
     ;;
   wasm32-wasi)
     # The first two are only needed for when the "wasm_c" feature is enabled.
-    export CC_wasm32_wasi=$WASI_SDK_PATH/bin/clang
-    export AR_wasm32_wasi=$WASI_SDK_PATH/bin/llvm-ar
-    export CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime
+    export CC_wasm32_wasi=clang-$llvm_version
+    export AR_wasm32_wasi=llvm-ar-$llvm_version
+    export CARGO_TARGET_WASM32_WASI_RUNNER=target/tools/linux-x86_64/wasmtime/wasmtime
     ;;
   *)
     ;;

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -140,6 +140,14 @@ case $target in
   cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner
   use_clang=1
   ;;
+--target=wasm32-wasi)
+  use_clang=1
+  git clone \
+      --branch linux-x86_64 \
+      --depth 1 \
+      https://github.com/briansmith/ring-toolchain \
+      target/tools/linux-x86_64
+  ;;
 --target=*)
   ;;
 esac

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -140,6 +140,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "solaris",
     target_os = "windows",
     target_os = "vita",
+    target_os = "wasi",
     all(
         feature = "wasm32_unknown_unknown_js",
         target_arch = "wasm32",

--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -12,10 +12,10 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 use core::ops::RangeFrom;

--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -48,11 +48,10 @@ macro_rules! test_aead {
             $(
                 #[allow(non_snake_case)]
                 mod $alg { // Provide a separate namespace for each algorithm's test.
-                    #[cfg(not(target_arch = "wasm32"))]
                     use super::super::*;
 
-                    #[cfg(target_arch = "wasm32")]
-                    use super::super::{*, test};
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+                    use wasm_bindgen_test::wasm_bindgen_test as test;
 
                     test_known_answer!(
                         $alg,

--- a/tests/constant_time_tests.rs
+++ b/tests/constant_time_tests.rs
@@ -14,10 +14,10 @@
 
 use ring::{constant_time, error, rand};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 // This logic is loosly based on BoringSSL's `TEST(ConstantTimeTest, MemCmp)`.

--- a/tests/digest_tests.rs
+++ b/tests/digest_tests.rs
@@ -14,10 +14,10 @@
 
 use ring::{digest, test, test_file};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 /// Test vectors from BoringSSL, Go, and other sources.
@@ -79,7 +79,7 @@ mod digest_shavs {
                 use super::{run_known_answer_test, run_monte_carlo_test};
                 use ring::{digest, test_file};
 
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                 use wasm_bindgen_test::wasm_bindgen_test as test;
 
                 #[test]

--- a/tests/ed25519_tests.rs
+++ b/tests/ed25519_tests.rs
@@ -18,10 +18,10 @@ use ring::{
     test, test_file,
 };
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 /// Test vectors from BoringSSL.

--- a/tests/hkdf_tests.rs
+++ b/tests/hkdf_tests.rs
@@ -14,10 +14,10 @@
 
 use ring::{digest, error, hkdf, test, test_file};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/hmac_tests.rs
+++ b/tests/hmac_tests.rs
@@ -14,10 +14,10 @@
 
 use ring::{digest, hmac, test, test_file};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/pbkdf2_tests.rs
+++ b/tests/pbkdf2_tests.rs
@@ -15,10 +15,10 @@
 use core::num::NonZeroU32;
 use ring::{digest, error, pbkdf2, test, test_file};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 /// Test vectors from BoringSSL, Go, and other sources.

--- a/tests/rand_tests.rs
+++ b/tests/rand_tests.rs
@@ -17,10 +17,10 @@ use ring::{
     test,
 };
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/rsa_tests.rs
+++ b/tests/rsa_tests.rs
@@ -22,10 +22,10 @@ use ring::{
     test, test_file,
 };
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]

--- a/tests/signature_tests.rs
+++ b/tests/signature_tests.rs
@@ -1,9 +1,9 @@
 use ring::{signature, test};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]


### PR DESCRIPTION
This is based on PR #1568. See the commit message of the first commit for details. Basically I squashed all the commits together from @JanKaul's PR, removed the changes to `build.rs`, and the GitHub Actions configuration, and rebased onto `main`.

For the CI integration, [ring-toolchain](https://github.com/briansmith/ring-toolchain) was updated to include wasmtime for x86-64 Linux. That is used to install wasmtime in CI.