### PR TITLE
internal: Add generalized "noinline" attribute support.

### DIFF
--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -132,6 +132,14 @@
 #include <stdalign.h>
 #endif
 
+#if defined(__clang__) || defined(__GNUC__)
+#define RING_NOINLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define RING_NOINLINE __declspec(noinline)
+#else
+#define RING_NOINLINE
+#endif
+
 // Some C compilers require a useless cast when dealing with arrays for the
 // reason explained in
 // https://gustedt.wordpress.com/2011/02/12/const-and-arrays/

--- a/third_party/fiat/curve25519_64_adx.h
+++ b/third_party/fiat/curve25519_64_adx.h
@@ -463,7 +463,7 @@ static void fe4_invert(fe4 out, const fe4 z) {
   fe4_mul(out, t1, t0);
 }
 
-__attribute__((noinline)) // https://github.com/rust-lang/rust/issues/116573
+RING_NOINLINE // https://github.com/rust-lang/rust/issues/116573
 __attribute__((target("adx,bmi2")))
 void x25519_scalar_mult_adx(uint8_t out[32], const uint8_t scalar[32],
                             const uint8_t point[32]) {
@@ -640,7 +640,7 @@ static inline void table_select_4(ge_precomp_4 *t, const int pos,
 //
 // Preconditions:
 //   a[31] <= 127
-__attribute__((noinline)) // https://github.com/rust-lang/rust/issues/116573
+RING_NOINLINE // https://github.com/rust-lang/rust/issues/116573
 __attribute__((target("adx,bmi2")))
 void x25519_ge_scalarmult_base_adx(uint8_t h[4][32], const uint8_t a[32]) {
   signed char e[64];


### PR DESCRIPTION
There are some functions that we never want to be (cross-language) inlined, and we expect to add more. Make it easier to add more, and make it easier to extend this capability to more C compilers.