### PR TITLE
bigint: Rename PartialModulus to Modulus, Modulus to OwnedModulusWithOne.

### DIFF
--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -33,8 +33,19 @@ pub struct KeyPair {
     p: PrivatePrime<P>,
     q: PrivatePrime<Q>,
     qInv: bigint::Elem<P, R>,
+
+    // XXX: qq's `oneRR` isn't used and thus this is about twice as large as
+    // it needs to be, according to how it is used. Further, it appears to be
+    // completely unnecessary since `elem_reduced` seems to be able to reduce
+    // an `Elem<N>` directly to an `Elem<Q>`. TODO: Verify that is true and
+    // eliminate this.
     qq: bigint::Modulus<QQ>,
+
+    // TODO: Eliminate `q_mod_n` entirely since it is a bad space:time trade-off.
+    // Also, this is the only non-temporary `Elem` so if we eliminate this, we
+    // can make all `Elem`s temporary (borrowed) values.
     q_mod_n: bigint::Elem<N, R>,
+
     public: PublicKey,
 }
 

--- a/src/rsa/public_modulus.rs
+++ b/src/rsa/public_modulus.rs
@@ -4,7 +4,7 @@ use core::ops::RangeInclusive;
 /// The modulus (n) of an RSA public key.
 #[derive(Clone)]
 pub struct PublicModulus {
-    value: bigint::Modulus<N>,
+    value: bigint::OwnedModulusWithOne<N>,
     bits: bits::BitLength,
 }
 
@@ -33,7 +33,8 @@ impl PublicModulus {
         const MIN_BITS: bits::BitLength = bits::BitLength::from_usize_bits(1024);
 
         // Step 3 / Step c for `n` (out of order).
-        let (value, bits) = bigint::Modulus::from_be_bytes_with_bit_length(n, cpu_features)?;
+        let (value, bits) =
+            bigint::OwnedModulusWithOne::from_be_bytes_with_bit_length(n, cpu_features)?;
 
         // Step 1 / Step a. XXX: SP800-56Br1 and SP800-89 require the length of
         // the public modulus to be exactly 2048 or 3072 bits, but we are more
@@ -63,7 +64,7 @@ impl PublicModulus {
         self.bits
     }
 
-    pub(super) fn value(&self) -> &bigint::Modulus<N> {
+    pub(super) fn value(&self) -> &bigint::OwnedModulusWithOne<N> {
         &self.value
     }
 }


### PR DESCRIPTION
Originally we only had `Modulus`. Then we had a need for a temporary `Modulus` without `oneRR` so we created `PartialModulus`. However, there is really nothing "partial" about them. So, improve the naming by renaming `PartialModulus` to `Modulus` and `Modulus` to `OwnedModulusWithOne`. In the future we may refactor things further to separate the ownership aspect from the "has oneRR" aspect.

Instead of just doing a straightforward rename, take this opportunity to refactor the code so that it uses the new `Modulus` whenever `oneRR()` isn't used. This eliminates the duplication of the APIs of the two modulus types, and the duplication of `elem_mul` and `elem_mul_`.