### PR TITLE
CI: Move rustdoc tests to a separate matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,12 +271,6 @@ jobs:
         run: |
           cargo +${{ matrix.rust_channel }} test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
 
-      # --all-targets doesn't run doctests: https://github.com/rust-lang/cargo/issues/6669
-      # Run doctests only on x86_64 to avoid cross-compilation hassles with `--no-run`.
-      - if: ${{ !contains(matrix.host_os, 'windows') && contains(matrix.target, 'x86_64') }}
-        run: |
-          mk/cargo.sh +${{ matrix.rust_channel }} test -vv --doc --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
-
       # Check that all the needed symbol renaming was done.
       # TODO: Do this check on Windows too.
       # TODO: Check iOS too.
@@ -307,6 +301,30 @@ jobs:
       - run: rustup --version
 
       - run: cargo test -p ring-bench --all-features --all-targets
+
+  test-doc:
+    # Don't run duplicate `push` jobs for the repo owner's PRs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        rust_channel:
+          - stable
+          - nightly
+
+    steps:
+      - run: sudo apt-get update -y
+
+      - run: rustup toolchain add --profile=minimal ${{ matrix.rust_channel }}
+
+      - uses: briansmith/actions-checkout@v4
+        with:
+          persist-credentials: false
+
+      - run: |
+          cargo +${{ matrix.rust_channel }} test -vv --doc --all-features
 
   # XXX: GitHub Actions won't let us test all the combinations of features in
   # the "test" matrix because the resultant matrix would be larger than the


### PR DESCRIPTION
Only build/run rustdoc tests once, instead of in every `test` matrix entry.