### PR TITLE
CI: Use nightly-2024-02-13 for code coverage testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,8 +530,10 @@ jobs:
           - # debug
 
         # Coverage collection is Nightly-only
+        # XXX: Starting with nightly-2024-02-14 there is a segfault when
+        # running the tests.
         rust_channel:
-          - nightly
+          - nightly-2024-02-13
 
         # TODO: targets
         include:


### PR DESCRIPTION
More recent versions of the toolchain cause the tests to crash with a segmentation fault when built/run with profiling.