### PR TITLE
CI: Use llvm-tools-preview instead of external llvm-tools for symbol prefix testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,10 +290,16 @@ jobs:
       #       Unknown attribute kind (528)
       #       (Producer: 'LLVM12.0.0-rust-1.54.0-nightly'
       #       Reader: 'LLVM APPLE_1_1200.0.32.29_0')
+
+      - if: ${{ matrix.target != 'aarch64-apple-ios' &&
+          !contains(matrix.host_os, 'windows') &&
+          (!contains(matrix.host_os, 'macos') || matrix.mode != '--release') }}
+        run: rustup toolchain install --component=llvm-tools-preview ${{ matrix.rust_channel }}
+
       - if: ${{ matrix.target != 'aarch64-apple-ios' &&
                 !contains(matrix.host_os, 'windows') &&
                 (!contains(matrix.host_os, 'macos') || matrix.mode != '--release') }}
-        run: mk/check-symbol-prefixes.sh --target=${{ matrix.target }}
+        run: mk/check-symbol-prefixes.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
 
   test-bench:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
@@ -419,11 +425,16 @@ jobs:
       #       Unknown attribute kind (528)
       #       (Producer: 'LLVM12.0.0-rust-1.54.0-nightly'
       #       Reader: 'LLVM APPLE_1_1200.0.32.29_0')
+
       - if: ${{ matrix.target != 'aarch64-apple-ios' &&
           !contains(matrix.host_os, 'windows') &&
           (!contains(matrix.host_os, 'macos') || matrix.mode != '--release') }}
-        run: mk/check-symbol-prefixes.sh --target=${{ matrix.target }}
+        run: rustup toolchain install --component=llvm-tools-preview ${{ matrix.rust_channel }}
 
+      - if: ${{ matrix.target != 'aarch64-apple-ios' &&
+          !contains(matrix.host_os, 'windows') &&
+          (!contains(matrix.host_os, 'macos') || matrix.mode != '--release') }}
+        run: mk/check-symbol-prefixes.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
 
   # The wasm32-unknown-unknown targets have a different set of feature sets and
   # an additional `webdriver` dimension.
@@ -477,7 +488,8 @@ jobs:
 
       # Check that all the needed symbol renaming was done.
       # TODO: Do this check on Windows too.
-      - run: mk/check-symbol-prefixes.sh --target=${{ matrix.target }}
+      - run: rustup toolchain install --component=llvm-tools-preview ${{ matrix.rust_channel }}
+      - run: mk/check-symbol-prefixes.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
 
   coverage:
     # Don't run duplicate `push` jobs for the repo owner's PRs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,20 +285,13 @@ jobs:
 
       # Check that all the needed symbol renaming was done.
       # TODO: Do this check on Windows too.
-      # TODO: Check iOS too.
-      # TODO: Do this on Apple-hosted release builds too; currently these fail with:
-      #       Unknown attribute kind (528)
-      #       (Producer: 'LLVM12.0.0-rust-1.54.0-nightly'
-      #       Reader: 'LLVM APPLE_1_1200.0.32.29_0')
 
-      - if: ${{ matrix.target != 'aarch64-apple-ios' &&
-          !contains(matrix.host_os, 'windows') &&
-          (!contains(matrix.host_os, 'macos') || matrix.mode != '--release') }}
+      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.61.0') &&
+                !contains(matrix.host_os, 'windows') }}
         run: rustup toolchain install --component=llvm-tools-preview ${{ matrix.rust_channel }}
 
-      - if: ${{ matrix.target != 'aarch64-apple-ios' &&
-                !contains(matrix.host_os, 'windows') &&
-                (!contains(matrix.host_os, 'macos') || matrix.mode != '--release') }}
+      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.61.0') &&
+                !contains(matrix.host_os, 'windows') }}
         run: mk/check-symbol-prefixes.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
 
   test-bench:
@@ -420,20 +413,13 @@ jobs:
 
       # Check that all the needed symbol renaming was done.
       # TODO: Do this check on Windows too.
-      # TODO: Check iOS too.
-      # TODO: Do this on Apple-hosted release builds too; currently these fail with:
-      #       Unknown attribute kind (528)
-      #       (Producer: 'LLVM12.0.0-rust-1.54.0-nightly'
-      #       Reader: 'LLVM APPLE_1_1200.0.32.29_0')
 
-      - if: ${{ matrix.target != 'aarch64-apple-ios' &&
-          !contains(matrix.host_os, 'windows') &&
-          (!contains(matrix.host_os, 'macos') || matrix.mode != '--release') }}
+      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.61.0') &&
+          !contains(matrix.host_os, 'windows') }}
         run: rustup toolchain install --component=llvm-tools-preview ${{ matrix.rust_channel }}
 
-      - if: ${{ matrix.target != 'aarch64-apple-ios' &&
-          !contains(matrix.host_os, 'windows') &&
-          (!contains(matrix.host_os, 'macos') || matrix.mode != '--release') }}
+      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.61.0') &&
+          !contains(matrix.host_os, 'windows') }}
         run: mk/check-symbol-prefixes.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
 
   # The wasm32-unknown-unknown targets have a different set of feature sets and

--- a/mk/check-symbol-prefixes.sh
+++ b/mk/check-symbol-prefixes.sh
@@ -17,6 +17,16 @@
 set -eux -o pipefail
 IFS=$'\n\t'
 
+for arg in $*; do
+  case $arg in
+    --target=*)
+      target=${arg#*=}
+      ;;
+    *)
+      ;;
+  esac
+done
+
 case "$OSTYPE" in
 darwin*)
   nm_exe=nm
@@ -35,7 +45,7 @@ esac
 #
 # This is very liberal in filtering out symbols that "look like"
 # Rust-compiler-generated symbols.
-find target -type f -name libring-*.rlib | while read -r infile; do
+find target/$target -type f -name libring-*.rlib | while read -r infile; do
   bad=$($nm_exe --defined-only --extern-only --print-file-name "$infile" \
     | ( grep -v -E " . _?(__imp__ZN4ring|ring_core_|__rustc|_ZN|DW.ref.rust_eh_personality)" || [[ $? == 1 ]] ))
   if [ ! -z "${bad-}" ]; then

--- a/mk/check-symbol-prefixes.sh
+++ b/mk/check-symbol-prefixes.sh
@@ -22,20 +22,16 @@ for arg in $*; do
     --target=*)
       target=${arg#*=}
       ;;
+    +*)
+      toolchain=${arg#*+}
+      ;;
     *)
       ;;
   esac
 done
 
-case "$OSTYPE" in
-darwin*)
-  nm_exe=nm
-  ;;
-*)
-  llvm_version=16
-  nm_exe=llvm-nm-$llvm_version
-  ;;
-esac
+# Use the host target-libdir, not the target target-libdir.
+nm_exe=$(rustc +${toolchain} --print target-libdir)/../bin/llvm-nm
 
 # TODO: This should only look in one target directory.
 # TODO: This isn't as strict as it should be.


### PR DESCRIPTION
See individual commit messages for details. This makes the script portable to all hosts and allows us to expand the symbol prefix checking to all tested targets. It also allows us to avoid incompatibilities between Apple nm and the toolchain's output.