### PR TITLE
CI: Use LLVM/Clang 18.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,10 +530,8 @@ jobs:
           - # debug
 
         # Coverage collection is Nightly-only
-        # XXX: Starting with nightly-2024-02-14 there is a segfault when
-        # running the tests.
         rust_channel:
-          - nightly-2024-02-13
+          - nightly
 
         # TODO: targets
         include:

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -54,7 +54,7 @@ for arg in $*; do
 done
 
 # See comments in install-build-tools.sh.
-llvm_version=16
+llvm_version=18
 
 case $target in
    aarch64-linux-android)

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -173,7 +173,7 @@ esac
 case "$OSTYPE" in
 linux*)
   ubuntu_codename=$(lsb_release --codename --short)
-  llvm_version=16
+  llvm_version=18
   sudo apt-key add mk/llvm-snapshot.gpg.key
   sudo add-apt-repository "deb http://apt.llvm.org/$ubuntu_codename/ llvm-toolchain-$ubuntu_codename-$llvm_version main"
   sudo apt-get update


### PR DESCRIPTION
Rust updated to LLVM 18. Use Clang 18 as the C compiler so that the coverage info for C is compatible with that for Rust.