### PR TITLE
CI: Use macos-13-large instead of macos-13-xlarge for aarch64-apple-darwin jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
 
         include:
           - target: aarch64-apple-darwin
-            host_os: macos-13-xlarge
+            host_os: macos-13-large
 
           - target: aarch64-apple-ios
             host_os: macos-13


### PR DESCRIPTION


Running these jobs cost $111.04 in December.