### PR TITLE
AES-GCM: Clarify that we need AVX (AVX1), not AVX2.

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -84,7 +84,7 @@ fn aes_gcm_seal(key: &aead::KeyInner, nonce: Nonce, aad: Aad<&[u8]>, in_out: &mu
 
     #[cfg(target_arch = "x86_64")]
     let in_out = {
-        if !aes_key.is_aes_hw() || !auth.is_avx2() {
+        if !aes_key.is_aes_hw() || !auth.is_avx() {
             in_out
         } else {
             use crate::c;
@@ -164,7 +164,7 @@ fn aes_gcm_open(
 
     #[cfg(target_arch = "x86_64")]
     let in_out = {
-        if !aes_key.is_aes_hw() || !auth.is_avx2() {
+        if !aes_key.is_aes_hw() || !auth.is_avx() {
             in_out
         } else {
             use crate::c;

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -244,7 +244,7 @@ impl Context {
     }
 
     #[cfg(target_arch = "x86_64")]
-    pub(super) fn is_avx2(&self) -> bool {
+    pub(super) fn is_avx(&self) -> bool {
         match detect_implementation(self.cpu_features) {
             Implementation::CLMUL => has_avx_movbe(self.cpu_features),
             _ => false,


### PR DESCRIPTION
The function was named `is_avx2()` but the test is for AVX1. Fix the name.