### PR TITLE
clippy: fix warning on aarch64

### DIFF
--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -344,7 +344,7 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
 
     #[cfg(target_arch = "aarch64")]
     {
-        return Implementation::NEON;
+        Implementation::NEON
     }
 
     #[cfg(not(target_arch = "aarch64"))]


### PR DESCRIPTION
Fix `warning: unneeded `return` statement` on aarch65