### PR TITLE
Enable getrandom for AIX

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -125,6 +125,7 @@ impl crate::sealed::Sealed for SystemRandom {}
 // system's) CSPRNG. Avoid using it on targets where it uses the `rdrand`
 // implementation.
 #[cfg(any(
+    target_os = "aix",
     target_os = "android",
     target_os = "dragonfly",
     target_os = "freebsd",


### PR DESCRIPTION
getrandom crate already supports AIX.