### PR TITLE
AES-GCM Aarch64: Clarify bytes -> bits conversion bounds checking.

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -124,23 +124,22 @@ fn aes_gcm_seal(
         if !aes_key.is_aes_hw(cpu_features) || !auth.is_clmul() {
             in_out
         } else {
-            use crate::c;
-            let (htable, xi) = auth.inner();
-            prefixed_extern! {
-                fn aes_gcm_enc_kernel(
-                    input: *const u8,
-                    in_bits: c::size_t,
-                    output: *mut u8,
-                    Xi: &mut gcm::Xi,
-                    ivec: &mut Counter,
-                    key: &aes::AES_KEY,
-                    Htable: &gcm::HTable);
-            }
-
             let len = in_out.len();
             let len_blocks = len & (!(0b1111));
 
             if len_blocks > 0 {
+                use crate::c;
+                let (htable, xi) = auth.inner();
+                prefixed_extern! {
+                    fn aes_gcm_enc_kernel(
+                        input: *const u8,
+                        in_bits: c::size_t,
+                        output: *mut u8,
+                        Xi: &mut gcm::Xi,
+                        ivec: &mut Counter,
+                        key: &aes::AES_KEY,
+                        Htable: &gcm::HTable);
+                }
                 unsafe {
                     aes_gcm_enc_kernel(
                         in_out.as_ptr(),
@@ -247,23 +246,22 @@ fn aes_gcm_open(
         if !aes_key.is_aes_hw(cpu_features) || !auth.is_clmul() {
             in_out
         } else {
-            use crate::c;
-            let (htable, xi) = auth.inner();
-            prefixed_extern! {
-                fn aes_gcm_dec_kernel(
-                    input: *const u8,
-                    in_bits: c::size_t,
-                    output: *mut u8,
-                    Xi: &mut gcm::Xi,
-                    ivec: &mut Counter,
-                    key: &aes::AES_KEY,
-                    Htable: &gcm::HTable);
-            }
-
             let len = in_out.len() - src.start;
             let len_blocks = len & (!(0b1111));
 
             if len_blocks > 0 {
+                use crate::c;
+                let (htable, xi) = auth.inner();
+                prefixed_extern! {
+                    fn aes_gcm_dec_kernel(
+                        input: *const u8,
+                        in_bits: c::size_t,
+                        output: *mut u8,
+                        Xi: &mut gcm::Xi,
+                        ivec: &mut Counter,
+                        key: &aes::AES_KEY,
+                        Htable: &gcm::HTable);
+                }
                 unsafe {
                     aes_gcm_dec_kernel(
                         in_out[src.clone()].as_ptr(),

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -128,6 +128,17 @@ impl Context {
         Ok(ctx)
     }
 
+    #[cfg(all(target_arch = "aarch64", target_pointer_width = "64"))]
+    pub(super) fn in_out_whole_block_bits(&self) -> BitLength<usize> {
+        use crate::polyfill::usize_from_u64;
+        const WHOLE_BLOCK_BITS_MASK: usize = !0b111_1111;
+        const _WHOLE_BLOCK_BITS_MASK_CORRECT: () =
+            assert!(WHOLE_BLOCK_BITS_MASK == !((BLOCK_LEN * 8) - 1));
+        BitLength::from_usize_bits(
+            usize_from_u64(self.in_out_len.as_bits()) & WHOLE_BLOCK_BITS_MASK,
+        )
+    }
+
     /// Access to `inner` for the integrated AES-GCM implementations only.
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[inline]

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -20,6 +20,7 @@ use crate::{error, polyfill};
 ///
 /// This can represent a bit length that isn't a whole number of bytes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
+#[repr(transparent)]
 pub struct BitLength<T = usize>(T);
 
 pub(crate) trait FromUsizeBytes: Sized {
@@ -71,7 +72,7 @@ impl BitLength<usize> {
     }
 
     /// The bit length, rounded up to a whole number of bytes.
-    #[cfg(feature = "alloc")]
+    #[cfg(any(target_arch = "aarch64", feature = "alloc"))]
     #[inline]
     pub fn as_usize_bytes_rounded_up(&self) -> usize {
         // Equivalent to (self.0 + 7) / 8, except with no potential for

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -26,6 +26,12 @@ pub fn usize_from_u32(x: u32) -> usize {
     x as usize
 }
 
+#[cfg(all(target_arch = "aarch64", target_pointer_width = "64"))]
+#[allow(clippy::cast_possible_truncation)]
+pub fn usize_from_u64(x: u64) -> usize {
+    x as usize
+}
+
 /// const-capable `x.try_into().unwrap_or(usize::MAX)`
 #[allow(clippy::cast_possible_truncation)]
 #[inline(always)]


### PR DESCRIPTION
The conversion of bytes to bits looked like it could potentially overflow `usize::MAX`, but it couldn't. Make this more obvious at the call site.

There are two commits. The first one just reorganizes/re-nests code, so it is easier to review this commit-by-commit.