### PR TITLE
Added MIPS 32-bit big-endian

### DIFF
--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -43,6 +43,9 @@
 #elif defined(__MIPSEL__) && defined(__LP64__)
 #define OPENSSL_64_BIT
 #define OPENSSL_MIPS64
+#elif defined(__MIPSEB__) && !defined(__LP64__)
+#define OPENSSL_32_BIT
+#define OPENSSL_MIPS
 #elif defined(__PPC64__) || defined(__powerpc64__)
 #define OPENSSL_64_BIT
 #elif (defined(__PPC__) || defined(__powerpc__)) && defined(_BIG_ENDIAN)

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -21,6 +21,7 @@ rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
 qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm_gnueabi="qemu-arm -L /usr/arm-linux-gnueabi"
 qemu_arm_gnueabihf="qemu-arm -L /usr/arm-linux-gnueabihf"
+qemu_mips="qemu-mips -L /usr/mips-linux-gnu"
 qemu_mipsel="qemu-mipsel -L /usr/mipsel-linux-gnu"
 qemu_powerpc="qemu-ppc -L /usr/powerpc-linux-gnu"
 qemu_powerpc64="qemu-ppc64 -L /usr/powerpc64-linux-gnu"
@@ -111,6 +112,12 @@ case $target in
     export CC_i686_unknown_linux_musl=clang-$llvm_version
     export AR_i686_unknown_linux_musl=llvm-ar-$llvm_version
     export CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_RUSTFLAGS="$rustflags_self_contained"
+    ;;
+  mips-unknown-linux-gnu)
+    export CC_mips_unknown_linux_gnu=mips-linux-gnu-gcc
+    export AR_mips_unknown_linux_gnu=mips-linux-gnu-gcc-ar
+    export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc
+    export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="$qemu_mips"
     ;;
   mipsel-unknown-linux-gnu)
     export CC_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -94,6 +94,12 @@ case $target in
 --target=loongarch64-unknown-linux-gnu)
   use_clang=1
   ;;
+--target=mips-unknown-linux-gnu)
+  install_packages \
+    gcc-mips-linux-gnu \
+    libc6-dev-mips-cross \
+    qemu-user
+  ;;
 --target=mipsel-unknown-linux-gnu)
   install_packages \
     gcc-mipsel-linux-gnu \


### PR DESCRIPTION
Now that ring has generic fallback code, we can compile it for new targets by allowing them through target.h checks.
I'd like to add MIPS support. This works well (all unit tests pass, and our application works on the target).
Unfortunately the Rust compiler recently got broken for MIPS, so version 1.71 or earlier is required.
Same as https://github.com/briansmith/ring/pull/1859, but without the unsquashable multiple commits over > 1 branch.