### PR TITLE
third_party/fiat: replace `memcpy` with `OPENSSL_memcpy`

### DIFF
--- a/third_party/fiat/curve25519_64_adx.h
+++ b/third_party/fiat/curve25519_64_adx.h
@@ -1,7 +1,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <immintrin.h>
-#include <string.h>
 
 typedef uint64_t fe4[4];
 typedef uint8_t fiat_uint1;
@@ -469,7 +468,7 @@ __attribute__((target("adx,bmi2")))
 void x25519_scalar_mult_adx(uint8_t out[32], const uint8_t scalar[32],
                             const uint8_t point[32]) {
   uint8_t e[32];
-  memcpy(e, scalar, 32);
+  OPENSSL_memcpy(e, scalar, 32);
   e[0] &= 248;
   e[31] &= 127;
   e[31] |= 64;


### PR DESCRIPTION
Align with the other use of `OPENSSL_memcpy` in `curve25519_64_adx.h`. `string.h` will no longer be needed.

Closes https://github.com/briansmith/ring/issues/1777