### PR TITLE
rsa bigint: Don't store CPU features in modulus/key

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -719,8 +719,8 @@ mod tests {
             |section, test_case| {
                 assert_eq!(section, "");
 
-                let m = consume_modulus::<M>(test_case, "M", cpu_features);
-                let m = m.modulus();
+                let m = consume_modulus::<M>(test_case, "M");
+                let m = m.modulus(cpu_features);
                 let expected_result = consume_elem(test_case, "ModExp", &m);
                 let base = consume_elem(test_case, "A", &m);
                 let e = {
@@ -749,8 +749,8 @@ mod tests {
             |section, test_case| {
                 assert_eq!(section, "");
 
-                let m = consume_modulus::<M>(test_case, "M", cpu_features);
-                let m = m.modulus();
+                let m = consume_modulus::<M>(test_case, "M");
+                let m = m.modulus(cpu_features);
                 let expected_result = consume_elem(test_case, "ModMul", &m);
                 let a = consume_elem(test_case, "A", &m);
                 let b = consume_elem(test_case, "B", &m);
@@ -774,8 +774,8 @@ mod tests {
             |section, test_case| {
                 assert_eq!(section, "");
 
-                let m = consume_modulus::<M>(test_case, "M", cpu_features);
-                let m = m.modulus();
+                let m = consume_modulus::<M>(test_case, "M");
+                let m = m.modulus(cpu_features);
                 let expected_result = consume_elem(test_case, "ModSquare", &m);
                 let a = consume_elem(test_case, "A", &m);
 
@@ -799,8 +799,8 @@ mod tests {
 
                 struct M {}
 
-                let m_ = consume_modulus::<M>(test_case, "M", cpu_features);
-                let m = m_.modulus();
+                let m_ = consume_modulus::<M>(test_case, "M");
+                let m = m_.modulus(cpu_features);
                 let expected_result = consume_elem(test_case, "R", &m);
                 let a =
                     consume_elem_unchecked::<M>(test_case, "A", expected_result.limbs.len() * 2);
@@ -826,8 +826,8 @@ mod tests {
 
                 struct M {}
                 struct O {}
-                let m = consume_modulus::<M>(test_case, "m", cpu_features);
-                let m = m.modulus();
+                let m = consume_modulus::<M>(test_case, "m");
+                let m = m.modulus(cpu_features);
                 let a = consume_elem_unchecked::<O>(test_case, "a", m.limbs().len());
                 let expected_result = consume_elem::<M>(test_case, "r", &m);
                 let other_modulus_len_bits = m.len_bits();
@@ -864,13 +864,9 @@ mod tests {
         }
     }
 
-    fn consume_modulus<M>(
-        test_case: &mut test::TestCase,
-        name: &str,
-        cpu_features: cpu::Features,
-    ) -> OwnedModulus<M> {
+    fn consume_modulus<M>(test_case: &mut test::TestCase, name: &str) -> OwnedModulus<M> {
         let value = test_case.consume_bytes(name);
-        OwnedModulus::from_be_bytes(untrusted::Input::from(&value), cpu_features).unwrap()
+        OwnedModulus::from_be_bytes(untrusted::Input::from(&value)).unwrap()
     }
 
     fn assert_elem_eq<M, E>(a: &Elem<M, E>, b: &Elem<M, E>) {

--- a/src/arithmetic/bigint/modulus.rs
+++ b/src/arithmetic/bigint/modulus.rs
@@ -75,8 +75,6 @@ pub struct OwnedModulus<M> {
     n0: N0,
 
     len_bits: BitLength,
-
-    cpu_features: cpu::Features,
 }
 
 impl<M: PublicModulus> Clone for OwnedModulus<M> {
@@ -85,16 +83,12 @@ impl<M: PublicModulus> Clone for OwnedModulus<M> {
             limbs: self.limbs.clone(),
             n0: self.n0,
             len_bits: self.len_bits,
-            cpu_features: self.cpu_features,
         }
     }
 }
 
 impl<M> OwnedModulus<M> {
-    pub(crate) fn from_be_bytes(
-        input: untrusted::Input,
-        cpu_features: cpu::Features,
-    ) -> Result<Self, error::KeyRejected> {
+    pub(crate) fn from_be_bytes(input: untrusted::Input) -> Result<Self, error::KeyRejected> {
         let n = BoxedLimbs::positive_minimal_width_from_be_bytes(input)?;
         if n.len() > MODULUS_MAX_LIMBS {
             return Err(error::KeyRejected::too_large());
@@ -135,7 +129,6 @@ impl<M> OwnedModulus<M> {
             limbs: n,
             n0,
             len_bits,
-            cpu_features,
         })
     }
 
@@ -158,13 +151,13 @@ impl<M> OwnedModulus<M> {
             encoding: PhantomData,
         })
     }
-    pub fn modulus(&self) -> Modulus<M> {
+    pub(crate) fn modulus(&self, cpu_features: cpu::Features) -> Modulus<M> {
         Modulus {
             limbs: &self.limbs,
             n0: self.n0,
             len_bits: self.len_bits,
             m: PhantomData,
-            cpu_features: self.cpu_features,
+            cpu_features,
         }
     }
 

--- a/src/rsa/public_modulus.rs
+++ b/src/rsa/public_modulus.rs
@@ -37,7 +37,7 @@ impl PublicModulus {
         const MIN_BITS: bits::BitLength = bits::BitLength::from_usize_bits(1024);
 
         // Step 3 / Step c for `n` (out of order).
-        let value = bigint::OwnedModulus::from_be_bytes(n, cpu_features)?;
+        let value = bigint::OwnedModulus::from_be_bytes(n)?;
         let bits = value.len_bits();
 
         // Step 1 / Step a. XXX: SP800-56Br1 and SP800-89 require the length of
@@ -52,7 +52,7 @@ impl PublicModulus {
         if bits > max_bits {
             return Err(error::KeyRejected::too_large());
         }
-        let oneRR = bigint::One::newRR(&value.modulus());
+        let oneRR = bigint::One::newRR(&value.modulus(cpu_features));
 
         Ok(Self { value, oneRR })
     }
@@ -69,8 +69,8 @@ impl PublicModulus {
         self.value.len_bits()
     }
 
-    pub(super) fn value(&self) -> bigint::Modulus<N> {
-        self.value.modulus()
+    pub(super) fn value(&self, cpu_features: cpu::Features) -> bigint::Modulus<N> {
+        self.value.modulus(cpu_features)
     }
 
     pub(super) fn oneRR(&self) -> &bigint::Elem<N, RR> {


### PR DESCRIPTION
Push the call of `cpu::features()` out towards the public API so that we can, in the future, expand the testing so that all variants can be tested without needing Intel SDE and other hacks.