### PR TITLE
Use small Curve25519 for wasm32 & other non-{aarch64,x86_64}.

### DIFF
--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -240,9 +240,11 @@ static void fe_mul_ltt(fe_loose *h, const fe *f, const fe *g) {
   fe_mul_impl(h->v, f->v, g->v);
 }
 
-// static void fe_mul_llt(fe_loose *h, const fe_loose *f, const fe *g) was
-// removed. This comment is here to make diffs vs. BoringSSL easier to read.
-
+#if defined(OPENSSL_SMALL)
+static void fe_mul_llt(fe_loose *h, const fe_loose *f, const fe *g) {
+  fe_mul_impl(h->v, f->v, g->v);
+}
+#endif
 
 static void fe_mul_ttt(fe *h, const fe *f, const fe *g) {
   fe_mul_impl(h->v, f->v, g->v);

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -152,4 +152,8 @@
 #endif
 #endif  // OPENSSL_ASM_INCOMPATIBLE
 
+#if !defined(OPENSSL_X86_64) && !defined(OPENSSL_AARCH64)
+#define OPENSSL_SMALL
+#endif
+
 #endif  // OPENSSL_HEADER_TARGET_H

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -36,7 +36,6 @@ derive_debug_via_id!(Curve);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CurveID {
-    #[cfg(not(target_arch = "wasm32"))]
     Curve25519,
     P256,
     P384,

--- a/src/ec/curve25519.rs
+++ b/src/ec/curve25519.rs
@@ -16,7 +16,6 @@
 
 pub mod ed25519;
 
-#[cfg(not(target_arch = "wasm32"))]
 pub mod x25519;
 
 mod ops;

--- a/src/ec/suite_b.rs
+++ b/src/ec/suite_b.rs
@@ -229,7 +229,6 @@ pub(crate) fn key_pair_from_bytes(
 
 pub mod curve;
 
-#[cfg(not(target_arch = "wasm32"))]
 pub mod ecdh;
 
 pub mod ecdsa;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@ mod polyfill;
 
 pub mod aead;
 
-#[cfg(not(target_arch = "wasm32"))]
 pub mod agreement;
 
 mod bits;

--- a/tests/agreement_tests.rs
+++ b/tests/agreement_tests.rs
@@ -12,7 +12,11 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(not(target_arch = "wasm32"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
 
 extern crate alloc;
 


### PR DESCRIPTION
Enable `ring::agreement` for wasm32 targets using the small implementation of Curve25519.

Use the small Curve25519 implementation of Curve25519 (and P-256) for all targets except for Aarch64 and x86-64.

Besides being smaller, the small implementations are likely more resistant to compiler-introduced side-channels, which is especially important for the wasm32 virtual machine and other targets that we don't QA as thoroughly as AAarch64 and x86-64.

Bring in the previously-removed definition of `fe_mul_llt` from BoringSSL as of commit
8d71d244c0debac4079beeb02b5802fde59b94bd.