### PR TITLE
rsa: Stop using `Nonnegative` in `RsaKeyPair` to check `d`.

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -20,7 +20,7 @@ pub mod bigint;
 pub mod montgomery;
 mod n0;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(test, feature = "alloc"))]
 mod nonnegative;
 
 #[allow(dead_code)]

--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -42,7 +42,6 @@ pub(crate) use self::{
     private_exponent::PrivateExponent,
 };
 use super::n0::N0;
-pub(crate) use super::nonnegative::Nonnegative;
 use crate::{
     arithmetic::montgomery::*,
     bits::BitLength,
@@ -703,21 +702,6 @@ pub fn elem_verify_equal_consttime<M, E>(
     }
 }
 
-// TODO: Move these methods from `Nonnegative` to `Modulus`.
-impl Nonnegative {
-    pub fn verify_less_than_modulus<M>(&self, m: &Modulus<M>) -> Result<(), error::Unspecified> {
-        if self.limbs().len() > m.limbs().len() {
-            return Err(error::Unspecified);
-        }
-        if self.limbs().len() == m.limbs().len() {
-            if limb::limbs_less_than_limbs_consttime(self.limbs(), m.limbs()) != LimbMask::True {
-                return Err(error::Unspecified);
-            }
-        }
-        Ok(())
-    }
-}
-
 /// r *= a
 fn limbs_mont_mul(r: &mut [Limb], a: &[Limb], m: &[Limb], n0: &N0, _cpu_features: cpu::Features) {
     debug_assert_eq!(r.len(), m.len());
@@ -789,7 +773,7 @@ prefixed_extern! {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{super::nonnegative::Nonnegative, *};
     use crate::test;
 
     // Type-level representation of an arbitrary modulus.

--- a/src/arithmetic/bigint/modulus.rs
+++ b/src/arithmetic/bigint/modulus.rs
@@ -146,13 +146,18 @@ impl<M> OwnedModulus<M> {
         })
     }
 
-    pub fn to_elem<L>(&self, l: &Modulus<L>) -> Result<Elem<L, Unencoded>, error::Unspecified> {
+    pub fn verify_less_than<L>(&self, l: &Modulus<L>) -> Result<(), error::Unspecified> {
         if self.len_bits() > l.len_bits()
             || (self.limbs.len() == l.limbs().len()
                 && limb::limbs_less_than_limbs_consttime(&self.limbs, l.limbs()) != LimbMask::True)
         {
             return Err(error::Unspecified);
         }
+        Ok(())
+    }
+
+    pub fn to_elem<L>(&self, l: &Modulus<L>) -> Result<Elem<L, Unencoded>, error::Unspecified> {
+        self.verify_less_than(l)?;
         let mut limbs = BoxedLimbs::zero(l.limbs.len());
         limbs[..self.limbs.len()].copy_from_slice(&self.limbs);
         Ok(Elem {

--- a/src/arithmetic/nonnegative.rs
+++ b/src/arithmetic/nonnegative.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     bits, error,
-    limb::{self, Limb, LimbMask, LIMB_BYTES},
+    limb::{self, Limb, LIMB_BYTES},
 };
 use alloc::{vec, vec::Vec};
 
@@ -37,10 +37,6 @@ impl Nonnegative {
         Ok((Self { limbs }, r_bits))
     }
 
-    #[inline]
-    pub fn is_odd(&self) -> bool {
-        limb::limbs_are_even_constant_time(&self.limbs) != LimbMask::True
-    }
     #[inline]
     pub fn limbs(&self) -> &[Limb] {
         &self.limbs


### PR DESCRIPTION
Check `d` by processing it as a `OwnedModulus` like we do for the other moduli. This should make the checking more consistent.

As a nice side effect, this eliminates the last non-test usage of `Nonnegative` and elimnates more now-dead `Nonnegative` code.