### PR TITLE
AEAD: Move input length checks to to individual algorithm implementations

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -143,7 +143,7 @@ pub struct Algorithm {
         aad: Aad<&[u8]>,
         in_out: &mut [u8],
         cpu_features: cpu::Features,
-    ) -> Tag,
+    ) -> Result<Tag, error::Unspecified>,
     open: fn(
         key: &KeyInner,
         nonce: Nonce,
@@ -151,12 +151,10 @@ pub struct Algorithm {
         in_out: &mut [u8],
         src: RangeFrom<usize>,
         cpu_features: cpu::Features,
-    ) -> Tag,
+    ) -> Result<Tag, error::Unspecified>,
 
     key_len: usize,
     id: AlgorithmID,
-
-    max_input_len: usize,
 }
 
 const fn max_input_len(block_len: usize, overhead_blocks_per_nonce: usize) -> usize {

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -18,7 +18,7 @@ use super::{
     quic::Sample,
 };
 use crate::{
-    bits::BitLength,
+    bits::{BitLength, FromUsizeBytes},
     c, cpu,
     endian::BigEndian,
     error,
@@ -49,7 +49,7 @@ fn set_encrypt_key(
 ) -> Result<(), error::Unspecified> {
     // Unusually, in this case zero means success and non-zero means failure.
     #[allow(clippy::cast_possible_truncation)]
-    if 0 == unsafe { f(bytes.as_ptr(), key_bits.as_usize_bits() as c::uint, key) } {
+    if 0 == unsafe { f(bytes.as_ptr(), key_bits.as_bits() as c::uint, key) } {
         Ok(())
     } else {
         Err(error::Unspecified)

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -346,10 +346,12 @@ fn finish(
     })
 }
 
-const AES_GCM_MAX_INPUT_LEN: u64 = super::max_input_len(BLOCK_LEN, 2);
+const AES_GCM_MAX_INPUT_LEN: usize = super::max_input_len(BLOCK_LEN, 2);
 
 #[cfg(test)]
 mod tests {
+    use crate::polyfill::usize_from_u64_saturated;
+
     #[test]
     fn max_input_len_test() {
         // [NIST SP800-38D] Section 5.2.1.1. Note that [RFC 5116 Section 5.1] and
@@ -361,13 +363,14 @@ mod tests {
         // [RFC 5116 Section 5.2]: https://tools.ietf.org/html/rfc5116#section-5.2
         const NIST_SP800_38D_MAX_BITS: u64 = (1u64 << 39) - 256;
         assert_eq!(NIST_SP800_38D_MAX_BITS, 549_755_813_632u64);
+        const NIST_SP800_38D_MAX_BYTES: u64 = NIST_SP800_38D_MAX_BITS / 8;
         assert_eq!(
-            super::AES_128_GCM.max_input_len * 8,
-            NIST_SP800_38D_MAX_BITS
+            super::AES_128_GCM.max_input_len,
+            usize_from_u64_saturated(NIST_SP800_38D_MAX_BYTES)
         );
         assert_eq!(
-            super::AES_256_GCM.max_input_len * 8,
-            NIST_SP800_38D_MAX_BITS
+            super::AES_256_GCM.max_input_len,
+            usize_from_u64_saturated(NIST_SP800_38D_MAX_BYTES)
         );
     }
 }

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -269,9 +269,15 @@ pub(super) fn derive_poly1305_key(chacha_key: &chacha::Key, iv: Iv) -> poly1305:
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::polyfill::usize_from_u64_saturated;
+
     #[test]
     fn max_input_len_test() {
         // https://tools.ietf.org/html/rfc8439#section-2.8
-        assert_eq!(super::CHACHA20_POLY1305.max_input_len, 274_877_906_880u64);
+        assert_eq!(
+            CHACHA20_POLY1305.max_input_len,
+            usize_from_u64_saturated(274_877_906_880u64)
+        );
     }
 }

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -64,6 +64,10 @@ fn chacha20_poly1305_seal(
     if in_out.len() > MAX_IN_OUT_LEN {
         return Err(error::Unspecified);
     }
+    /// RFC 8439 Section 2.8 says the maximum AAD length is 2**64 - 1, which is
+    /// never larger than usize::MAX, so we don't need an explicit length
+    /// check.
+    const _USIZE_BOUNDED_BY_U64: u64 = u64_from_usize(usize::MAX);
 
     #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
     if has_integrated(cpu_features) {
@@ -152,6 +156,10 @@ fn chacha20_poly1305_open(
     if unprefixed_len > MAX_IN_OUT_LEN {
         return Err(error::Unspecified);
     }
+    // RFC 8439 Section 2.8 says the maximum AAD length is 2**64 - 1, which is
+    // never larger than usize::MAX, so we don't need an explicit length
+    // check.
+    const _USIZE_BOUNDED_BY_U64: u64 = u64_from_usize(usize::MAX);
 
     #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
     if has_integrated(cpu_features) {

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -105,6 +105,10 @@ impl Context {
             return Err(error::Unspecified);
         }
 
+        // NIST SP800-38D Section 5.2.1.1 says that the maximum AAD length is
+        // 2**64 - 1 bits, i.e. BitLength<u64>::MAX, so we don't need to do an
+        // explicit check here.
+
         let mut ctx = Self {
             inner: ContextInner {
                 Xi: Xi(Block::zero()),

--- a/src/aead/less_safe_key.rs
+++ b/src/aead/less_safe_key.rs
@@ -13,7 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{Aad, Algorithm, KeyInner, Nonce, Tag, UnboundKey, TAG_LEN};
-use crate::{constant_time, cpu, error, polyfill};
+use crate::{constant_time, cpu, error};
 use core::ops::RangeFrom;
 
 /// Immutable keys for use in situations where `OpeningKey`/`SealingKey` and
@@ -209,7 +209,7 @@ pub(super) fn seal_in_place_separate_tag_(
 }
 
 fn check_per_nonce_max_bytes(alg: &Algorithm, in_out_len: usize) -> Result<(), error::Unspecified> {
-    if polyfill::u64_from_usize(in_out_len) > alg.max_input_len {
+    if in_out_len > alg.max_input_len {
         return Err(error::Unspecified);
     }
     Ok(())

--- a/src/arithmetic/bigint/modulus.rs
+++ b/src/arithmetic/bigint/modulus.rs
@@ -189,7 +189,7 @@ impl<M> Modulus<'_, M> {
         // out = 2**r - m where m = self.
         limb::limbs_negative_odd(out, self.limbs);
 
-        let lg_m = self.len_bits().as_usize_bits();
+        let lg_m = self.len_bits().as_bits();
         let leading_zero_bits_in_m = r - lg_m;
 
         // When m's length is a multiple of LIMB_BITS, which is the case we

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -14,30 +14,53 @@
 
 //! Bit lengths.
 
-use crate::error;
+use crate::{error, polyfill};
 
 /// The length of something, in bits.
 ///
 /// This can represent a bit length that isn't a whole number of bytes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
-pub struct BitLength(usize);
+pub struct BitLength<T = usize>(T);
+
+pub(crate) trait FromUsizeBytes: Sized {
+    /// Constructs a `BitLength` from the given length in bytes.
+    ///
+    /// Fails if `bytes * 8` is too large for a `T`.
+    fn from_usize_bytes(bytes: usize) -> Result<Self, error::Unspecified>;
+}
+
+impl FromUsizeBytes for BitLength<usize> {
+    #[inline]
+    fn from_usize_bytes(bytes: usize) -> Result<Self, error::Unspecified> {
+        let bits = bytes.checked_shl(3).ok_or(error::Unspecified)?;
+        Ok(Self(bits))
+    }
+}
+
+impl FromUsizeBytes for BitLength<u64> {
+    #[inline]
+    fn from_usize_bytes(bytes: usize) -> Result<Self, error::Unspecified> {
+        let bytes = polyfill::u64_from_usize(bytes);
+        let bits = bytes.checked_shl(3).ok_or(error::Unspecified)?;
+        Ok(Self(bits))
+    }
+}
+
+impl<T: Copy> BitLength<T> {
+    /// The number of bits this bit length represents, as a `usize`.
+    #[inline]
+    pub fn as_bits(self) -> T {
+        self.0
+    }
+}
 
 // Lengths measured in bits, where all arithmetic is guaranteed not to
 // overflow.
-impl BitLength {
+impl BitLength<usize> {
     /// Constructs a `BitLength` from the given length in bits.
     #[inline]
     pub const fn from_usize_bits(bits: usize) -> Self {
         Self(bits)
-    }
-
-    /// Constructs a `BitLength` from the given length in bytes.
-    ///
-    /// Fails if `bytes * 8` is too large for a `usize`.
-    #[inline]
-    pub fn from_usize_bytes(bytes: usize) -> Result<Self, error::Unspecified> {
-        let bits = bytes.checked_mul(8).ok_or(error::Unspecified)?;
-        Ok(Self::from_usize_bits(bits))
     }
 
     #[cfg(feature = "alloc")]
@@ -45,12 +68,6 @@ impl BitLength {
     pub(crate) fn half_rounded_up(&self) -> Self {
         let round_up = self.0 & 1;
         Self((self.0 / 2) + round_up)
-    }
-
-    /// The number of bits this bit length represents, as a `usize`.
-    #[inline]
-    pub fn as_usize_bits(&self) -> usize {
-        self.0
     }
 
     /// The bit length, rounded up to a whole number of bytes.

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -622,7 +622,7 @@ mod tests {
             (&[ALL_ONES, ALL_ONES >> 1], LIMB_BITS + (LIMB_BITS) - 1),
         ];
         for (limbs, bits) in CASES {
-            assert_eq!(limbs_minimal_bits(limbs).as_usize_bits(), *bits);
+            assert_eq!(limbs_minimal_bits(limbs).as_bits(), *bits);
         }
     }
 }

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -15,11 +15,13 @@
 //! Polyfills for functionality that will (hopefully) be added to Rust's
 //! standard library soon.
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 #[inline(always)]
 pub const fn u64_from_usize(x: usize) -> u64 {
     x as u64
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 pub fn usize_from_u32(x: u32) -> usize {
     x as usize
 }

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -26,6 +26,18 @@ pub fn usize_from_u32(x: u32) -> usize {
     x as usize
 }
 
+/// const-capable `x.try_into().unwrap_or(usize::MAX)`
+#[allow(clippy::cast_possible_truncation)]
+#[inline(always)]
+pub const fn usize_from_u64_saturated(x: u64) -> usize {
+    const USIZE_MAX: u64 = u64_from_usize(usize::MAX);
+    if x < USIZE_MAX {
+        x as usize
+    } else {
+        usize::MAX
+    }
+}
+
 mod array_flat_map;
 mod array_flatten;
 mod array_split_map;
@@ -45,3 +57,20 @@ pub use self::{
 
 #[cfg(feature = "alloc")]
 pub use leading_zeros_skipped::LeadingZerosStripped;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_usize_from_u64_saturated() {
+        const USIZE_MAX: u64 = u64_from_usize(usize::MAX);
+        assert_eq!(usize_from_u64_saturated(u64::MIN), usize::MIN);
+        assert_eq!(usize_from_u64_saturated(USIZE_MAX), usize::MAX);
+        assert_eq!(usize_from_u64_saturated(USIZE_MAX - 1), usize::MAX - 1);
+
+        #[cfg(not(target_pointer_width = "64"))]
+        {
+            assert_eq!(usize_from_u64_saturated(USIZE_MAX + 1), usize::MAX);
+        }
+    }
+}

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -429,7 +429,7 @@ impl<M> PrivatePrime<M> {
             return Err(KeyRejected::inconsistent_components());
         }
 
-        if p.len_bits().as_usize_bits() % 512 != 0 {
+        if p.len_bits().as_bits() % 512 != 0 {
             return Err(error::KeyRejected::private_modulus_len_not_multiple_of_512_bits());
         }
 

--- a/src/rsa/padding/pss.rs
+++ b/src/rsa/padding/pss.rs
@@ -207,7 +207,7 @@ impl PSSMetrics {
     ) -> Result<Self, error::Unspecified> {
         let em_bits = mod_bits.try_sub_1()?;
         let em_len = em_bits.as_usize_bytes_rounded_up();
-        let leading_zero_bits = (8 * em_len) - em_bits.as_usize_bits();
+        let leading_zero_bits = (8 * em_len) - em_bits.as_bits();
         debug_assert!(leading_zero_bits < 8);
         let top_byte_mask = 0xffu8 >> leading_zero_bits;
 
@@ -226,7 +226,7 @@ impl PSSMetrics {
         let db_len = em_len.checked_sub(1 + s_len).ok_or(error::Unspecified)?;
         let ps_len = db_len.checked_sub(h_len + 1).ok_or(error::Unspecified)?;
 
-        debug_assert!(em_bits.as_usize_bits() >= (8 * h_len) + (8 * s_len) + 9);
+        debug_assert!(em_bits.as_bits() >= (8 * h_len) + (8 * s_len) + 9);
 
         Ok(Self {
             em_len,

--- a/src/rsa/public_modulus.rs
+++ b/src/rsa/public_modulus.rs
@@ -1,6 +1,7 @@
 use crate::{
     arithmetic::{bigint, montgomery::RR},
-    bits, cpu, error,
+    bits::{self, FromUsizeBytes as _},
+    cpu, error,
     rsa::N,
 };
 use core::ops::RangeInclusive;

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -17,7 +17,10 @@
 use super::{
     parse_public_key, public_key, PublicExponent, RsaParameters, PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN,
 };
-use crate::{bits, cpu, digest, error, sealed, signature};
+use crate::{
+    bits::{self, FromUsizeBytes as _},
+    cpu, digest, error, sealed, signature,
+};
 
 impl signature::VerificationAlgorithm for RsaParameters {
     fn verify(


### PR DESCRIPTION
Use `usize`-based math instead of `u64`-based math, addressing the longstanding TODO. Then move the length check into the individual algorithm implementations. Especially in the case of AES-GCM, this makes it clearer that there will be no overflows in the handling of the input lengths. (There weren't any, but this makes that clearer.) See the individual commit messages for details.