### PR TITLE
windows-sys 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ spin = { version = "0.9.8", default-features = false, features = ["once"] }
 libc = { version = "0.2.148", default-features = false }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
-windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.37", default-features = false }


### PR DESCRIPTION
I was unable to locally test this due to the asm/C code.

I also couldn't run the CI on this commit due to the amount of jobs the CI spawns.

I stripped the non-Windows CIs out on my master branch and the Windows CIs did pass, so I believe this is valid without any actual code edits.

See https://github.com/kayabaNerve/ring/actions/runs/7096652359 for those.