### PR TITLE
NFC bigint: Remove `Width`.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -68,13 +68,6 @@ mod private_exponent;
 /// preemptively.)
 pub unsafe trait Prime {}
 
-struct Width<M> {
-    num_limbs: usize,
-
-    /// The modulus *m* that the width originated from.
-    m: PhantomData<M>,
-}
-
 /// A modulus *s* that is smaller than another modulus *l* so every element of
 /// ℤ/sℤ is also an element of ℤ/lℤ.
 ///
@@ -152,10 +145,9 @@ fn from_montgomery_amm<M>(limbs: BoxedLimbs<M>, m: &Modulus<M>) -> Elem<M, Unenc
     debug_assert_eq!(limbs.len(), m.limbs().len());
 
     let mut limbs = limbs;
-    let num_limbs = m.width().num_limbs;
     let mut one = [0; MODULUS_MAX_LIMBS];
     one[0] = 1;
-    let one = &one[..num_limbs]; // assert!(num_limbs <= MODULUS_MAX_LIMBS);
+    let one = &one[..m.limbs().len()];
     limbs_mont_mul(&mut limbs, one, m.limbs(), m.n0(), m.cpu_features());
     Elem {
         limbs,
@@ -1001,10 +993,7 @@ mod tests {
         num_limbs: usize,
     ) -> Elem<M, Unencoded> {
         let value = consume_nonnegative(test_case, name);
-        let mut limbs = BoxedLimbs::zero(Width {
-            num_limbs,
-            m: PhantomData,
-        });
+        let mut limbs = BoxedLimbs::zero(num_limbs);
         limbs[0..value.limbs().len()].copy_from_slice(value.limbs());
         Elem {
             limbs,

--- a/src/arithmetic/bigint/modulus.rs
+++ b/src/arithmetic/bigint/modulus.rs
@@ -18,7 +18,6 @@ use super::{
         n0::N0,
     },
     BoxedLimbs, Elem, Nonnegative, One, PublicModulus, SlightlySmallerModulus, SmallerModulus,
-    Width,
 };
 use crate::{
     bits, cpu, error,
@@ -210,14 +209,9 @@ impl<M> Modulus<M> {
         &self.n0
     }
 
-    #[inline]
-    pub(super) fn width(&self) -> Width<M> {
-        self.limbs.width()
-    }
-
     pub(super) fn zero<E>(&self) -> Elem<M, E> {
         Elem {
-            limbs: BoxedLimbs::zero(self.width()),
+            limbs: BoxedLimbs::zero(self.limbs().len()),
             encoding: PhantomData,
         }
     }
@@ -238,7 +232,7 @@ impl<M> Modulus<M> {
         M: SmallerModulus<L>,
     {
         // TODO: Encode this assertion into the `where` above.
-        assert_eq!(self.width().num_limbs, l.width().num_limbs);
+        assert_eq!(self.limbs().len(), l.limbs().len());
         Elem {
             limbs: BoxedLimbs::new_unchecked(self.limbs.clone().into_limbs()),
             encoding: PhantomData,
@@ -271,12 +265,8 @@ pub(crate) struct PartialModulus<'a, M> {
 impl<M> PartialModulus<'_, M> {
     // TODO: XXX Avoid duplication with `Modulus`.
     pub(super) fn zero(&self) -> Elem<M, R> {
-        let width = Width {
-            num_limbs: self.limbs.len(),
-            m: PhantomData,
-        };
         Elem {
-            limbs: BoxedLimbs::zero(width),
+            limbs: BoxedLimbs::zero(self.limbs.len()),
             encoding: PhantomData,
         }
     }


### PR DESCRIPTION
The original idea of `Width` was that we'd support operatings that worked on multiple same-width but different-modulus values, and/or we'd support splitting a 2N-limb `BoxedLimb` into two N-limb `&[Limb]`, etc. However, as things are now, `Width` doesn't really serve a useful purpose.