### PR TITLE
bigint: Calculate 1*R and 1*RR slightly more efficiently.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -298,10 +298,10 @@ impl<M> One<M, RR> {
         // doubling. Unusual moduli require more doublings but we are less
         // concerned about the performance of those.
         //
-        // Then double `base` again so that base == 2*R (mod n), i.e. `2` in
+        // Then double `base` again so that base == 2*R (mod m), i.e. `2` in
         // Montgomery form (`elem_exp_vartime()` requires the base to be in
         // Montgomery form). Then compute
-        // RR = R**2 == base**r == R**r == (2**r)**r (mod n).
+        // RR = R**2 == base**r == R**r == (2**r)**r (mod m).
         //
         // Take advantage of the fact that `elem_mul_by_2` is faster than
         // `elem_squared` by replacing some of the early squarings with shifts.

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -350,6 +350,19 @@ pub(crate) fn limbs_add_assign_mod(a: &mut [Limb], b: &[Limb], m: &[Limb]) {
     unsafe { LIMBS_add_mod(a.as_mut_ptr(), a.as_ptr(), b.as_ptr(), m.as_ptr(), m.len()) }
 }
 
+// *r = -a, assuming a is odd.
+pub(crate) fn limbs_negative_odd(r: &mut [Limb], a: &[Limb]) {
+    debug_assert_eq!(r.len(), a.len());
+    // Two's complement step 1: flip all the bits.
+    // The compiler should optimize this to vectorized (a ^ !0).
+    r.iter_mut().zip(a.iter()).for_each(|(r, &a)| {
+        *r = !a;
+    });
+    // Two's complement step 2: Add one. Since `a` is odd, `r` is even. Thus we
+    // can use a bitwise or for addition.
+    r[0] |= 1;
+}
+
 prefixed_extern! {
     fn LIMBS_are_zero(a: *const Limb, num_limbs: c::size_t) -> LimbMask;
     fn LIMBS_less_than(a: *const Limb, b: *const Limb, num_limbs: c::size_t) -> LimbMask;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -350,6 +350,17 @@ pub(crate) fn limbs_add_assign_mod(a: &mut [Limb], b: &[Limb], m: &[Limb]) {
     unsafe { LIMBS_add_mod(a.as_mut_ptr(), a.as_ptr(), b.as_ptr(), m.as_ptr(), m.len()) }
 }
 
+// r *= 2 (mod m).
+pub(crate) fn limbs_double_mod(r: &mut [Limb], m: &[Limb]) {
+    assert_eq!(r.len(), m.len());
+    prefixed_extern! {
+        fn LIMBS_shl_mod(r: *mut Limb, a: *const Limb, m: *const Limb, num_limbs: c::size_t);
+    }
+    unsafe {
+        LIMBS_shl_mod(r.as_mut_ptr(), r.as_ptr(), m.as_ptr(), m.len());
+    }
+}
+
 // *r = -a, assuming a is odd.
 pub(crate) fn limbs_negative_odd(r: &mut [Limb], a: &[Limb]) {
     debug_assert_eq!(r.len(), a.len());

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -468,7 +468,7 @@ fn elem_exp_consttime<M>(
     // in the Smooth CRT-RSA paper.
     let c_mod_m = bigint::elem_mul(p.modulus.oneRR().as_ref(), c_mod_m, m);
     let c_mod_m = bigint::elem_mul(p.modulus.oneRR().as_ref(), c_mod_m, m);
-    bigint::elem_exp_consttime(c_mod_m, &p.exponent, &p.modulus)
+    bigint::elem_exp_consttime(c_mod_m, &p.exponent, m)
 }
 
 // Type-level representations of the different moduli used in RSA signing, in


### PR DESCRIPTION
See individual commit messages for details. The effect is to make RSA signature verification and RSA signing slightly faster.