### PR TITLE
generate asm symbols for `target_os = "none"` targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -260,6 +260,7 @@ const LINUX_ABI: &[&str] = &[
     "linux",
     "redox",
     "solaris",
+    "none",
 ];
 
 /// Operating systems that have the same ABI as macOS on every architecture


### PR DESCRIPTION
the built-in rustc targets `{x86,x86_64,arm,aarch64}-none` all use the ELF format

fixes #1793 

more context can be found in issue #1793 . I have tested this with the `x86_64-unknown-none` and `aarch64-unknown-none` targets and run the binary on Linux. I plan to test `thumbv7em-none-eabihf` in the future.
