### PR TITLE
Docs: Add clang path for Windows ARM64 hosts

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -34,6 +34,14 @@ If you (locally) have “Build Tools for Visual Studio 2022” instead, use:
 $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin"
 ```
 
+Alternatively, if the host machine is already a Windows ARM64 then use:
+
+```
+$env:Path += ";C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\ARM64\bin"
+```
+
+# Windows ARM64
+
 Packaged Builds
 ---------------
 


### PR DESCRIPTION
This PR just adds a new clang path to the `BUILDING.md` when the host is a Windows ARM64.

It was tested by building a Rust project using ring 0.17.5 on a Windows 11 ARM64 (M1 Parallels VM) successfully.

Otherwise, I should get an error similar to the following:

```log
ring-0.17.5\build.rs:673:9:
  failed to execute ["clang" "-O3" "--target=aarch64-pc-windows-msvc" "-ffunction-sections" "-fdata-sections" "--target=aarch64-pc-windows-msvc" "-I" "include" "-I" "C:\\Users\\joseluisq\\devel\\static-web-server\\target\\aarch64-pc-windows-msvc\\release\\build\\ring-400e2572fe09d335\\out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-DNDEBUG" "-c" "-oC:\\Users\\joseluisq\\devel\\static-web-server\\target\\aarch64-pc-windows-msvc\\release\\build\\ring-400e2572fe09d335\\out\\aesv8-armx-win64.o" "C:\\Users\\joseluisq\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\ring-0.17.5\\pregenerated\\aesv8-armx-win64.S"]: program not found
```