### PR TITLE
Stop exporting unmangled symbols on ARM/AArch64.

### DIFF
--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -14,7 +14,6 @@
 
 #include <ring-core/base.h>
 
-#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 // Our assembly does not use the GOT to reference symbols, which means
 // references to visible symbols will often require a TEXTREL. This is
 // undesirable, so all assembly-referenced symbols should be hidden. CPU
@@ -26,6 +25,7 @@
 #define HIDDEN __attribute__((visibility("hidden")))
 #endif
 
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 // This value must be explicitly initialised to zero in order to work around a
 // bug in libtool or the linker on OS X.
 //
@@ -34,4 +34,6 @@
 // initialising it to zero, it becomes a "data symbol", which isn't so
 // affected.
 HIDDEN uint32_t OPENSSL_ia32cap_P[4] = {0};
+#elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
+HIDDEN uint32_t OPENSSL_armcap_P = 0;
 #endif

--- a/src/arithmetic/montgomery.rs
+++ b/src/arithmetic/montgomery.rs
@@ -118,6 +118,8 @@ use {
     target_arch = "x86",
     target_arch = "x86_64"
 )))]
+// TODO: Stop calling this from C and un-export it.
+#[allow(deprecated)]
 prefixed_export! {
     unsafe fn bn_mul_mont(
         r: *mut Limb,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -52,15 +52,7 @@ pub(crate) fn features() -> Features {
                 }
             }
 
-            #[cfg(all(
-                any(target_arch = "aarch64", target_arch = "arm"),
-                any(
-                    target_os = "android",
-                    target_os = "fuchsia",
-                    all(target_os = "linux", not(target_env = "uclibc")),
-                    target_os = "windows"
-                )
-            ))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
             {
                 unsafe { arm::initialize_OPENSSL_armcap_P() }
             }

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -40,7 +40,13 @@ macro_rules! prefixed_extern {
     };
 }
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[deprecated = "`#[export_name]` creates problems and we will stop doing it."]
+#[cfg(not(any(
+    target_arch = "aarc64",
+    target_arch = "arm",
+    target_arch = "x86",
+    target_arch = "x86_64"
+)))]
 macro_rules! prefixed_export {
     // A function.
     {
@@ -53,21 +59,6 @@ macro_rules! prefixed_export {
             {
                 $( #[$meta] )*
                 $vis unsafe fn $name ( $( $arg_pat : $arg_ty ),* ) $body
-            }
-        }
-    };
-
-    // A global variable.
-    {
-        $( #[$meta:meta] )*
-        $vis:vis static mut $name:ident: $typ:ty = $initial_value:expr;
-    } => {
-        prefixed_item! {
-            export_name
-            $name
-            {
-                $( #[$meta] )*
-                $vis static mut $name: $typ = $initial_value;
             }
         }
     };


### PR DESCRIPTION
We want all of our internal symbols to be internal so that none of these internal symbols leak from a static/dynamic library that is built with *ring* inside.