### PR TITLE
cpu: Always use #[cfg] for target-arch-specific tests.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,7 @@ all-features = true
 name = "ring"
 
 [dependencies]
+cfg-if = { version = "1.0.0", default-features = false }
 getrandom = { version = "0.2.10" }
 untrusted = { version = "0.9" }
 

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -395,14 +395,16 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
     )))]
     let _cpu_features = cpu_features;
 
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
-        target_arch = "x86_64",
-        target_arch = "x86"
-    ))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
     {
-        if cpu::intel::AES.available(cpu_features) || cpu::arm::AES.available(cpu_features) {
+        if cpu::arm::AES.available(cpu_features) {
+            return Implementation::HWAES;
+        }
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    {
+        if cpu::intel::AES.available(cpu_features) {
             return Implementation::HWAES;
         }
     }

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -320,16 +320,16 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
     )))]
     let _cpu_features = cpu_features;
 
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
-        target_arch = "x86_64",
-        target_arch = "x86"
-    ))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
     {
-        if (cpu::intel::FXSR.available(cpu_features)
-            && cpu::intel::PCLMULQDQ.available(cpu_features))
-            || cpu::arm::PMULL.available(cpu_features)
+        if cpu::arm::PMULL.available(cpu_features) {
+            return Implementation::CLMUL;
+        }
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    {
+        if cpu::intel::FXSR.available(cpu_features) && cpu::intel::PCLMULQDQ.available(cpu_features)
         {
             return Implementation::CLMUL;
         }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -44,5 +44,8 @@ pub(crate) fn features() -> Features {
     Features(())
 }
 
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
 pub mod arm;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod intel;

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -81,6 +81,7 @@ pub(crate) const SSSE3: Feature = Feature {
     mask: 1 << 9,
 };
 
+#[allow(dead_code)]
 pub(crate) const SSE41: Feature = Feature {
     word: 1,
     mask: 1 << 19,

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -51,16 +51,19 @@ impl Feature {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) const ADX: Feature = Feature {
     word: 2,
     mask: 1 << 19,
 };
 
+#[allow(dead_code)]
 pub(crate) const BMI1: Feature = Feature {
     word: 2,
     mask: 1 << 3,
 };
 
+#[allow(dead_code)]
 pub(crate) const BMI2: Feature = Feature {
     word: 2,
     mask: 1 << 8,

--- a/src/ec/curve25519/ops.rs
+++ b/src/ec/curve25519/ops.rs
@@ -157,12 +157,20 @@ fn encode_point(x: Elem<T>, y: Elem<T>, z: Elem<T>) -> EncodedPoint {
     bytes
 }
 
-#[inline]
-pub(super) fn has_fe25519_adx(cpu: cpu::Features) -> bool {
-    cfg!(all(target_arch = "x86_64", not(target_os = "windows")))
-        && cpu::intel::ADX.available(cpu)
-        && cpu::intel::BMI1.available(cpu)
-        && cpu::intel::BMI2.available(cpu)
+cfg_if::cfg_if! {
+    if #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))] {
+        #[inline(always)]
+        pub(super) fn has_fe25519_adx(cpu: cpu::Features) -> bool {
+            cpu::intel::ADX.available(cpu)
+            && cpu::intel::BMI1.available(cpu)
+            && cpu::intel::BMI2.available(cpu)
+        }
+    } else {
+        #[inline(always)]
+        pub (super) fn has_fe25519_adx(_cpu: cpu::Features) -> bool {
+            false
+        }
+    }
 }
 
 prefixed_extern! {


### PR DESCRIPTION
Previously we were relying in part on the compiler and linker to work together to inline always-false guards around calls to architecture-specific functions that might not even exist. However, this isn't guaranteed to work, though so far it always has. Instead, use compile-time logic to guard all architecture-specific calls.

To help ensure tihs happens, only expose `cpu::intel` on Intel targets and similarly only expose `cpu::arm` on ARM targets.