### PR TITLE
RSA signature verification: Avoid wasteful key re-serialization.

### DIFF
--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -302,7 +302,7 @@ impl KeyPair {
             cpu_features,
         )?;
 
-        let n = public_key.n().value();
+        let n = public_key.inner().n().value();
 
         // 6.4.1.4.3 says to skip 6.4.1.2.1 Step 2.
 
@@ -323,7 +323,7 @@ impl KeyPair {
         // TODO: First, stop if `p < (√2) * 2**((nBits/2) - 1)`.
         //
         // Second, stop if `p > 2**(nBits/2) - 1`.
-        let half_n_bits = public_key.n().len_bits().half_rounded_up();
+        let half_n_bits = public_key.inner().n().len_bits().half_rounded_up();
         if p_bits != half_n_bits {
             return Err(KeyRejected::inconsistent_components());
         }
@@ -580,7 +580,7 @@ impl KeyPair {
 
         // Use the output buffer as the scratch space for the signature to
         // reduce the required stack space.
-        padding_alg.encode(m_hash, signature, self.public().n().len_bits(), rng)?;
+        padding_alg.encode(m_hash, signature, self.public().inner().n().len_bits(), rng)?;
 
         // RFC 8017 Section 5.1.2: RSADP, using the Chinese Remainder Theorem
         // with Garner's algorithm.
@@ -607,7 +607,7 @@ impl KeyPair {
         // RFC 8017 Section 5.1.2: RSADP, using the Chinese Remainder Theorem
         // with Garner's algorithm.
 
-        let n = self.public.n().value();
+        let n = self.public.inner().n().value();
 
         // Step 1. The value zero is also rejected.
         let base = bigint::Elem::from_be_bytes_padded(untrusted::Input::from(base), n)?;
@@ -648,7 +648,7 @@ impl KeyPair {
         // minimum value, since the relationship of `e` to `d`, `p`, and `q` is
         // not verified during `KeyPair` construction.
         {
-            let verify = self.public.exponentiate_elem(m.clone());
+            let verify = self.public.inner().exponentiate_elem(m.clone());
             bigint::elem_verify_equal_consttime(&verify, &c)?;
         }
 

--- a/src/rsa/public_key_components.rs
+++ b/src/rsa/public_key_components.rs
@@ -45,8 +45,8 @@ where
 {
     fn from(public_key: &PublicKey) -> Self {
         Self {
-            n: public_key.n().be_bytes().collect(),
-            e: public_key.e().be_bytes().collect(),
+            n: public_key.inner().n().be_bytes().collect(),
+            e: public_key.inner().e().be_bytes().collect(),
         }
     }
 }

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -15,7 +15,7 @@
 //! Verification of RSA signatures.
 
 use super::{
-    parse_public_key, PublicExponent, PublicKey, RsaParameters, PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN,
+    parse_public_key, public_key, PublicExponent, RsaParameters, PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN,
 };
 use crate::{bits, cpu, digest, error, sealed, signature};
 
@@ -201,7 +201,7 @@ pub(crate) fn verify_rsa_(
     // exponent value is 2**16 + 1, but it isn't clear if this is just for
     // signing or also for verification. We support exponents of 3 and larger
     // for compatibility with other commonly-used crypto libraries.
-    let key = PublicKey::from_modulus_and_exponent(
+    let key = public_key::Inner::from_modulus_and_exponent(
         n,
         e,
         params.min_bits,


### PR DESCRIPTION
When we added `rsa::PublicKey` we changed the `ring::signature` RSA implementation to construct an `rsa::PublicKey` and then verify the signature using it. Unfortunately for backward compatibility with old uses of `RsaKeyPair`, `rsa::PublicKey` constructor constructs (and allocates) a copy of the ASN.1-serialized public key. This is not acceptable for users who are using `ring::signature` to verify a single signature. Refactor `PublicKey` so that it can be bypassed by the `ring::signature` implementation.

This is a step towards implementing allocation-free RSA signature verification.