### PR TITLE
Add riscv32 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
           - i686-unknown-linux-musl
           - powerpc-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
+          - riscv32gc-unknown-linux-gnu
           - wasm32-wasi
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
@@ -221,6 +222,9 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: riscv32gc-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: wasm32-wasi
@@ -494,6 +498,7 @@ jobs:
           - powerpc64-unknown-linux-gnu    # No assembly 64-bit big-endian with flags
           - powerpc64le-unknown-linux-gnu  # No assembly 64-bit little-endian with flags
           - riscv64gc-unknown-linux-gnu    # No assembly 64-bit little-endian without flags
+          - riscv32gc-unknown-linux-gnu    # No assembly 32-bit little-endian without flags
           - s390x-unknown-linux-gnu        # No assembly 64-bit big-endian
           - x86_64-unknown-linux-musl      # Has assembly
 
@@ -525,6 +530,9 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: riscv32gc-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: s390x-unknown-linux-gnu

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -52,7 +52,6 @@
 #define OPENSSL_RISCV64
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 4
 #define OPENSSL_32_BIT
-#define OPENSSL_RISCV32
 #elif defined(__s390x__)
 #define OPENSSL_64_BIT
 #define OPENSSL_S390X

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -50,6 +50,9 @@
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 8
 #define OPENSSL_64_BIT
 #define OPENSSL_RISCV64
+#elif defined(__riscv) && __SIZEOF_POINTER__ == 4
+#define OPENSSL_32_BIT
+#define OPENSSL_RISCV32
 #elif defined(__s390x__)
 #define OPENSSL_64_BIT
 #define OPENSSL_S390X

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -26,6 +26,7 @@ qemu_powerpc="qemu-ppc -L /usr/powerpc-linux-gnu"
 qemu_powerpc64="qemu-ppc64 -L /usr/powerpc64-linux-gnu"
 qemu_powerpc64le="qemu-ppc64le -L /usr/powerpc64le-linux-gnu"
 qemu_riscv64="qemu-riscv64 -L /usr/riscv64-linux-gnu"
+qemu_riscv32="qemu-riscv32 -L /usr/riscv32-linux-gnu"
 qemu_s390x="qemu-s390x -L /usr/s390x-linux-gnu"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
@@ -144,6 +145,12 @@ case $target in
     export AR_riscv64gc_unknown_linux_gnu=llvm-ar-$llvm_version
     export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
     export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="$qemu_riscv64"
+    ;;
+  riscv32gc-unknown-linux-gnu)
+    export CC_riscv32gc_unknown_linux_gnu=clang-$llvm_version
+    export AR_riscv32gc_unknown_linux_gnu=llvm-ar-$llvm_version
+    export CARGO_TARGET_RISCV32GC_UNKNOWN_LINUX_GNU_LINKER=riscv32-linux-gnu-gcc
+    export CARGO_TARGET_RISCV32GC_UNKNOWN_LINUX_GNU_RUNNER="$qemu_riscv32"
     ;;
   s390x-unknown-linux-gnu)
     export CC_s390x_unknown_linux_gnu=clang-$llvm_version

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -128,6 +128,12 @@ case $target in
     libc6-dev-riscv64-cross \
     qemu-user
   ;;
+--target=riscv32gc-unknown-linux-gnu)
+  use_clang=1
+  install_packages \
+    #https://github.com/riscv-collab/riscv-gnu-toolchain#installation-newliblinux-multilib
+    qemu-user
+  ;;
 --target=s390x-unknown-linux-gnu)
   # Clang is needed for code coverage.
   use_clang=1

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -143,6 +143,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "tvos",
     target_os = "vita",
     target_os = "windows",
+    target_os = "espidf",
     all(
         target_arch = "wasm32",
         any(


### PR DESCRIPTION
> I am happy to accept a PR that adds riscv32 support. I suggest we start with riscv32gc-unknown-linux-gnu since we can just copy-paste-edit the changes from PR https://github.com/briansmith/ring/pull/1627, at least for for target.h, mk/cargo.sh, mk/install-build-tools.sh.