### PR TITLE
aes-gcm: Make use of the optimized aarch64 implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ include = [
     "crypto/fipsmodule/modes/asm/ghash-x86.pl",
     "crypto/fipsmodule/modes/asm/ghash-x86_64.pl",
     "crypto/fipsmodule/modes/asm/ghashv8-armx.pl",
+    "crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl",
     "crypto/fipsmodule/sha/asm/sha256-armv4.pl",
     "crypto/fipsmodule/sha/asm/sha512-armv4.pl",
     "crypto/fipsmodule/sha/asm/sha512-armv8.pl",

--- a/build.rs
+++ b/build.rs
@@ -94,6 +94,7 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[AARCH64], "crypto/fipsmodule/bn/asm/armv8-mont.pl"),
     (&[AARCH64], "crypto/fipsmodule/ec/asm/p256-armv8-asm.pl"),
     (&[AARCH64], "crypto/fipsmodule/modes/asm/ghash-neon-armv8.pl"),
+    (&[AARCH64], "crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl"),
     (&[AARCH64], SHA512_ARMV8),
 ];
 
@@ -943,6 +944,8 @@ fn prefix_all_symbols(pp: char, prefix_prefix: &str, prefix: &str) -> String {
         "gcm_init_avx",
         "gcm_init_clmul",
         "gcm_init_neon",
+        "aes_gcm_enc_kernel",
+        "aes_gcm_dec_kernel",
         "k25519Precomp",
         "limbs_mul_add_limb",
         "little_endian_bytes_from_scalar",

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -285,13 +285,13 @@ impl Key {
         out
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[must_use]
     pub fn is_aes_hw(&self, cpu_features: cpu::Features) -> bool {
         matches!(detect_implementation(cpu_features), Implementation::HWAES)
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[must_use]
     pub(super) fn inner_less_safe(&self) -> &AES_KEY {
         &self.inner

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -107,7 +107,7 @@ impl Context {
     }
 
     /// Access to `inner` for the integrated AES-GCM implementations only.
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[inline]
     pub(super) fn inner(&mut self) -> (&HTable, &mut Xi) {
         (&self.inner.Htable, &mut self.inner.Xi)
@@ -243,6 +243,14 @@ impl Context {
             Implementation::CLMUL => has_avx_movbe(self.cpu_features),
             _ => false,
         }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(super) fn is_clmul(&self) -> bool {
+        matches!(
+            detect_implementation(self.cpu_features),
+            Implementation::CLMUL
+        )
     }
 }
 


### PR DESCRIPTION
Currently ring bundles an interleaved AES-GCM implementation for aarch64, but does not make use of it, instead calling AES-CTR + GHASH in succession.

This change makes use of the bundled implementation, resulting in speedups of 45% for AES-128-GCM and 55% for AES-256-GCM on Apple M1 CPU.