### PR TITLE
ec: NFC: Refactor `scalar_sum` to eliminate `LIMBS_add_mod` use.

### DIFF
--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -266,7 +266,7 @@ impl EcdsaKeyPair {
             // Step 6.
             let s = {
                 let dr = scalar_ops.scalar_product(&self.d, &r);
-                let e_plus_dr = scalar_sum(cops, &e, &dr);
+                let e_plus_dr = scalar_sum(cops, &e, dr);
                 scalar_ops.scalar_product(&k_inv, &e_plus_dr)
             };
             if cops.is_zero(&s) {


### PR DESCRIPTION
Use the pattern we typically use where one argument is passed by value.

This lets us use `limbs_add_assign_mod`, eliminating the `unsafe` direct use of `LIMBS_add_mod`. This will make future refactoring easier.

This also eliminates the need to construct and zeroize a new scalar `r` for the result.