### PR TITLE
Refactor away parse_big_endian_in_range_partially_reduced_and_pad_consttime.

### DIFF
--- a/src/ec/suite_b/ecdsa/digest_scalar.rs
+++ b/src/ec/suite_b/ecdsa/digest_scalar.rs
@@ -14,11 +14,7 @@
 
 //! ECDSA Signatures using the P-256 and P-384 curves.
 
-use crate::{
-    digest,
-    ec::suite_b::ops::*,
-    limb::{self, LIMB_BYTES},
-};
+use crate::{digest, ec::suite_b::ops::*, limb::LIMB_BYTES};
 
 /// Calculate the digest of `msg` using the digest algorithm `digest_alg`. Then
 /// convert the digest to a scalar in the range [0, n) as described in
@@ -68,7 +64,6 @@ fn digest_scalar_(ops: &ScalarOps, digest: &[u8]) -> Scalar {
 
     scalar_parse_big_endian_partially_reduced_variable_consttime(
         cops,
-        limb::AllowZero::Yes,
         untrusted::Input::from(digest),
     )
     .unwrap()

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -393,16 +393,16 @@ pub fn scalar_parse_big_endian_variable(
 
 pub fn scalar_parse_big_endian_partially_reduced_variable_consttime(
     ops: &CommonOps,
-    allow_zero: AllowZero,
     bytes: untrusted::Input,
 ) -> Result<Scalar, error::Unspecified> {
     let mut r = Scalar::zero();
-    parse_big_endian_in_range_partially_reduced_and_pad_consttime(
-        bytes,
-        allow_zero,
-        &ops.n.limbs[..ops.num_limbs],
-        &mut r.limbs[..ops.num_limbs],
-    )?;
+
+    {
+        let r = &mut r.limbs[..ops.num_limbs];
+        parse_big_endian_and_pad_consttime(bytes, r)?;
+        limbs_reduce_once_constant_time(r, &ops.n.limbs[..ops.num_limbs]);
+    }
+
     Ok(r)
 }
 

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -141,28 +141,6 @@ pub enum AllowZero {
     Yes,
 }
 
-/// Parses `input` into `result`, reducing it via conditional subtraction
-/// (mod `m`). Assuming 2**((self.num_limbs * LIMB_BITS) - 1) < m and
-/// m < 2**(self.num_limbs * LIMB_BITS), the value will be reduced mod `m` in
-/// constant time so that the result is in the range [0, m) if `allow_zero` is
-/// `AllowZero::Yes`, or [1, m) if `allow_zero` is `AllowZero::No`. `result` is
-/// padded with zeros to its length.
-pub fn parse_big_endian_in_range_partially_reduced_and_pad_consttime(
-    input: untrusted::Input,
-    allow_zero: AllowZero,
-    m: &[Limb],
-    result: &mut [Limb],
-) -> Result<(), error::Unspecified> {
-    parse_big_endian_and_pad_consttime(input, result)?;
-    limbs_reduce_once_constant_time(result, m);
-    if allow_zero != AllowZero::Yes {
-        if limbs_are_zero_constant_time(result) != LimbMask::False {
-            return Err(error::Unspecified);
-        }
-    }
-    Ok(())
-}
-
 /// Parses `input` into `result`, verifies that the value is less than
 /// `max_exclusive`, and pads `result` with zeros to its length. If `allow_zero`
 /// is not `AllowZero::Yes`, zero values are rejected.


### PR DESCRIPTION
It only had one caller and it contained unreached code.