### PR TITLE
Extend elliptic curve code generator to generate C code boilerplate.

### DIFF
--- a/crypto/fipsmodule/ec/gfp_p256.c
+++ b/crypto/fipsmodule/ec/gfp_p256.c
@@ -24,10 +24,12 @@ typedef Limb Scalar[P256_LIMBS];
 #include "../bn/internal.h"
 
 static const BN_ULONG N[P256_LIMBS] = {
-  TOBN(0xf3b9cac2, 0xfc632551),
-  TOBN(0xbce6faad, 0xa7179e84),
-  TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0)
+#if defined(OPENSSL_64_BIT)
+  0xf3b9cac2fc632551, 0xbce6faada7179e84, 0xffffffffffffffff, 0xffffffff00000000
+#else
+  0xfc632551, 0xf3b9cac2, 0xa7179e84, 0xbce6faad, 0xffffffff, 0xffffffff, 0,
+  0xffffffff
+#endif
 };
 
 static const BN_ULONG N_N0[] = {

--- a/crypto/fipsmodule/ec/gfp_p256.c
+++ b/crypto/fipsmodule/ec/gfp_p256.c
@@ -23,17 +23,19 @@ typedef Limb Scalar[P256_LIMBS];
 
 #include "../bn/internal.h"
 
+static const BN_ULONG N[P256_LIMBS] = {
+  TOBN(0xf3b9cac2, 0xfc632551),
+  TOBN(0xbce6faad, 0xa7179e84),
+  TOBN(0xffffffff, 0xffffffff),
+  TOBN(0xffffffff, 0)
+};
+
+static const BN_ULONG N_N0[] = {
+  BN_MONT_CTX_N0(0xccd1c8aa, 0xee00bc4f)
+};
+
 void p256_scalar_mul_mont(ScalarMont r, const ScalarMont a,
                               const ScalarMont b) {
-  static const BN_ULONG N[] = {
-    TOBN(0xf3b9cac2, 0xfc632551),
-    TOBN(0xbce6faad, 0xa7179e84),
-    TOBN(0xffffffff, 0xffffffff),
-    TOBN(0xffffffff, 0x00000000),
-  };
-  static const BN_ULONG N_N0[] = {
-    BN_MONT_CTX_N0(0xccd1c8aa, 0xee00bc4f)
-  };
   /* XXX: Inefficient. TODO: optimize with dedicated multiplication routine. */
   bn_mul_mont(r, a, b, N, N_N0, P256_LIMBS);
 }

--- a/crypto/fipsmodule/ec/gfp_p384.c
+++ b/crypto/fipsmodule/ec/gfp_p384.c
@@ -29,14 +29,13 @@ typedef Limb Elem[P384_LIMBS];
 typedef Limb ScalarMont[P384_LIMBS];
 typedef Limb Scalar[P384_LIMBS];
 
-
 static const BN_ULONG Q[P384_LIMBS] = {
-  TOBN(0x00000000, 0xffffffff),
-  TOBN(0xffffffff, 0x00000000),
+  TOBN(0, 0xffffffff),
+  TOBN(0xffffffff, 0),
   TOBN(0xffffffff, 0xfffffffe),
   TOBN(0xffffffff, 0xffffffff),
   TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0xffffffff),
+  TOBN(0xffffffff, 0xffffffff)
 };
 
 static const BN_ULONG N[P384_LIMBS] = {
@@ -45,15 +44,34 @@ static const BN_ULONG N[P384_LIMBS] = {
   TOBN(0xc7634d81, 0xf4372ddf),
   TOBN(0xffffffff, 0xffffffff),
   TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0xffffffff),
+  TOBN(0xffffffff, 0xffffffff)
 };
-
 
 static const BN_ULONG ONE[P384_LIMBS] = {
-  TOBN(0xffffffff, 1), TOBN(0, 0xffffffff), TOBN(0, 1), TOBN(0, 0), TOBN(0, 0),
+  TOBN(0xffffffff, 1),
+  TOBN(0, 0xffffffff),
+  TOBN(0, 1),
   TOBN(0, 0),
+  TOBN(0, 0),
+  TOBN(0, 0)
 };
 
+static const Elem Q_PLUS_1_SHR_1 = {
+  TOBN(0, 0x80000000),
+  TOBN(0x7fffffff, 0x80000000),
+  TOBN(0xffffffff, 0xffffffff),
+  TOBN(0xffffffff, 0xffffffff),
+  TOBN(0xffffffff, 0xffffffff),
+  TOBN(0x7fffffff, 0xffffffff)
+};
+
+static const BN_ULONG Q_N0[] = {
+  BN_MONT_CTX_N0(1, 1)
+};
+
+static const BN_ULONG N_N0[] = {
+  BN_MONT_CTX_N0(0x6ed46089, 0xe88fdc45)
+};
 
 /* XXX: MSVC for x86 warns when it fails to inline these functions it should
  * probably inline. */
@@ -141,12 +159,6 @@ static void elem_div_by_2(Elem r, const Elem a) {
     carry = new_carry;
   }
 
-  static const Elem Q_PLUS_1_SHR_1 = {
-    TOBN(0x00000000, 0x80000000), TOBN(0x7fffffff, 0x80000000),
-    TOBN(0xffffffff, 0xffffffff), TOBN(0xffffffff, 0xffffffff),
-    TOBN(0xffffffff, 0xffffffff), TOBN(0x7fffffff, 0xffffffff),
-  };
-
   Elem adjusted;
   BN_ULONG carry2 = limbs_add(adjusted, r, Q_PLUS_1_SHR_1, P384_LIMBS);
   dev_assert_secret(carry2 == 0);
@@ -155,9 +167,6 @@ static void elem_div_by_2(Elem r, const Elem a) {
 }
 
 static inline void elem_mul_mont(Elem r, const Elem a, const Elem b) {
-  static const BN_ULONG Q_N0[] = {
-    BN_MONT_CTX_N0(0x1, 0x1)
-  };
   /* XXX: Not (clearly) constant-time; inefficient.*/
   bn_mul_mont(r, a, b, Q, Q_N0, P384_LIMBS);
 }
@@ -203,9 +212,6 @@ void p384_elem_neg(Elem r, const Elem a) {
 
 void p384_scalar_mul_mont(ScalarMont r, const ScalarMont a,
                               const ScalarMont b) {
-  static const BN_ULONG N_N0[] = {
-    BN_MONT_CTX_N0(0x6ed46089, 0xe88fdc45)
-  };
   /* XXX: Inefficient. TODO: Add dedicated multiplication routine. */
   bn_mul_mont(r, a, b, N, N_N0, P384_LIMBS);
 }

--- a/crypto/fipsmodule/ec/gfp_p384.c
+++ b/crypto/fipsmodule/ec/gfp_p384.c
@@ -30,39 +30,41 @@ typedef Limb ScalarMont[P384_LIMBS];
 typedef Limb Scalar[P384_LIMBS];
 
 static const BN_ULONG Q[P384_LIMBS] = {
-  TOBN(0, 0xffffffff),
-  TOBN(0xffffffff, 0),
-  TOBN(0xffffffff, 0xfffffffe),
-  TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0xffffffff)
+#if defined(OPENSSL_64_BIT)
+  0xffffffff, 0xffffffff00000000, 0xfffffffffffffffe, 0xffffffffffffffff,
+  0xffffffffffffffff, 0xffffffffffffffff
+#else
+  0xffffffff, 0, 0, 0xffffffff, 0xfffffffe, 0xffffffff, 0xffffffff, 0xffffffff,
+  0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
+#endif
 };
 
 static const BN_ULONG N[P384_LIMBS] = {
-  TOBN(0xecec196a, 0xccc52973),
-  TOBN(0x581a0db2, 0x48b0a77a),
-  TOBN(0xc7634d81, 0xf4372ddf),
-  TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0xffffffff)
+#if defined(OPENSSL_64_BIT)
+  0xecec196accc52973, 0x581a0db248b0a77a, 0xc7634d81f4372ddf, 0xffffffffffffffff,
+  0xffffffffffffffff, 0xffffffffffffffff
+#else
+  0xccc52973, 0xecec196a, 0x48b0a77a, 0x581a0db2, 0xf4372ddf, 0xc7634d81,
+  0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
+#endif
 };
 
 static const BN_ULONG ONE[P384_LIMBS] = {
-  TOBN(0xffffffff, 1),
-  TOBN(0, 0xffffffff),
-  TOBN(0, 1),
-  TOBN(0, 0),
-  TOBN(0, 0),
-  TOBN(0, 0)
+#if defined(OPENSSL_64_BIT)
+  0xffffffff00000001, 0xffffffff, 1, 0, 0
+#else
+  1, 0xffffffff, 0xffffffff, 0, 1, 0, 0, 0, 0, 0
+#endif
 };
 
 static const Elem Q_PLUS_1_SHR_1 = {
-  TOBN(0, 0x80000000),
-  TOBN(0x7fffffff, 0x80000000),
-  TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0xffffffff),
-  TOBN(0xffffffff, 0xffffffff),
-  TOBN(0x7fffffff, 0xffffffff)
+#if defined(OPENSSL_64_BIT)
+  0x80000000, 0x7fffffff80000000, 0xffffffffffffffff, 0xffffffffffffffff,
+  0xffffffffffffffff, 0x7fffffffffffffff
+#else
+  0x80000000, 0, 0x80000000, 0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+  0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0x7fffffff
+#endif
 };
 
 static const BN_ULONG Q_N0[] = {


### PR DESCRIPTION
Generate some of the C boilerplate, particularly the large constants. The output is written into target/curves/, and can be merged into the actual code in crypto/fipsmodule/ec/ using a two-way merge tool; this is the same as the Rust code generation.

Changes to gfp_p{256,384}.c are due to differences in the generator's output:

* The generator doesn't generate trailing commas in arrays.
* The generator consistently avoids adding leading zeros to hex constants, and consistently format values less than 10 in decimal; the exiting code used a mix of styles.
* The generator wraps arrays consistently; the existing code used a mix of wrapping styles.
* The generator does not nest constants in the functions that need them. This was changed to support future refactorings.
* In order to support P-521, we avoid `TOBN` as it won't work for 32-bit targets for P-521 since there are an odd number of limbs in that case.
