### PR TITLE
Add Windows ARM32 (`thumbv7a-pc-windows-msvc`/`thumbv7a-uwp-windows-msvc`) support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -152,13 +152,6 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/wd4820", // C4820: <struct>: <n> bytes padding added after <name>
             "/wd5045", /* C5045: Compiler will insert Spectre mitigation for memory load if
                         * /Qspectre switch specified */
-            "/wd4163", // C4163: '_addcarry_u32': not available as an intrinsic function
-            "/wd4013", // C4013: '_addcarry_u32' undefined; assuming extern returning int
-            "/wd4242", // C4242: '=': conversion from 'int' to 'Carry', possible loss of data
-            "/wd4244", // C4244: '=': conversion from 'int' to 'Carry', possible loss of data
-            "/wd4068", // C4068: unknown pragma 'GCC'
-            "/wd4146", // C4146: unary minus operator applied to unsigned type, result still unsigned
-            "/wd4132", // C4132: 'zero': const object should be initialized
         ];
         MSVC_FLAGS
     }

--- a/build.rs
+++ b/build.rs
@@ -82,6 +82,7 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[ARM], "crypto/chacha/asm/chacha-armv4.pl"),
     (&[ARM], "crypto/curve25519/asm/x25519-asm-arm.S"),
     (&[ARM], "crypto/fipsmodule/modes/asm/ghash-armv4.pl"),
+    (&[ARM], "crypto/poly1305/poly1305_arm.c"),
     (&[ARM], "crypto/poly1305/poly1305.c"), // For Windows ARM32 only
     (&[ARM], "crypto/poly1305/poly1305_arm_asm.S"),
     (&[ARM], "crypto/fipsmodule/sha/asm/sha256-armv4.pl"),

--- a/build.rs
+++ b/build.rs
@@ -152,6 +152,13 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/wd4820", // C4820: <struct>: <n> bytes padding added after <name>
             "/wd5045", /* C5045: Compiler will insert Spectre mitigation for memory load if
                         * /Qspectre switch specified */
+            "/wd4163", // C4163: '_addcarry_u32': not available as an intrinsic function
+            "/wd4013", // C4013: '_addcarry_u32' undefined; assuming extern returning int
+            "/wd4242", // C4242: '=': conversion from 'int' to 'Carry', possible loss of data
+            "/wd4244", // C4244: '=': conversion from 'int' to 'Carry', possible loss of data
+            "/wd4068", // C4068: unknown pragma 'GCC'
+            "/wd4146", // C4146: unary minus operator applied to unsigned type, result still unsigned
+            "/wd4132", // C4132: 'zero': const object should be initialized
         ];
         MSVC_FLAGS
     }
@@ -223,6 +230,13 @@ const ASM_TARGETS: &[AsmTarget] = &[
         asm_extension: "S",
         preassemble: false,
     },
+    AsmTarget {
+        oss: &[WINDOWS],
+        arch: "arm",
+        perlasm_format: "win64",
+        asm_extension: "S",
+        preassemble: false,
+    }
 ];
 
 struct AsmTarget {
@@ -576,7 +590,10 @@ fn obj_path(out_dir: &Path, src: &Path) -> PathBuf {
 
 fn configure_cc(c: &mut cc::Build, target: &Target, include_dir: &Path) {
     // FIXME: On Windows AArch64 we currently must use Clang to compile C code
-    if target.os == WINDOWS && target.arch == AARCH64 && !c.get_compiler().is_like_clang() {
+    if target.os == WINDOWS
+        && (target.arch == AARCH64 || target.arch == ARM)
+        && !c.get_compiler().is_like_clang()
+    {
         let _ = c.compiler("clang");
     }
 
@@ -619,7 +636,7 @@ fn configure_cc(c: &mut cc::Build, target: &Target, include_dir: &Path) {
     }
 }
 
-/// Assembles the assemply language source `file` into the object file
+/// Assembles the assembly language source `file` into the object file
 /// `out_file`.
 fn cc_asm(b: &cc::Build, file: &Path, out_file: &Path) -> Command {
     let cc = b.get_compiler();

--- a/crypto/perlasm/arm-xlate.pl
+++ b/crypto/perlasm/arm-xlate.pl
@@ -31,7 +31,7 @@ my $fpu = sub {
 };
 my $hidden = sub {
     if ($flavour =~ /ios/)	{ ".private_extern\t".join(',',@_); }
-    elsif ($flavour =~ /win64/) { ""; }
+    elsif ($flavour =~ /win/) { ""; }
     else			{ ".hidden\t".join(',',@_); }
 };
 my $comm = sub {

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -146,7 +146,7 @@ impl Key {
         match detect_implementation(cpu_features) {
             #[cfg(any(
                 target_arch = "aarch64",
-                target_arch = "arm",
+                all(target_arch = "arm", not(target_os = "windows")),
                 target_arch = "x86_64",
                 target_arch = "x86"
             ))]
@@ -181,7 +181,7 @@ impl Key {
         match detect_implementation(self.cpu_features) {
             #[cfg(any(
                 target_arch = "aarch64",
-                target_arch = "arm",
+                all(target_arch = "arm", not(target_os = "windows")),
                 target_arch = "x86_64",
                 target_arch = "x86"
             ))]
@@ -220,7 +220,7 @@ impl Key {
         match detect_implementation(self.cpu_features) {
             #[cfg(any(
                 target_arch = "aarch64",
-                target_arch = "arm",
+                all(target_arch = "arm", not(target_os = "windows")),
                 target_arch = "x86_64",
                 target_arch = "x86"
             ))]
@@ -370,7 +370,7 @@ impl Iv {
 pub enum Implementation {
     #[cfg(any(
         target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "arm", not(target_os = "windows")),
         target_arch = "x86_64",
         target_arch = "x86"
     ))]
@@ -401,7 +401,7 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
 
     #[cfg(any(
         target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "arm", not(target_os = "windows")),
         target_arch = "x86_64",
         target_arch = "x86"
     ))]

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -53,7 +53,7 @@ impl Key {
 
             #[cfg(any(
                 target_arch = "aarch64",
-                target_arch = "arm",
+                all(target_arch = "arm", not(target_os = "windows")),
                 target_arch = "x86_64",
                 target_arch = "x86"
             ))]
@@ -154,7 +154,7 @@ impl Context {
 
             #[cfg(any(
                 target_arch = "aarch64",
-                target_arch = "arm",
+                all(target_arch = "arm", not(target_os = "windows")),
                 target_arch = "x86_64",
                 target_arch = "x86"
             ))]
@@ -206,7 +206,7 @@ impl Context {
         match detect_implementation(self.cpu_features) {
             #[cfg(any(
                 target_arch = "aarch64",
-                target_arch = "arm",
+                all(target_arch = "arm", not(target_os = "windows")),
                 target_arch = "x86_64",
                 target_arch = "x86"
             ))]
@@ -298,7 +298,7 @@ struct ContextInner {
 enum Implementation {
     #[cfg(any(
         target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "arm", not(target_os = "windows")),
         target_arch = "x86_64",
         target_arch = "x86"
     ))]
@@ -324,7 +324,7 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
 
     #[cfg(any(
         target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "arm", not(target_os = "windows")),
         target_arch = "x86_64",
         target_arch = "x86"
     ))]

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -60,7 +60,7 @@ macro_rules! dispatch {
       ( $( $a:expr ),+ ) ) => {
         match () {
             // Apple's 32-bit ARM ABI is incompatible with the assembly code.
-            #[cfg(all(target_arch = "arm", not(target_vendor = "apple")))]
+            #[cfg(all(target_arch = "arm", not(any(target_vendor = "apple", target_os = "windows"))))]
             () if cpu::arm::NEON.available($features) => {
                 prefixed_extern! {
                     fn $neon_f( $( $p : $t ),+ );

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -122,6 +122,24 @@ fn detect_features() -> u32 {
     features
 }
 
+#[cfg(all(target_os = "windows", target_arch = "arm"))]
+fn detect_features() -> u32 {
+    extern "C" {
+        fn IsProcessorFeaturePresent(ProcessorFeature: u32) -> i32;
+    }
+    const PF_ARM_VFP_32_REGISTERS_AVAILABLE: u32 = 18;
+
+    let mut features = 0;
+
+    let result = unsafe { IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE) };
+
+    if result != 0 {
+        features |= NEON.mask;
+    }
+
+    features
+}
+
 #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
 fn detect_features() -> u32 {
     // We do not need to check for the presence of NEON, as Armv8-A always has it

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -63,7 +63,10 @@ fn x25519_public_from_private(
     let private_key: &[u8; SCALAR_LEN] = private_key.bytes_less_safe().try_into()?;
     let private_key = ops::MaskedScalar::from_bytes_masked(*private_key);
 
-    #[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+    #[cfg(all(
+        not(any(target_os = "ios", target_os = "windows")),
+        target_arch = "arm"
+    ))]
     {
         if cpu::arm::NEON.available(cpu_features) {
             static MONTGOMERY_BASE_POINT: [u8; 32] = [
@@ -109,7 +112,10 @@ fn x25519_ecdh(
         point: &ops::EncodedPoint,
         #[allow(unused_variables)] cpu_features: cpu::Features,
     ) {
-        #[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+        #[cfg(all(
+            not(any(target_os = "ios", target_os = "windows")),
+            target_arch = "arm"
+        ))]
         {
             if cpu::arm::NEON.available(cpu_features) {
                 return x25519_neon(out, scalar, point);
@@ -158,7 +164,10 @@ fn x25519_ecdh(
     Ok(())
 }
 
-#[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+#[cfg(all(
+    not(any(target_os = "ios", target_os = "windows")),
+    target_arch = "arm"
+))]
 fn x25519_neon(out: &mut ops::EncodedPoint, scalar: &ops::MaskedScalar, point: &ops::EncodedPoint) {
     prefixed_extern! {
         fn x25519_NEON(


### PR DESCRIPTION
- Similar to ARM64, clang is used as the compiler for C and assembly
- Target platform does not support AES instruction set, using fallback implementation
- BoringSSL-provided `x25519` and `poly1305` assembly implementation for ARM do not support Windows, using fallback implementation
Xref: #960 