### PR TITLE
bigint: Stop implementing `Debug` for `OwnedModulus`.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -791,9 +791,8 @@ prefixed_extern! {
 
 #[cfg(test)]
 mod tests {
-    use super::{modulus::MODULUS_MIN_LIMBS, *};
-    use crate::{limb::LIMB_BYTES, test};
-    use alloc::format;
+    use super::*;
+    use crate::test;
 
     // Type-level representation of an arbitrary modulus.
     struct M {}
@@ -926,16 +925,6 @@ mod tests {
                 Ok(())
             },
         )
-    }
-
-    #[test]
-    fn test_modulus_debug() {
-        let modulus = OwnedModulus::<M>::from_be_bytes(
-            untrusted::Input::from(&[0xff; LIMB_BYTES * MODULUS_MIN_LIMBS]),
-            cpu::features(),
-        )
-        .unwrap();
-        assert_eq!("Modulus", format!("{:?}", modulus));
     }
 
     fn consume_elem<M>(

--- a/src/arithmetic/bigint/modulus.rs
+++ b/src/arithmetic/bigint/modulus.rs
@@ -90,14 +90,6 @@ impl<M: PublicModulus> Clone for OwnedModulus<M> {
     }
 }
 
-impl<M: PublicModulus> core::fmt::Debug for OwnedModulus<M> {
-    fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
-        fmt.debug_struct("Modulus")
-            // TODO: Print modulus value.
-            .finish()
-    }
-}
-
 impl<M> OwnedModulus<M> {
     pub(crate) fn from_be_bytes(
         input: untrusted::Input,


### PR DESCRIPTION
This was necessary at some point in the past, but no longer is. It is better to avoid depending on any of the `core::fmt` machinery in these lower layers if we can avoid it.