### PR TITLE
Build: Don't mention `invalid_reference_casting` lint.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,6 @@
 #![deny(variant_size_differences)]
 #![forbid(
     unused_results,
-    invalid_reference_casting,
     clippy::char_lit_as_u8,
     clippy::fn_to_numeric_cast,
     clippy::fn_to_numeric_cast_with_truncation,


### PR DESCRIPTION
https://doc.rust-lang.org/beta/rustc/lints/listing/deny-by-default.html says that it is deny-by-default, so don't mention it. This eliminates an "unknown lint" warning for Rust versions prior to Rust 1.73.

This was `clippy::cast_ref_to_mut` prior to Rust 1.72.0, according to https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1720-2023-08-24.