### PR TITLE
build.rs: don't use `-pedantic` flag

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -111,7 +111,6 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
         static NON_MSVC_FLAGS: &[&str] = &[
             "-fvisibility=hidden",
             "-std=c1x", // GCC 4.6 requires "c1x" instead of "c11"
-            "-pedantic",
             "-Wall",
             "-Wextra",
             "-Wbad-function-cast",


### PR DESCRIPTION
In some build systems, target sysroots may use non-standard C extentions like `#include_next`. In such cases, the `-pedantic` flag breaks the compilation.

Resolves issue #1923.