### PR TITLE
CI: Update macOS runners to macOS 13 and start running tests for aarch64-apple-darwin.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,7 @@ jobs:
 
         include:
           - target: aarch64-apple-darwin
-            host_os: macos-13
-            # GitHub Actions doesn't have a way to run this target yet.
-            cargo_options: --no-run
+            host_os: macos-13-xlarge
 
           - target: aarch64-apple-ios
             host_os: macos-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,12 +175,12 @@ jobs:
 
         include:
           - target: aarch64-apple-darwin
-            host_os: macos-12
+            host_os: macos-13
             # GitHub Actions doesn't have a way to run this target yet.
             cargo_options: --no-run
 
           - target: aarch64-apple-ios
-            host_os: macos-12
+            host_os: macos-13
             # GitHub Actions doesn't have a way to run this target yet.
             cargo_options: --no-run
 
@@ -236,7 +236,7 @@ jobs:
             host_os: windows-latest
 
           - target: x86_64-apple-darwin
-            host_os: macos-12
+            host_os: macos-13
 
           - target: x86_64-unknown-linux-musl
             host_os: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
 
           - target: aarch64-apple-ios
             host_os: macos-13
-            # GitHub Actions doesn't have a way to run this target yet.
+            # TODO: Run in the emulator.
             cargo_options: --no-run
 
           - target: aarch64-linux-android


### PR DESCRIPTION
See the individual commit messages for details. This testing catches the issue fixed by PR #1842.