### PR TITLE
build.rs: Use named constants instead of string literals more consistently

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,7 @@ const X86: &str = "x86";
 const X86_64: &str = "x86_64";
 const AARCH64: &str = "aarch64";
 const ARM: &str = "arm";
+const WASM32: &str = "wasm32";
 
 #[rustfmt::skip]
 const RING_SRCS: &[(&[&str], &str)] = &[
@@ -162,63 +163,63 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
 const ASM_TARGETS: &[AsmTarget] = &[
     AsmTarget {
         oss: LINUX_ABI,
-        arch: "aarch64",
+        arch: AARCH64,
         perlasm_format: "linux64",
         asm_extension: "S",
         preassemble: false,
     },
     AsmTarget {
         oss: LINUX_ABI,
-        arch: "arm",
+        arch: ARM,
         perlasm_format: "linux32",
         asm_extension: "S",
         preassemble: false,
     },
     AsmTarget {
         oss: LINUX_ABI,
-        arch: "x86",
+        arch: X86,
         perlasm_format: "elf",
         asm_extension: "S",
         preassemble: false,
     },
     AsmTarget {
         oss: LINUX_ABI,
-        arch: "x86_64",
+        arch: X86_64,
         perlasm_format: "elf",
         asm_extension: "S",
         preassemble: false,
     },
     AsmTarget {
         oss: MACOS_ABI,
-        arch: "aarch64",
+        arch: AARCH64,
         perlasm_format: "ios64",
         asm_extension: "S",
         preassemble: false,
     },
     AsmTarget {
         oss: MACOS_ABI,
-        arch: "x86_64",
+        arch: X86_64,
         perlasm_format: "macosx",
         asm_extension: "S",
         preassemble: false,
     },
     AsmTarget {
         oss: &[WINDOWS],
-        arch: "x86",
+        arch: X86,
         perlasm_format: "win32n",
         asm_extension: "asm",
         preassemble: true,
     },
     AsmTarget {
         oss: &[WINDOWS],
-        arch: "x86_64",
+        arch: X86_64,
         perlasm_format: "nasm",
         asm_extension: "asm",
         preassemble: true,
     },
     AsmTarget {
         oss: &[WINDOWS],
-        arch: "aarch64",
+        arch: AARCH64,
         perlasm_format: "win64",
         asm_extension: "S",
         preassemble: false,
@@ -602,8 +603,7 @@ fn configure_cc(c: &mut cc::Build, target: &Target, include_dir: &Path) {
     // Allow cross-compiling without a target sysroot for these targets.
     //
     // poly1305_vec.c requires <emmintrin.h> which requires <stdlib.h>.
-    if (target.arch == "wasm32")
-        || (target.os == "linux" && target.is_musl && target.arch != "x86_64")
+    if (target.arch == WASM32) || (target.os == "linux" && target.is_musl && target.arch != X86_64)
     {
         if let Ok(compiler) = c.try_get_compiler() {
             // TODO: Expand this to non-clang compilers in 0.17.0 if practical.
@@ -634,8 +634,8 @@ fn cc_asm(b: &cc::Build, file: &Path, out_file: &Path) -> Command {
 
 fn nasm(file: &Path, arch: &str, include_dir: &Path, out_file: &Path) -> Command {
     let oformat = match arch {
-        "x86_64" => "win64",
-        "x86" => "win32",
+        x if x == X86_64 => "win64",
+        x if x == X86 => "win32",
         _ => panic!("unsupported arch: {}", arch),
     };
 
@@ -742,7 +742,7 @@ fn perlasm(src_dst: &[(PathBuf, PathBuf)], asm_target: &AsmTarget) {
             src.to_string_lossy().into_owned(),
             asm_target.perlasm_format.to_owned(),
         ];
-        if asm_target.arch == "x86" {
+        if asm_target.arch == X86 {
             args.push("-fPIC".into());
             args.push("-DOPENSSL_IA32_SSE2".into());
         }

--- a/build.rs
+++ b/build.rs
@@ -265,8 +265,9 @@ const LINUX_ABI: &[&str] = &[
 
 /// Operating systems that have the same ABI as macOS on every architecture
 /// mentioned in `ASM_TARGETS`.
-const MACOS_ABI: &[&str] = &["ios", "macos", "tvos"];
+const MACOS_ABI: &[&str] = &["ios", MACOS, "tvos"];
 
+const MACOS: &str = "macos";
 const WINDOWS: &str = "windows";
 
 /// Read an environment variable and tell Cargo that we depend on it.
@@ -589,7 +590,7 @@ fn configure_cc(c: &mut cc::Build, target: &Target, include_dir: &Path) {
         let _ = c.flag(f);
     }
 
-    if target.os.as_str() == "macos" {
+    if target.os.as_str() == MACOS {
         // ``-gfull`` is required for Darwin's |-dead_strip|.
         let _ = c.flag("-gfull");
     } else if !compiler.is_like_msvc() {


### PR DESCRIPTION
This doesn't try to fix every case.