### PR TITLE
getauxval isn't defined on uclibc, so disable dynamic feature detection

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -57,7 +57,7 @@ pub(crate) fn features() -> Features {
                 any(
                     target_os = "android",
                     target_os = "fuchsia",
-                    target_os = "linux",
+                    all(target_os = "linux", not(target_env = "uclibc")),
                     target_os = "windows"
                 )
             ))]

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -17,9 +17,18 @@
     allow(dead_code)
 )]
 
+// uclibc: When linked statically, uclibc doesn't provide getauxval.
+// When linked dynamically, recent versions do provide it, but we
+// want to support older versions too. Assume that if uclibc is being
+// used, this is an embedded target where the user cares a lot about
+// minimizing code size and also that they know in advance exactly
+// what target features are supported, so rely only on static feature
+// detection.
+
 #[cfg(all(
     any(target_os = "android", target_os = "linux"),
-    any(target_arch = "aarch64", target_arch = "arm")
+    any(target_arch = "aarch64", target_arch = "arm"),
+    not(target_env = "uclibc")
 ))]
 fn detect_features() -> u32 {
     use libc::c_ulong;
@@ -196,7 +205,7 @@ impl Feature {
             any(
                 target_os = "android",
                 target_os = "fuchsia",
-                target_os = "linux",
+                all(target_os = "linux", not(target_env = "uclibc")),
                 target_os = "windows"
             ),
             any(target_arch = "arm", target_arch = "aarch64")
@@ -251,7 +260,7 @@ features! {
     any(
         target_os = "android",
         target_os = "fuchsia",
-        target_os = "linux",
+        all(target_os = "linux", not(target_env = "uclibc")),
         target_os = "windows"
     )
 ))]


### PR DESCRIPTION
This is my attempt at the suggested alternative approach @briansmith suggested in https://github.com/briansmith/ring/pull/1800