### PR TITLE
CI: Use macos-13 instead of macos-13-xlarge for most aarch64-apple-darwin jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,19 @@ jobs:
 
         include:
           - target: aarch64-apple-darwin
-            host_os: macos-13-xlarge
+            mode: --release
+            rust_channel: stable
+            host_os: macos-13-xlarge # This always costs $$$ but can actually run the tests.
+
+          - target: aarch64-apple-darwin
+            rust_channel: 1.61.0
+            host_os: macos-13 # This can use free credits...
+            cargo_options: --no-run # ... but can't run the tests.
+
+          - target: aarch64-apple-darwin
+            mode: # debug
+            host_os: macos-13 # This can use free credits...
+            cargo_options: --no-run # ... but can't run the tests.
 
           - target: aarch64-apple-ios
             host_os: macos-13


### PR DESCRIPTION
Running these jobs cost $111.04 in December. Reduce the cost by an expected 75%.