### PR TITLE
Add support for watchOS.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -264,7 +264,7 @@ const LINUX_ABI: &[&str] = &[
 
 /// Operating systems that have the same ABI as macOS on every architecture
 /// mentioned in `ASM_TARGETS`.
-const MACOS_ABI: &[&str] = &["ios", "macos", "tvos"];
+const MACOS_ABI: &[&str] = &["ios", "macos", "tvos", "watchos"];
 
 const WINDOWS: &str = "windows";
 

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -63,7 +63,11 @@ fn x25519_public_from_private(
     let private_key: &[u8; SCALAR_LEN] = private_key.bytes_less_safe().try_into()?;
     let private_key = ops::MaskedScalar::from_bytes_masked(*private_key);
 
-    #[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+    #[cfg(all(
+        target_arch = "arm",
+        not(target_os = "ios"),
+        not(target_os = "watchos")
+    ))]
     {
         if cpu::arm::NEON.available(cpu_features) {
             static MONTGOMERY_BASE_POINT: [u8; 32] = [
@@ -109,7 +113,11 @@ fn x25519_ecdh(
         point: &ops::EncodedPoint,
         #[allow(unused_variables)] cpu_features: cpu::Features,
     ) {
-        #[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+        #[cfg(all(
+            target_arch = "arm",
+            not(target_os = "ios"),
+            not(target_os = "watchos")
+        ))]
         {
             if cpu::arm::NEON.available(cpu_features) {
                 return x25519_neon(out, scalar, point);
@@ -158,7 +166,11 @@ fn x25519_ecdh(
     Ok(())
 }
 
-#[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+#[cfg(all(
+    target_arch = "arm",
+    not(target_os = "ios"),
+    not(target_os = "watchos")
+))]
 fn x25519_neon(out: &mut ops::EncodedPoint, scalar: &ops::MaskedScalar, point: &ops::EncodedPoint) {
     prefixed_extern! {
         fn x25519_NEON(

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -142,6 +142,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "solaris",
     target_os = "tvos",
     target_os = "vita",
+    target_os = "watchos",
     target_os = "windows",
     all(
         target_arch = "wasm32",


### PR DESCRIPTION
Hoping to make a follow-up PR to #1689 to add watchOS support, although in the current state this doesn't yet work for all of the targets:

- `aarch64-apple-watchos` is the only target to compile happily, although I don't believe there's any hardware actually using this yet 🙈
- `armv7k-apple-watchos` builds although there are 4 warnings about .o files with no symbols which I'm not sure if that is to be expected or not?
- `arm64_32-apple-watchos` fails to build, due to a couple of `implicit conversion loses integer precision` errors. I think this makes sense as arm64_32 is considered to be aarch64 by Rust, even if the pointer size is 32-bit but I have no idea where to fix this.
- `aarch64-apple-watchos-sim` and `x86_64-apple-watchos-sim` both fail to build due to conflicting clang arguments `-mwatchsimulator-version-min=2.0` and `--target={aarch64|x86_64}-apple-watchos5.0-simulator`, although again, I'm failing to see where these 2 parameters come from 🤔

Any pointers towards potential answers would be greatly appreciated 🙂

**Build output**

<details>
<summary>aarch64-apple-watchos ✅</summary>
<pre><code>ring git:(watchos) ❯ cargo +nightly build -Zbuild-std --target "aarch64-apple-watchos"
   Compiling ring v0.17.7 (/Users/runner/Fork/ring)
warning: field `0` is never read
  --> src/arithmetic/n0.rs:19:15
   |19
   | pub struct N0([Limb; 2]);
   |            -- ^^^^^^^^^
   |            |
   |            field in this struct
   |
   = note: `N0` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
19 | pub struct N0(());
   |               ~~

warning: field `0` is never read
  --> src/ec/curve25519/scalar.rs:18:19
   |
18 | pub struct Scalar([u8; SCALAR_LEN]);
   |            ------ ^^^^^^^^^^^^^^^^
   |            |
   |            field in this struct
   |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
18 | pub struct Scalar(());
   |                   ~~

warning: `ring` (lib) generated 2 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 1.90s</code></pre>
</details>

<details>
<summary>armv7k-apple-watchos ❓</summary>
<pre><code>ring git:(watchos) ❯ cargo +nightly build -Zbuild-std --target "armv7k-apple-watchos"
warning: ring@0.17.7: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: /Users/runner/Fork/ring/target/armv7k-apple-watchos/debug/build/ring-e19af6c0555b724d/out/libring_core_0_17_7_.a(x25519-asm-arm.o) has no symbols
warning: ring@0.17.7: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: /Users/runner/Fork/ring/target/armv7k-apple-watchos/debug/build/ring-e19af6c0555b724d/out/libring_core_0_17_7_.a(poly1305_arm_asm.o) has no symbols
warning: ring@0.17.7: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: /Users/runner/Fork/ring/target/armv7k-apple-watchos/debug/build/ring-e19af6c0555b724d/out/libring_core_0_17_7_.a(x25519-asm-arm.o) has no symbols
warning: ring@0.17.7: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: /Users/runner/Fork/ring/target/armv7k-apple-watchos/debug/build/ring-e19af6c0555b724d/out/libring_core_0_17_7_.a(poly1305_arm_asm.o) has no symbols
   Compiling ring v0.17.7 (/Users/runner/Fork/ring)
warning: field `0` is never read
  --> src/arithmetic/n0.rs:19:15
   |
19 | pub struct N0([Limb; 2]);
   |            -- ^^^^^^^^^
   |            |
   |            field in this struct
   |
   = note: `N0` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
19 | pub struct N0(());
   |               ~~

warning: field `0` is never read
  --> src/ec/curve25519/scalar.rs:18:19
   |
18 | pub struct Scalar([u8; SCALAR_LEN]);
   |            ------ ^^^^^^^^^^^^^^^^
   |            |
   |            field in this struct
   |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
18 | pub struct Scalar(());
   |                   ~~

warning: `ring` (lib) generated 2 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 1.29s</pre></code>
</details>

<details>
<summary>arm64_32-apple-watchos ❌</summary>
<pre><code>ring git:(watchos) ❯ cargo +nightly build -Zbuild-std --target "arm64_32-apple-watchos"
   Compiling ring v0.17.7 (/Users/runner/Fork/ring)
The following warnings were emitted during compilation:

warning: ring@0.17.7: In file included from crypto/fipsmodule/ec/gfp_p384.c:246:
warning: ring@0.17.7: crypto/fipsmodule/ec/ecp_nistz384.inl:167:35: error: implicit conversion loses integer precision: 'crypto_word_t' (aka 'unsigned long long') to 'size_t' (aka 'unsigned long') [-Werror,-Wshorten-64-to-32]
warning: ring@0.17.7:   p384_point_select_w5(&h, table, recoded);
warning: ring@0.17.7:   ~~~~~~~~~~~~~~~~~~~~            ^~~~~~~
warning: ring@0.17.7: crypto/fipsmodule/ec/ecp_nistz384.inl:230:34: error: implicit conversion loses integer precision: 'crypto_word_t' (aka 'unsigned long long') to 'size_t' (aka 'unsigned long') [-Werror,-Wshorten-64-to-32]
warning: ring@0.17.7:   p384_point_select_w5(r, table, recoded);
warning: ring@0.17.7:   ~~~~~~~~~~~~~~~~~~~~           ^~~~~~~
warning: ring@0.17.7: 2 errors generated.

error: failed to run custom build command for `ring v0.17.7 (/Users/runner/Fork/ring)`

Caused by:
  process didn't exit successfully: `/Users/runner/Fork/ring/target/debug/build/ring-46c716d55784f0d8/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=RING_PREGENERATE_ASM
  cargo:rustc-env=RING_CORE_PREFIX=ring_core_0_17_7_
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  OPT_LEVEL = Some("0")
  TARGET = Some("arm64_32-apple-watchos")
  HOST = Some("x86_64-apple-darwin")
  cargo:rerun-if-env-changed=CC_arm64_32-apple-watchos
  CC_arm64_32-apple-watchos = None
  cargo:rerun-if-env-changed=CC_arm64_32_apple_watchos
  CC_arm64_32_apple_watchos = None
  cargo:rerun-if-env-changed=TARGET_CC
  TARGET_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  Detecting WatchOS SDK path for watchos
  running: "xcrun" "--show-sdk-path" "--sdk" "watchos"
  exit status: 0
  cargo:rerun-if-env-changed=CFLAGS_arm64_32-apple-watchos
  CFLAGS_arm64_32-apple-watchos = None
  cargo:rerun-if-env-changed=CFLAGS_arm64_32_apple_watchos
  CFLAGS_arm64_32_apple_watchos = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64_32-apple-watchos" "-arch" "arm64_32" "-mwatchos-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/crypto/curve25519/curve25519.o" "-c" "crypto/curve25519/curve25519.c"
  exit status: 0
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64_32-apple-watchos" "-arch" "arm64_32" "-mwatchos-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/crypto/fipsmodule/aes/aes_nohw.o" "-c" "crypto/fipsmodule/aes/aes_nohw.c"
  exit status: 0
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64_32-apple-watchos" "-arch" "arm64_32" "-mwatchos-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/crypto/fipsmodule/bn/montgomery.o" "-c" "crypto/fipsmodule/bn/montgomery.c"
  exit status: 0
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64_32-apple-watchos" "-arch" "arm64_32" "-mwatchos-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/crypto/fipsmodule/bn/montgomery_inv.o" "-c" "crypto/fipsmodule/bn/montgomery_inv.c"
  exit status: 0
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64_32-apple-watchos" "-arch" "arm64_32" "-mwatchos-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/crypto/fipsmodule/ec/ecp_nistz.o" "-c" "crypto/fipsmodule/ec/ecp_nistz.c"
  exit status: 0
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64_32-apple-watchos" "-arch" "arm64_32" "-mwatchos-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/crypto/fipsmodule/ec/gfp_p256.o" "-c" "crypto/fipsmodule/ec/gfp_p256.c"
  exit status: 0
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64_32-apple-watchos" "-arch" "arm64_32" "-mwatchos-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/crypto/fipsmodule/ec/gfp_p384.o" "-c" "crypto/fipsmodule/ec/gfp_p384.c"
  cargo:warning=In file included from crypto/fipsmodule/ec/gfp_p384.c:246:

  cargo:warning=crypto/fipsmodule/ec/ecp_nistz384.inl:167:35: error: implicit conversion loses integer precision: 'crypto_word_t' (aka 'unsigned long long') to 'size_t' (aka 'unsigned long') [-Werror,-Wshorten-64-to-32]

  cargo:warning=  p384_point_select_w5(&h, table, recoded);

  cargo:warning=  ~~~~~~~~~~~~~~~~~~~~            ^~~~~~~

  cargo:warning=crypto/fipsmodule/ec/ecp_nistz384.inl:230:34: error: implicit conversion loses integer precision: 'crypto_word_t' (aka 'unsigned long long') to 'size_t' (aka 'unsigned long') [-Werror,-Wshorten-64-to-32]

  cargo:warning=  p384_point_select_w5(r, table, recoded);

  cargo:warning=  ~~~~~~~~~~~~~~~~~~~~           ^~~~~~~

  cargo:warning=2 errors generated.

  exit status: 1

  --- stderr
  running "perl" "crypto/fipsmodule/aes/asm/aesv8-armx.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/aesv8-armx-ios64.S"
  running "perl" "crypto/fipsmodule/modes/asm/ghashv8-armx.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/ghashv8-armx-ios64.S"
  running "perl" "crypto/chacha/asm/chacha-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/chacha-armv8-ios64.S"
  running "perl" "crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/chacha20_poly1305_armv8-ios64.S"
  running "perl" "crypto/fipsmodule/aes/asm/vpaes-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/vpaes-armv8-ios64.S"
  running "perl" "crypto/fipsmodule/bn/asm/armv8-mont.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/armv8-mont-ios64.S"
  running "perl" "crypto/fipsmodule/ec/asm/p256-armv8-asm.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/p256-armv8-asm-ios64.S"
  running "perl" "crypto/fipsmodule/modes/asm/ghash-neon-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/ghash-neon-armv8-ios64.S"
  running "perl" "crypto/fipsmodule/sha/asm/sha512-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/sha512-armv8-ios64.S"
  running "perl" "crypto/fipsmodule/sha/asm/sha512-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/sha256-armv8-ios64.S"


  error occurred: Command "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64_32-apple-watchos" "-arch" "arm64_32" "-mwatchos-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/arm64_32-apple-watchos/debug/build/ring-09e11a18001a51a3/out/crypto/fipsmodule/ec/gfp_p384.o" "-c" "crypto/fipsmodule/ec/gfp_p384.c" with args "clang" did not execute successfully (status code exit status: 1).</pre></code>
</details>

<details>
<summary> aarch64-apple-watchos-sim ❌</summary>
<pre><code>ring git:(watchos) ❯ cargo +nightly build -Zbuild-std --target "aarch64-apple-watchos-sim"
   Compiling ring v0.17.7 (/Users/runner/Fork/ring)
The following warnings were emitted during compilation:

warning: ring@0.17.7: clang: error: overriding '-mwatchsimulator-version-min=2.0' option with '--target=arm64-apple-watchos5.0-simulator' [-Werror,-Woverriding-t-option]

error: failed to run custom build command for `ring v0.17.7 (/Users/runner/Fork/ring)`

Caused by:
  process didn't exit successfully: `/Users/runner/Fork/ring/target/debug/build/ring-46c716d55784f0d8/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=RING_PREGENERATE_ASM
  cargo:rustc-env=RING_CORE_PREFIX=ring_core_0_17_7_
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  OPT_LEVEL = Some("0")
  TARGET = Some("aarch64-apple-watchos-sim")
  HOST = Some("x86_64-apple-darwin")
  cargo:rerun-if-env-changed=CC_aarch64-apple-watchos-sim
  CC_aarch64-apple-watchos-sim = None
  cargo:rerun-if-env-changed=CC_aarch64_apple_watchos_sim
  CC_aarch64_apple_watchos_sim = None
  cargo:rerun-if-env-changed=TARGET_CC
  TARGET_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  Detecting WatchOS SDK path for watchsimulator
  running: "xcrun" "--show-sdk-path" "--sdk" "watchsimulator"
  exit status: 0
  cargo:rerun-if-env-changed=CFLAGS_aarch64-apple-watchos-sim
  CFLAGS_aarch64-apple-watchos-sim = None
  cargo:rerun-if-env-changed=CFLAGS_aarch64_apple_watchos_sim
  CFLAGS_aarch64_apple_watchos_sim = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64-apple-watchos5.0-simulator" "-arch" "arm64" "-mwatchsimulator-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/crypto/curve25519/curve25519.o" "-c" "crypto/curve25519/curve25519.c"
  cargo:warning=clang: error: overriding '-mwatchsimulator-version-min=2.0' option with '--target=arm64-apple-watchos5.0-simulator' [-Werror,-Woverriding-t-option]

  exit status: 1

  --- stderr
  running "perl" "crypto/fipsmodule/aes/asm/aesv8-armx.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/aesv8-armx-ios64.S"
  running "perl" "crypto/fipsmodule/modes/asm/ghashv8-armx.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/ghashv8-armx-ios64.S"
  running "perl" "crypto/chacha/asm/chacha-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/chacha-armv8-ios64.S"
  running "perl" "crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/chacha20_poly1305_armv8-ios64.S"
  running "perl" "crypto/fipsmodule/aes/asm/vpaes-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/vpaes-armv8-ios64.S"
  running "perl" "crypto/fipsmodule/bn/asm/armv8-mont.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/armv8-mont-ios64.S"
  running "perl" "crypto/fipsmodule/ec/asm/p256-armv8-asm.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/p256-armv8-asm-ios64.S"
  running "perl" "crypto/fipsmodule/modes/asm/ghash-neon-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/ghash-neon-armv8-ios64.S"
  running "perl" "crypto/fipsmodule/sha/asm/sha512-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/sha512-armv8-ios64.S"
  running "perl" "crypto/fipsmodule/sha/asm/sha512-armv8.pl" "ios64" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/sha256-armv8-ios64.S"


  error occurred: Command "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64-apple-watchos5.0-simulator" "-arch" "arm64" "-mwatchsimulator-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/aarch64-apple-watchos-sim/debug/build/ring-11a107ac5fda9a2a/out/crypto/curve25519/curve25519.o" "-c" "crypto/curve25519/curve25519.c" with args "clang" did not execute successfully (status code exit status: 1).</pre></code>
</details>

<details>
<summary>x86_64-apple-watchos-sim ❌</summary>
ring git:(watchos) ❯ cargo +nightly build -Zbuild-std --target "x86_64-apple-watchos-sim"
   Compiling ring v0.17.7 (/Users/runner/Fork/ring)
The following warnings were emitted during compilation:

warning: ring@0.17.7: clang: error: overriding '-mwatchsimulator-version-min=2.0' option with '--target=x86_64-apple-watchos5.0-simulator' [-Werror,-Woverriding-t-option]

error: failed to run custom build command for `ring v0.17.7 (/Users/runner/Fork/ring)`

Caused by:
  process didn't exit successfully: `/Users/runner/Fork/ring/target/debug/build/ring-46c716d55784f0d8/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=RING_PREGENERATE_ASM
  cargo:rustc-env=RING_CORE_PREFIX=ring_core_0_17_7_
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  OPT_LEVEL = Some("0")
  TARGET = Some("x86_64-apple-watchos-sim")
  HOST = Some("x86_64-apple-darwin")
  cargo:rerun-if-env-changed=CC_x86_64-apple-watchos-sim
  CC_x86_64-apple-watchos-sim = None
  cargo:rerun-if-env-changed=CC_x86_64_apple_watchos_sim
  CC_x86_64_apple_watchos_sim = None
  cargo:rerun-if-env-changed=TARGET_CC
  TARGET_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  Detecting WatchOS SDK path for watchsimulator
  running: "xcrun" "--show-sdk-path" "--sdk" "watchsimulator"
  exit status: 0
  cargo:rerun-if-env-changed=CFLAGS_x86_64-apple-watchos-sim
  CFLAGS_x86_64-apple-watchos-sim = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_apple_watchos_sim
  CFLAGS_x86_64_apple_watchos_sim = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  running: "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=x86_64-apple-watchos5.0-simulator" "-m64" "-mwatchsimulator-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/crypto/curve25519/curve25519.o" "-c" "crypto/curve25519/curve25519.c"
  cargo:warning=clang: error: overriding '-mwatchsimulator-version-min=2.0' option with '--target=x86_64-apple-watchos5.0-simulator' [-Werror,-Woverriding-t-option]

  exit status: 1

  --- stderr
  running "perl" "crypto/chacha/asm/chacha-x86_64.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/chacha-x86_64-macosx.S"
  running "perl" "crypto/fipsmodule/aes/asm/aesni-x86_64.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/aesni-x86_64-macosx.S"
  running "perl" "crypto/fipsmodule/aes/asm/vpaes-x86_64.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/vpaes-x86_64-macosx.S"
  running "perl" "crypto/fipsmodule/bn/asm/x86_64-mont.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/x86_64-mont-macosx.S"
  running "perl" "crypto/fipsmodule/bn/asm/x86_64-mont5.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/x86_64-mont5-macosx.S"
  running "perl" "crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/p256-x86_64-asm-macosx.S"
  running "perl" "crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/aesni-gcm-x86_64-macosx.S"
  running "perl" "crypto/fipsmodule/modes/asm/ghash-x86_64.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/ghash-x86_64-macosx.S"
  running "perl" "crypto/fipsmodule/sha/asm/sha512-x86_64.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/sha512-x86_64-macosx.S"
  running "perl" "crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/chacha20_poly1305_x86_64-macosx.S"
  running "perl" "crypto/fipsmodule/sha/asm/sha512-x86_64.pl" "macosx" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/sha256-x86_64-macosx.S"


  error occurred: Command "clang" "-O0" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=x86_64-apple-watchos5.0-simulator" "-m64" "-mwatchsimulator-version-min=2.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator10.2.sdk" "-fembed-bitcode" "-I" "include" "-I" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-pedantic" "-Wall" "-Wextra" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-g3" "-Werror" "-o" "/Users/runner/Fork/ring/target/x86_64-apple-watchos-sim/debug/build/ring-5e8917d212bd1162/out/crypto/curve25519/curve25519.o" "-c" "crypto/curve25519/curve25519.c" with args "clang" did not execute successfully (status code exit status: 1).</pre></code>
</details>