### PR TITLE
cpu arm: Fix static feature detection initialization.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ name = "ring"
 getrandom = { version = "0.2.10" }
 untrusted = { version = "0.9" }
 
-[target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
+[target.'cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86",target_arch = "x86_64"))'.dependencies]
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
 
 [target.'cfg(all(any(target_os = "android", target_os = "linux"), any(target_arch = "aarch64", target_arch = "arm")))'.dependencies]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -24,39 +24,21 @@ pub(crate) struct Features(());
 
 #[inline(always)]
 pub(crate) fn features() -> Features {
-    // We don't do runtime feature detection on aarch64-apple-* as all AAarch64
-    // features we use are available on every device since the first devices.
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    use arm::init_global_shared_with_assembly;
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use intel::init_global_shared_with_assembly;
+
     #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
         target_arch = "x86",
         target_arch = "x86_64",
-        all(
-            any(target_arch = "aarch64", target_arch = "arm"),
-            any(
-                target_os = "android",
-                target_os = "fuchsia",
-                target_os = "linux",
-                target_os = "windows"
-            )
-        )
     ))]
     {
         static INIT: spin::Once<()> = spin::Once::new();
-        let () = INIT.call_once(|| {
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            {
-                prefixed_extern! {
-                    fn OPENSSL_cpuid_setup();
-                }
-                unsafe {
-                    OPENSSL_cpuid_setup();
-                }
-            }
-
-            #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-            {
-                unsafe { arm::initialize_OPENSSL_armcap_P() }
-            }
-        });
+        let () = INIT.call_once(|| unsafe { init_global_shared_with_assembly() });
     }
 
     Features(())

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -269,7 +269,7 @@ features! {
 //   `INIT`.
 // - See the safety invariants of `OPENSSL_armcap_P` below.
 #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-pub unsafe fn initialize_OPENSSL_armcap_P() {
+pub unsafe fn init_global_shared_with_assembly() {
     let detected = detect_features();
     let filtered = (if cfg!(feature = "unstable-testing-arm-no-hw") {
         AES.mask | SHA256.mask | PMULL.mask

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -22,6 +22,16 @@ pub(crate) struct Feature {
     mask: u32,
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(super) unsafe fn init_global_shared_with_assembly() {
+    prefixed_extern! {
+        fn OPENSSL_cpuid_setup();
+    }
+    unsafe {
+        OPENSSL_cpuid_setup();
+    }
+}
+
 impl Feature {
     #[allow(clippy::needless_return)]
     #[inline(always)]


### PR DESCRIPTION
Commit f932b941bd1f59782cb3db8f7cd7b8b2c9842ee9 was incomplete and wrong. On targets where we do any static or dynamic feature detection and where we have these global variables, we need to unconditionally write the detected features to the global variable so that assembly can see them. Since we do static feature detection regardless of operating system, the initialization of the global most be done without any conditions on the operating system.