### PR TITLE
rsa: NFC: Eliminate unnecessary `Nonnegative` -> `Modulus` conversion.

### DIFF
--- a/src/arithmetic/bigint/modulus.rs
+++ b/src/arithmetic/bigint/modulus.rs
@@ -14,7 +14,7 @@
 
 use super::{
     super::{montgomery::RR, n0::N0},
-    BoxedLimbs, Elem, Nonnegative, One, PublicModulus, SmallerModulus, Unencoded,
+    BoxedLimbs, Elem, One, PublicModulus, SmallerModulus, Unencoded,
 };
 use crate::{
     bits::BitLength,
@@ -110,14 +110,6 @@ impl<M> OwnedModulusWithOne<M> {
         cpu_features: cpu::Features,
     ) -> Result<Self, error::KeyRejected> {
         let limbs = BoxedLimbs::positive_minimal_width_from_be_bytes(input)?;
-        Self::from_boxed_limbs(limbs, cpu_features)
-    }
-
-    pub(crate) fn from_nonnegative(
-        n: Nonnegative,
-        cpu_features: cpu::Features,
-    ) -> Result<Self, error::KeyRejected> {
-        let limbs = BoxedLimbs::new_unchecked(n.into_limbs());
         Self::from_boxed_limbs(limbs, cpu_features)
     }
 

--- a/src/arithmetic/nonnegative.rs
+++ b/src/arithmetic/nonnegative.rs
@@ -16,7 +16,7 @@ use crate::{
     bits, error,
     limb::{self, Limb, LimbMask, LIMB_BYTES},
 };
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{vec, vec::Vec};
 
 /// Nonnegative integers.
 pub(crate) struct Nonnegative {
@@ -44,10 +44,5 @@ impl Nonnegative {
     #[inline]
     pub fn limbs(&self) -> &[Limb] {
         &self.limbs
-    }
-
-    #[inline]
-    pub fn into_limbs(self) -> Box<[Limb]> {
-        self.limbs.into_boxed_slice()
     }
 }

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -252,11 +252,6 @@ impl KeyPair {
         let dQ = untrusted::Input::from(dQ);
         let qInv = untrusted::Input::from(qInv);
 
-        let (p, _p_bits) = bigint::Nonnegative::from_be_bytes_with_bit_length(p)
-            .map_err(|error::Unspecified| KeyRejected::invalid_encoding())?;
-        let (q, _q_bits) = bigint::Nonnegative::from_be_bytes_with_bit_length(q)
-            .map_err(|error::Unspecified| KeyRejected::invalid_encoding())?;
-
         // XXX: Some steps are done out of order, but the NIST steps are worded
         // in such a way that it is clear that NIST intends for them to be done
         // in order. TODO: Does this matter at all?
@@ -410,12 +405,12 @@ impl<M> PrivatePrime<M> {
     /// Constructs a `PrivatePrime` from the private prime `p` and `dP` where
     /// dP == d % (p - 1).
     fn new(
-        p: bigint::Nonnegative,
+        p: untrusted::Input,
         dP: untrusted::Input,
         n_bits: BitLength,
         cpu_features: cpu::Features,
     ) -> Result<Self, KeyRejected> {
-        let p = bigint::OwnedModulusWithOne::from_nonnegative(p, cpu_features)?;
+        let p = bigint::OwnedModulusWithOne::from_be_bytes(p, cpu_features)?;
 
         // 5.c / 5.g:
         //


### PR DESCRIPTION
After 5ed0a45c65074a0640e6f9e21512a8c4d9540f1e we no longer needs `p` or `q` in `Nonnegative` form.