### PR TITLE
Simplified `SystemRandom` with const constructor and `rand` (crate) API impl.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ name = "ring"
 [dependencies]
 cfg-if = { version = "1.0.0", default-features = false }
 getrandom = { version = "0.2.10" }
+rand = { version = "0.8.5", default-features = false, optional = true }
 untrusted = { version = "0.9" }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86",target_arch = "x86_64"))'.dependencies]
@@ -205,6 +206,7 @@ unstable-testing-arm-no-hw = []
 unstable-testing-arm-no-neon = []
 test_logging = []
 wasm32_unknown_unknown_js = ["getrandom/js"]
+rand-api = ["dep:rand"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -109,13 +109,13 @@ impl<T> RandomlyConstructable for T where T: self::sealed::RandomlyConstructable
 /// `fill()` once at a non-latency-sensitive time to minimize latency for
 /// future calls.
 #[derive(Clone, Debug)]
-pub struct SystemRandom(());
+pub struct SystemRandom;
 
 impl SystemRandom {
     /// Constructs a new `SystemRandom`.
     #[inline(always)]
     pub fn new() -> Self {
-        Self(())
+        Self
     }
 }
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -114,7 +114,7 @@ pub struct SystemRandom;
 impl SystemRandom {
     /// Constructs a new `SystemRandom`.
     #[inline(always)]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }


### PR DESCRIPTION
Quality of life PR to make rng easier to use. Anyone who understands `rand` can follow their examples to use `SystemRandom`.

### Considered changes not done in this PR (yet)
Remove superfluous `new` constructor
Add more docs
Back `ring::rand` with crate `rand` under feature flag

If you merge I will be like this: :>