### PR TITLE
bigint: NFC: Take `oneRR` out of `OwnedModulus`.

### DIFF
--- a/src/rsa/public_key.rs
+++ b/src/rsa/public_key.rs
@@ -145,7 +145,7 @@ impl Inner {
         base: untrusted::Input,
         out_buffer: &'out mut [u8; PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN],
     ) -> Result<&'out [u8], error::Unspecified> {
-        let n = &self.n.value().modulus();
+        let n = &self.n.value();
 
         // The encoded value of the base must be the same length as the modulus,
         // in bytes.
@@ -177,10 +177,9 @@ impl Inner {
         // The exponent was already checked to be odd.
         debug_assert_ne!(exponent_without_low_bit, self.e.value());
 
-        let n_ = self.n.value();
-        let n = &n_.modulus();
+        let n = &self.n.value();
 
-        let base_r = bigint::elem_mul(n_.oneRR().as_ref(), base.clone(), n);
+        let base_r = bigint::elem_mul(self.n.oneRR(), base.clone(), n);
 
         // During RSA public key operations the exponent is almost always either
         // 65537 (0b10000000000000001) or 3 (0b11), both of which have a Hamming


### PR DESCRIPTION
`PublicModulus` and `PrivatePrime` are basically duplicates of `OwnedModulusWithOne`. In the future we would like to create an `OwnedModulus` that doesn't need 1RR to be calculated. Also in the future we'd like to be able to "take" 1RR from a public modulus. This change is a step towards those ends.