### PR TITLE
aes-gcm: Don't assume NEON is available on AArch64.

### DIFF
--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -165,7 +165,6 @@ impl Key {
                 set_encrypt_key!(vpaes_set_encrypt_key, bytes, key_bits, &mut key)?
             }
 
-            #[cfg(not(target_arch = "aarch64"))]
             Implementation::NOHW => {
                 set_encrypt_key!(aes_nohw_set_encrypt_key, bytes, key_bits, &mut key)?
             }
@@ -193,7 +192,6 @@ impl Key {
             ))]
             Implementation::VPAES_BSAES => encrypt_block!(vpaes_encrypt, a, self),
 
-            #[cfg(not(target_arch = "aarch64"))]
             Implementation::NOHW => encrypt_block!(aes_nohw_encrypt, a, self),
         }
     }
@@ -272,7 +270,6 @@ impl Key {
                 });
             }
 
-            #[cfg(not(target_arch = "aarch64"))]
             Implementation::NOHW => {
                 ctr32_encrypt_blocks!(aes_nohw_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr)
             }
@@ -381,7 +378,6 @@ pub enum Implementation {
     ))]
     VPAES_BSAES = 2,
 
-    #[cfg(not(target_arch = "aarch64"))]
     NOHW = 3,
 }
 
@@ -416,19 +412,13 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
         }
     }
 
-    #[cfg(target_arch = "arm")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
     {
         if cpu::arm::NEON.available(cpu_features) {
             return Implementation::VPAES_BSAES;
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
-    {
-        Implementation::VPAES_BSAES
-    }
-
-    #[cfg(not(target_arch = "aarch64"))]
     {
         Implementation::NOHW
     }

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -19,7 +19,6 @@ use super::{
 use crate::{cpu, polyfill::ArraySplitMap};
 use core::ops::BitXorAssign;
 
-#[cfg(not(target_arch = "aarch64"))]
 mod gcm_nohw;
 
 #[derive(Clone)]
@@ -74,7 +73,6 @@ impl Key {
                 }
             }
 
-            #[cfg(not(target_arch = "aarch64"))]
             Implementation::Fallback => {
                 h_table.Htable[0] = gcm_nohw::init(h);
             }
@@ -185,7 +183,6 @@ impl Context {
                 }
             }
 
-            #[cfg(not(target_arch = "aarch64"))]
             Implementation::Fallback => {
                 gcm_nohw::ghash(xi, h_table.Htable[0], input);
             }
@@ -227,7 +224,6 @@ impl Context {
                 }
             }
 
-            #[cfg(not(target_arch = "aarch64"))]
             Implementation::Fallback => {
                 gcm_nohw::gmult(xi, h_table.Htable[0]);
             }
@@ -305,7 +301,6 @@ enum Implementation {
     #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
     NEON,
 
-    #[cfg(not(target_arch = "aarch64"))]
     Fallback,
 }
 
@@ -335,19 +330,13 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
         }
     }
 
-    #[cfg(target_arch = "arm")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
     {
         if cpu::arm::NEON.available(cpu_features) {
             return Implementation::NEON;
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
-    {
-        return Implementation::NEON;
-    }
-
-    #[cfg(not(target_arch = "aarch64"))]
     Implementation::Fallback
 }
 


### PR DESCRIPTION
Some of the assembly probably assumes NEON is available on Aarch64, so don't remove the assertion in the feature detection logic. But move closer to supporting NEON-less Aarch64 configurations, e.g. within an OS kernel or when NEON is disabled for testing purposes, or when we have a target that for whatever reason doesn't statically enable NEON for AAarch64 and also doesn't support dynamic feature detection.