### PR TITLE
target.h: Only define `OPENSSL_<arch>` when we have code specific to that arch.

### DIFF
--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -36,10 +36,8 @@
 #define OPENSSL_ARM
 #elif defined(__loongarch_lp64)
 #define OPENSSL_64_BIT
-#define OPENSSL_LOONGARCH64
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 8
 #define OPENSSL_64_BIT
-#define OPENSSL_RISCV64
 #elif defined(__wasm__)
 #define OPENSSL_32_BIT
 // All of following architectures are only supported when `__BYTE_ORDER__` can be used to detect
@@ -52,17 +50,14 @@
 #error "Unsupported endianness"
 #elif defined(__MIPSEL__) && !defined(__LP64__)
 #define OPENSSL_32_BIT
-#define OPENSSL_MIPS
 #elif defined(__MIPSEL__) && defined(__LP64__)
 #define OPENSSL_64_BIT
-#define OPENSSL_MIPS64
 #elif defined(__PPC64__) || defined(__powerpc64__)
 #define OPENSSL_64_BIT
 #elif (defined(__PPC__) || defined(__powerpc__))
 #define OPENSSL_32_BIT
 #elif defined(__s390x__)
 #define OPENSSL_64_BIT
-#define OPENSSL_S390X
 #else
 #error "Unknown target CPU"
 #endif


### PR DESCRIPTION
New architecture-conditional logic should be done Rust, not in C.