### PR TITLE
Curve25519: Add missing static assertion.

### DIFF
--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -327,6 +327,7 @@ static void fe_copy(fe *h, const fe *f) {
 }
 
 static void fe_copy_lt(fe_loose *h, const fe *f) {
+  OPENSSL_STATIC_ASSERT(sizeof(fe_loose) == sizeof(fe), "fe and fe_loose mismatch");
   fe_limbs_copy(h->v, f->v);
 }
 


### PR DESCRIPTION
Sync with BoringSSL.