### PR TITLE
CI: Add mips64el- to test matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,11 @@ jobs:
             rust_channel: 1.71.0 # No prebuilt toolchain for later versions.
             host_os: ubuntu-22.04
 
+          - target: mips64el-unknown-linux-gnuabi64
+            mode: --release
+            rust_channel: 1.71.0 # No prebuilt toolchain for later versions.
+            host_os: ubuntu-22.04
+
           - target: mipsel-unknown-linux-gnu
             mode: --release
             rust_channel: 1.71.0 # No prebuilt toolchain for later versions.

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -22,6 +22,8 @@ qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm_gnueabi="qemu-arm -L /usr/arm-linux-gnueabi"
 qemu_arm_gnueabihf="qemu-arm -L /usr/arm-linux-gnueabihf"
 qemu_mips="qemu-mips -L /usr/mips-linux-gnu"
+qemu_mips64="qemu-mips64 -L /usr/mips64-linux-gnuabi64"
+qemu_mips64el="qemu-mips64el -L /usr/mips64el-linux-gnuabi64"
 qemu_mipsel="qemu-mipsel -L /usr/mipsel-linux-gnu"
 qemu_powerpc="qemu-ppc -L /usr/powerpc-linux-gnu"
 qemu_powerpc64="qemu-ppc64 -L /usr/powerpc64-linux-gnu"
@@ -118,6 +120,18 @@ case $target in
     export AR_mips_unknown_linux_gnu=mips-linux-gnu-gcc-ar
     export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc
     export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="$qemu_mips"
+    ;;
+  mips64-unknown-linux-gnuabi64)
+    export CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc
+    export AR_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc-ar
+    export CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc
+    export CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_RUNNER="$qemu_mips64"
+    ;;
+  mips64el-unknown-linux-gnuabi64)
+    export CC_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-gcc
+    export AR_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-gcc-ar
+    export CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER=mips64el-linux-gnuabi64-gcc
+    export CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER="$qemu_mips64el"
     ;;
   mipsel-unknown-linux-gnu)
     export CC_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -100,6 +100,18 @@ case $target in
     libc6-dev-mips-cross \
     qemu-user
   ;;
+--target=mips64-unknown-linux-gnuabi64)
+  install_packages \
+    gcc-mips64-linux-gnuabi64 \
+    libc6-dev-mips64-cross \
+    qemu-user
+  ;;
+--target=mips64el-unknown-linux-gnuabi64)
+  install_packages \
+    gcc-mips64el-linux-gnuabi64 \
+    libc6-dev-mips64el-cross \
+    qemu-user
+  ;;
 --target=mipsel-unknown-linux-gnu)
   install_packages \
     gcc-mipsel-linux-gnu \


### PR DESCRIPTION
mips64- (big-endian) wasn't added to the test matrix because it isn't enabled in target.h.