### PR TITLE
Remove libc dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,17 +177,11 @@ untrusted = { version = "0.9" }
 [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
 
-[target.'cfg(all(any(target_os = "android", target_os = "linux"), any(target_arch = "aarch64", target_arch = "arm")))'.dependencies]
-libc = { version = "0.2.148", default-features = false }
-
 [target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
 windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.37", default-features = false }
-
-[target.'cfg(any(unix, windows, target_os = "wasi"))'.dev-dependencies]
-libc = { version = "0.2.148", default-features = false }
 
 [build-dependencies]
 cc = { version = "1.0.83", default-features = false }

--- a/src/c.rs
+++ b/src/c.rs
@@ -13,42 +13,11 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 //! C types.
-//!
-//! Avoid using the `libc` crate to get C types since `libc` doesn't support
-//! all the targets we need to support. It turns out that the few types we need
-//! are all uniformly defined on the platforms we care about. This will
-//! probably change if/when we support 16-bit platforms or platforms where
-//! `usize` and `uintptr_t` are different sizes.
-//!
-//! TODO(MSRV-1.64): Use `core::ffi::{c_int, c_uint}`, remove the libc
-//! compatibility testing, and remove the libc dev-dependency.
 
 // Keep in sync with the checks in base.h that verify these assumptions.
 
-pub(crate) type int = i32;
-pub(crate) type uint = u32;
+pub(crate) type int = core::ffi::c_int;
+pub(crate) type uint = core::ffi::c_uint;
+
+// TODO(https://github.com/rust-lang/rust/issues/88345): Use `core::ffi::c_size_t`.
 pub(crate) type size_t = usize;
-
-#[cfg(all(test, any(unix, windows)))]
-mod tests {
-    use crate::c;
-
-    #[test]
-    fn test_libc_compatible() {
-        {
-            let x: c::int = 1;
-            let _x: libc::c_int = x;
-        }
-
-        {
-            let x: c::uint = 1;
-            let _x: libc::c_uint = x;
-        }
-
-        {
-            let x: c::size_t = 1;
-            let _x: libc::size_t = x;
-            let _x: usize = x;
-        }
-    }
-}

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -31,7 +31,7 @@
     not(target_env = "uclibc")
 ))]
 fn detect_features() -> u32 {
-    use libc::c_ulong;
+    use core::ffi::c_ulong;
 
     // XXX: The `libc` crate doesn't provide `libc::getauxval` consistently
     // across all Android/Linux targets, e.g. musl.


### PR DESCRIPTION
Use `core::ffi` instead of `libc`.