### PR TITLE
ec suite_b: Encapsulate access to limbs of scalars and field elements.

### DIFF
--- a/src/ec/suite_b/ecdh.rs
+++ b/src/ec/suite_b/ecdh.rs
@@ -183,7 +183,7 @@ mod tests {
             // getting that value from the PRNG.
             let mut n_bytes = [0u8; ec::SCALAR_MAX_BYTES];
             let num_bytes = curve.elem_scalar_seed_len;
-            limb::big_endian_from_limbs(&ops.n.limbs[..ops.num_limbs], &mut n_bytes[..num_bytes]);
+            limb::big_endian_from_limbs(ops.n_limbs(), &mut n_bytes[..num_bytes]);
             {
                 let n_bytes = &mut n_bytes[..num_bytes];
                 let rng = test::rand::FixedSliceRandom { bytes: n_bytes };

--- a/src/ec/suite_b/ecdsa/digest_scalar.rs
+++ b/src/ec/suite_b/ecdsa/digest_scalar.rs
@@ -95,7 +95,6 @@ mod tests {
                     }
                 };
 
-                let num_limbs = ops.public_key_ops.common.num_limbs;
                 assert_eq!(input.len(), digest_alg.output_len());
                 assert_eq!(output.len(), ops.scalar_ops.scalar_bytes_len());
 
@@ -107,7 +106,10 @@ mod tests {
                 .unwrap();
 
                 let actual = digest_bytes_scalar(ops.scalar_ops, &input);
-                assert_eq!(actual.limbs[..num_limbs], expected.limbs[..num_limbs]);
+                assert_eq!(
+                    ops.scalar_ops.leak_limbs(&actual),
+                    ops.scalar_ops.leak_limbs(&expected)
+                );
 
                 Ok(())
             },

--- a/src/ec/suite_b/ecdsa/digest_scalar.rs
+++ b/src/ec/suite_b/ecdsa/digest_scalar.rs
@@ -14,7 +14,7 @@
 
 //! ECDSA Signatures using the P-256 and P-384 curves.
 
-use crate::{digest, ec::suite_b::ops::*, limb::LIMB_BYTES};
+use crate::{digest, ec::suite_b::ops::*};
 
 /// Calculate the digest of `msg` using the digest algorithm `digest_alg`. Then
 /// convert the digest to a scalar in the range [0, n) as described in
@@ -54,16 +54,15 @@ pub(crate) fn digest_bytes_scalar(ops: &ScalarOps, digest: &[u8]) -> Scalar {
 // This is a separate function solely so that we can test specific digest
 // values like all-zero values and values larger than `n`.
 fn digest_scalar_(ops: &ScalarOps, digest: &[u8]) -> Scalar {
-    let cops = ops.common;
-    let num_limbs = cops.num_limbs;
-    let digest = if digest.len() > num_limbs * LIMB_BYTES {
-        &digest[..(num_limbs * LIMB_BYTES)]
+    let len = ops.scalar_bytes_len();
+    let digest = if digest.len() > len {
+        &digest[..len]
     } else {
         digest
     };
 
     scalar_parse_big_endian_partially_reduced_variable_consttime(
-        cops,
+        ops.common,
         untrusted::Input::from(digest),
     )
     .unwrap()
@@ -72,12 +71,7 @@ fn digest_scalar_(ops: &ScalarOps, digest: &[u8]) -> Scalar {
 #[cfg(test)]
 mod tests {
     use super::digest_bytes_scalar;
-    use crate::{
-        digest,
-        ec::suite_b::ops::*,
-        limb::{self, LIMB_BYTES},
-        test,
-    };
+    use crate::{digest, ec::suite_b::ops::*, limb, test};
 
     #[test]
     fn test() {
@@ -103,10 +97,7 @@ mod tests {
 
                 let num_limbs = ops.public_key_ops.common.num_limbs;
                 assert_eq!(input.len(), digest_alg.output_len());
-                assert_eq!(
-                    output.len(),
-                    ops.public_key_ops.common.num_limbs * LIMB_BYTES
-                );
+                assert_eq!(output.len(), ops.scalar_ops.scalar_bytes_len());
 
                 let expected = scalar_parse_big_endian_variable(
                     ops.public_key_ops.common,
@@ -116,7 +107,6 @@ mod tests {
                 .unwrap();
 
                 let actual = digest_bytes_scalar(ops.scalar_ops, &input);
-
                 assert_eq!(actual.limbs[..num_limbs], expected.limbs[..num_limbs]);
 
                 Ok(())

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -386,10 +386,10 @@ fn format_rs_fixed(ops: &'static ScalarOps, r: &Scalar, s: &Scalar, out: &mut [u
     let scalar_len = ops.scalar_bytes_len();
 
     let (r_out, rest) = out.split_at_mut(scalar_len);
-    limb::big_endian_from_limbs(&r.limbs[..ops.common.num_limbs], r_out);
+    limb::big_endian_from_limbs(ops.leak_limbs(r), r_out);
 
     let (s_out, _) = rest.split_at_mut(scalar_len);
-    limb::big_endian_from_limbs(&s.limbs[..ops.common.num_limbs], s_out);
+    limb::big_endian_from_limbs(ops.leak_limbs(s), s_out);
 
     2 * scalar_len
 }
@@ -400,7 +400,7 @@ fn format_rs_asn1(ops: &'static ScalarOps, r: &Scalar, s: &Scalar, out: &mut [u8
     fn format_integer_tlv(ops: &ScalarOps, a: &Scalar, out: &mut [u8]) -> usize {
         let mut fixed = [0u8; ec::SCALAR_MAX_BYTES + 1];
         let fixed = &mut fixed[..(ops.scalar_bytes_len() + 1)];
-        limb::big_endian_from_limbs(&a.limbs[..ops.common.num_limbs], &mut fixed[1..]);
+        limb::big_endian_from_limbs(ops.leak_limbs(a), &mut fixed[1..]);
 
         // Since `a_fixed_out` is an extra byte long, it is guaranteed to start
         // with a zero.

--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -157,10 +157,7 @@ impl EcdsaVerificationAlgorithm {
             return Ok(());
         }
         if self.ops.elem_less_than(&r, &self.ops.q_minus_n) {
-            self.ops
-                .scalar_ops
-                .common
-                .elem_add(&mut r, &public_key_ops.common.n);
+            self.ops.scalar_ops.common.elem_add(&mut r, self.ops.n());
             if sig_r_equals_x(self.ops, &r, &x, &z2) {
                 return Ok(());
             }

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -54,7 +54,7 @@ impl Point {
 pub struct CommonOps {
     pub num_limbs: usize,
     q: Modulus,
-    pub n: Elem<Unencoded>,
+    n: Elem<Unencoded>,
 
     pub a: Elem<R>, // Must be -3 mod q
     pub b: Elem<R>,
@@ -71,6 +71,11 @@ impl CommonOps {
     // scalar, in bytes.
     pub fn len(&self) -> usize {
         self.num_limbs * LIMB_BYTES
+    }
+
+    #[cfg(test)]
+    pub(super) fn n_limbs(&self) -> &[Limb] {
+        &self.n.limbs[..self.num_limbs]
     }
 
     #[inline]
@@ -280,6 +285,10 @@ pub struct PublicScalarOps {
 }
 
 impl PublicScalarOps {
+    pub fn n(&self) -> &Elem<Unencoded> {
+        &self.scalar_ops.common.n
+    }
+
     #[inline]
     pub fn scalar_as_elem(&self, a: &Scalar) -> Elem<Unencoded> {
         Elem {

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -52,7 +52,7 @@ impl Point {
 
 /// Operations and values needed by all curve operations.
 pub struct CommonOps {
-    pub num_limbs: usize,
+    num_limbs: usize,
     q: Modulus,
     n: Elem<Unencoded>,
 
@@ -186,6 +186,10 @@ pub struct PrivateKeyOps {
 }
 
 impl PrivateKeyOps {
+    pub fn leak_limbs<'a>(&self, a: &'a Elem<Unencoded>) -> &'a [Limb] {
+        &a.limbs[..self.common.num_limbs]
+    }
+
     #[inline(always)]
     pub fn point_mul_base(&self, a: &Scalar) -> Point {
         (self.point_mul_base_impl)(a)
@@ -253,6 +257,10 @@ impl ScalarOps {
     // The (maximum) length of a scalar, not including any padding.
     pub fn scalar_bytes_len(&self) -> usize {
         self.common.len()
+    }
+
+    pub fn leak_limbs<'s>(&self, s: &'s Scalar) -> &'s [Limb] {
+        &s.limbs[..self.common.num_limbs]
     }
 
     /// Returns the modular inverse of `a` (mod `n`). Panics of `a` is zero,

--- a/src/ec/suite_b/ops/elem.rs
+++ b/src/ec/suite_b/ops/elem.rs
@@ -26,14 +26,14 @@ use core::marker::PhantomData;
 #[derive(Clone, Copy)]
 pub struct Elem<M, E: Encoding> {
     // XXX: pub
-    pub limbs: [Limb; MAX_LIMBS],
+    pub(super) limbs: [Limb; MAX_LIMBS],
 
     /// The modulus *m* for the ring ℤ/mℤ for which this element is a value.
-    pub m: PhantomData<M>,
+    pub(super) m: PhantomData<M>,
 
     /// The number of Montgomery factors that need to be canceled out from
     /// `value` to get the actual value.
-    pub encoding: PhantomData<E>,
+    pub(super) encoding: PhantomData<E>,
 }
 
 impl<M, E: Encoding> Elem<M, E> {

--- a/src/ec/suite_b/private_key.rs
+++ b/src/ec/suite_b/private_key.rs
@@ -183,14 +183,13 @@ pub fn big_endian_affine_from_jacobian(
     p: &Point,
 ) -> Result<(), error::Unspecified> {
     let (x_aff, y_aff) = affine_from_jacobian(ops, p)?;
-    let num_limbs = ops.common.num_limbs;
     if let Some(x_out) = x_out {
         let x = ops.common.elem_unencoded(&x_aff);
-        limb::big_endian_from_limbs(&x.limbs[..num_limbs], x_out);
+        limb::big_endian_from_limbs(ops.leak_limbs(&x), x_out);
     }
     if let Some(y_out) = y_out {
         let y = ops.common.elem_unencoded(&y_aff);
-        limb::big_endian_from_limbs(&y.limbs[..num_limbs], y_out);
+        limb::big_endian_from_limbs(ops.leak_limbs(&y), y_out);
     }
 
     Ok(())


### PR DESCRIPTION
Provide a better API to (internal) users of `ec::suite_b::ops` so they don't have to do their own low-level slice indexing.

This is also a step towards a better `ops` API that also handles the `cpu::Features` aspects.