### PR TITLE
Include arm_arch.h in crypto/internal.h.

### DIFF
--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -111,6 +111,7 @@
 
 #include <ring-core/base.h> // Must be first.
 
+#include "ring-core/arm_arch.h"
 #include "ring-core/check.h"
 
 #if defined(__clang__)


### PR DESCRIPTION
Do it because BoringSSL does it. BoringSSL has some other headers it includes here but we intentionally do not have them and/or we intentionally do not include them here (string.h and assert.h).