### PR TITLE
Prevent most inappropriate uses of `as` for conversions

### DIFF
--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -49,6 +49,7 @@ fn set_encrypt_key(
     key: &mut AES_KEY,
 ) -> Result<(), error::Unspecified> {
     // Unusually, in this case zero means success and non-zero means failure.
+    #[allow(clippy::cast_possible_truncation)]
     if 0 == unsafe { f(bytes.as_ptr(), key_bits.as_usize_bits() as c::uint, key) } {
         Ok(())
     } else {
@@ -111,6 +112,7 @@ fn ctr32_encrypt_blocks_(
     assert_eq!(in_out_len % BLOCK_LEN, 0);
 
     let blocks = in_out_len / BLOCK_LEN;
+    #[allow(clippy::cast_possible_truncation)]
     let blocks_u32 = blocks as u32;
     assert_eq!(blocks, polyfill::usize_from_u32(blocks_u32));
 

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -114,8 +114,8 @@ fn ctr32_encrypt_blocks_(
     let blocks_u32 = blocks as u32;
     assert_eq!(blocks, polyfill::usize_from_u32(blocks_u32));
 
-    let input = in_out[src].as_ptr() as *const [u8; BLOCK_LEN];
-    let output = in_out.as_mut_ptr() as *mut [u8; BLOCK_LEN];
+    let input = in_out[src].as_ptr().cast::<[u8; BLOCK_LEN]>();
+    let output = in_out.as_mut_ptr().cast::<[u8; BLOCK_LEN]>();
 
     unsafe {
         f(input, output, blocks, key, ctr);

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -272,6 +272,7 @@ mod tests {
             // behavior of ChaCha20 implementation changes dependent on the
             // length of the input.
             for len in 0..=input.len() {
+                #[allow(clippy::cast_possible_truncation)]
                 chacha20_test_case_inner(
                     &key,
                     &nonce,

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -124,7 +124,7 @@ impl Context {
         debug_assert_eq!(input_bytes % BLOCK_LEN, 0);
         debug_assert!(input_bytes > 0);
 
-        let input = input.as_ptr() as *const [u8; BLOCK_LEN];
+        let input = input.as_ptr().cast::<[u8; BLOCK_LEN]>();
         // SAFETY:
         // - `[[u8; BLOCK_LEN]]` has the same bit validity as `[u8]`.
         // - `[[u8; BLOCK_LEN]]` has the same alignment requirement as `[u8]`.

--- a/src/aead/gcm/gcm_nohw.rs
+++ b/src/aead/gcm/gcm_nohw.rs
@@ -27,6 +27,7 @@ use crate::polyfill::ArraySplitMap;
 
 #[cfg(target_pointer_width = "64")]
 fn gcm_mul64_nohw(a: u64, b: u64) -> (u64, u64) {
+    #[allow(clippy::cast_possible_truncation)]
     #[inline(always)]
     fn lo(a: u128) -> u64 {
         a as u64

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -40,7 +40,7 @@ pub(super) extern "C" fn block_data_order(
 ) {
     let state = unsafe { &mut state.as32 };
     let state: &mut State = (&mut state[..CHAINING_WORDS]).try_into().unwrap();
-    let data = data as *const [<W32 as Word>::InputBytes; 16];
+    let data = data.cast::<[<W32 as Word>::InputBytes; 16]>();
     let blocks = unsafe { core::slice::from_raw_parts(data, num) };
     *state = block_data_order_(*state, blocks)
 }

--- a/src/digest/sha2.rs
+++ b/src/digest/sha2.rs
@@ -48,7 +48,7 @@ fn block_data_order<S: Sha2>(
     M: *const u8,
     num: c::size_t,
 ) -> [S; CHAINING_WORDS] {
-    let M = M as *const [S::InputBytes; 16];
+    let M = M.cast::<[S::InputBytes; 16]>();
     let M: &[[S::InputBytes; 16]] = unsafe { core::slice::from_raw_parts(M, num) };
 
     for M in M {

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -14,6 +14,8 @@
 
 //! ECDSA Signatures using the P-256 and P-384 curves.
 
+#![allow(clippy::cast_possible_truncation)] // XXX
+
 use super::digest_scalar::digest_scalar;
 use crate::{
     arithmetic::montgomery::*,

--- a/src/ec/suite_b/ops/p256.rs
+++ b/src/ec/suite_b/ops/p256.rs
@@ -248,6 +248,7 @@ fn p256_scalar_inv_to_mont(a: &Scalar<Unencoded>) -> Scalar<R> {
     //    1011110011100110111110101010110110100111000101111001111010000100
     //    1111001110111001110010101100001011111100011000110010010101001111
 
+    #[allow(clippy::cast_possible_truncation)]
     static REMAINING_WINDOWS: [(u8, u8); 26] = [
         (6, B_101111 as u8),
         (2 + 3, B_111 as u8),

--- a/src/ec/suite_b/ops/p384.rs
+++ b/src/ec/suite_b/ops/p384.rs
@@ -220,6 +220,7 @@ fn p384_scalar_inv_to_mont(a: &Scalar<Unencoded>) -> Scalar<R> {
     //    0101100000011010000011011011001001001000101100001010011101111010
     //    1110110011101100000110010110101011001100110001010010100101110001
 
+    #[allow(clippy::cast_possible_truncation)]
     static REMAINING_WINDOWS: [(u8, u8); 39] = [
         (2, B_11 as u8),
         (3 + 3, B_111 as u8),

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -32,8 +32,9 @@ macro_rules! impl_array_encoding {
         {
             #[inline]
             fn as_byte_array(&self) -> &[u8; $elems * core::mem::size_of::<$base>()] {
-                let as_bytes_ptr =
-                    self.as_ptr() as *const [u8; $elems * core::mem::size_of::<$base>()];
+                let as_bytes_ptr = self
+                    .as_ptr()
+                    .cast::<[u8; $elems * core::mem::size_of::<$base>()]>();
                 unsafe { &*as_bytes_ptr }
             }
         }

--- a/src/io/der_writer.rs
+++ b/src/io/der_writer.rs
@@ -39,6 +39,7 @@ pub(crate) fn write_all(tag: Tag, write_value: &dyn Fn(&mut dyn Accumulator)) ->
     output.into()
 }
 
+#[allow(clippy::cast_possible_truncation)]
 fn write_tlv<F>(output: &mut dyn Accumulator, tag: Tag, write_value: F)
 where
     F: Fn(&mut dyn Accumulator),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,8 @@
     invalid_reference_casting,
     clippy::char_lit_as_u8,
     clippy::fn_to_numeric_cast,
-    clippy::fn_to_numeric_cast_with_truncation
+    clippy::fn_to_numeric_cast_with_truncation,
+    clippy::ptr_as_ptr
 )]
 #![warn(
     clippy::unnecessary_cast,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 #![warn(
     clippy::unnecessary_cast,
     clippy::cast_lossless,
+    clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,20 @@
     unsafe_code
 )]
 #![deny(variant_size_differences)]
-#![forbid(unused_results)]
+#![forbid(
+    unused_results,
+    invalid_reference_casting,
+    clippy::char_lit_as_u8,
+    clippy::fn_to_numeric_cast,
+    clippy::fn_to_numeric_cast_with_truncation
+)]
+#![warn(
+    clippy::unnecessary_cast,
+    clippy::cast_lossless,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
 #![no_std]
 
 #[cfg(feature = "alloc")]

--- a/src/polyfill/chunks_fixed.rs
+++ b/src/polyfill/chunks_fixed.rs
@@ -18,8 +18,8 @@ macro_rules! define_chunks_fixed {
         {
             #[inline(always)]
             fn chunks_fixed(self) -> &'a [[T; $chunk_len]; $chunked_len] {
-                let as_ptr: *const [T; $chunk_len] = self.as_ptr() as *const [T; $chunk_len];
-                let as_ptr = as_ptr as *const [[T; $chunk_len]; $chunked_len];
+                let as_ptr = self.as_ptr().cast::<[T; $chunk_len]>();
+                let as_ptr = as_ptr.cast::<[[T; $chunk_len]; $chunked_len]>();
                 unsafe { &*as_ptr }
             }
         }


### PR DESCRIPTION
See each commit message for details.