### PR TITLE
rsa/der: Make it clearer that ASN.1 serialization is panic-free and lossless.

### DIFF
--- a/src/io/der.rs
+++ b/src/io/der.rs
@@ -44,14 +44,21 @@ pub enum Tag {
 
 impl From<Tag> for usize {
     fn from(tag: Tag) -> Self {
-        tag as Self
+        Self::from(Tag::into(tag))
     }
 }
 
 impl From<Tag> for u8 {
     fn from(tag: Tag) -> Self {
-        tag as Self
-    } // XXX: narrowing conversion.
+        Tag::into(tag)
+    }
+}
+
+// `impl From<Tag> for u8` but as a `const fn`.
+impl Tag {
+    pub const fn into(self) -> u8 {
+        self as u8
+    }
 }
 
 pub fn expect_tag_and_get_value<'a>(

--- a/src/io/der_writer.rs
+++ b/src/io/der_writer.rs
@@ -47,7 +47,6 @@ pub(crate) fn write_all(
     Ok(output.into())
 }
 
-#[allow(clippy::cast_possible_truncation)]
 fn write_tlv<F>(
     output: &mut dyn Accumulator,
     tag: Tag,
@@ -61,20 +60,18 @@ where
         write_value(&mut length)?;
         length.into()
     };
+    let length: u16 = length.try_into().map_err(|_| error::Unspecified)?;
 
-    output.write_byte(tag as u8);
-    if length < 0x80 {
-        output.write_byte(length as u8);
-    } else if length < 0x1_00 {
-        output.write_byte(0x81);
-        output.write_byte(length as u8);
-    } else if length < 0x1_00_00 {
+    output.write_byte(tag.into());
+
+    let [lo, hi] = length.to_le_bytes();
+    if length >= 0x1_00 {
         output.write_byte(0x82);
-        output.write_byte((length / 0x1_00) as u8);
-        output.write_byte(length as u8);
-    } else {
-        return Err(error::Unspecified);
-    };
+        output.write_byte(hi);
+    } else if length >= 0x80 {
+        output.write_byte(0x81);
+    }
+    output.write_byte(lo);
 
     write_value(output)
 }

--- a/src/rsa/padding/pkcs1.rs
+++ b/src/rsa/padding/pkcs1.rs
@@ -139,11 +139,11 @@ macro_rules! pkcs1_digestinfo_prefix {
     ( $name:ident, $digest_len:expr, $digest_oid_len:expr,
       [ $( $digest_oid:expr ),* ] ) => {
         static $name: [u8; 2 + 8 + $digest_oid_len] = [
-            der::Tag::Sequence as u8, 8 + $digest_oid_len + $digest_len,
-                der::Tag::Sequence as u8, 2 + $digest_oid_len + 2,
-                    der::Tag::OID as u8, $digest_oid_len, $( $digest_oid ),*,
-                    der::Tag::Null as u8, 0,
-                der::Tag::OctetString as u8, $digest_len,
+            der::Tag::Sequence.into(), 8 + $digest_oid_len + $digest_len,
+                der::Tag::Sequence.into(), 2 + $digest_oid_len + 2,
+                    der::Tag::OID.into(), $digest_oid_len, $( $digest_oid ),*,
+                    der::Tag::Null.into(), 0,
+                der::Tag::OctetString.into(), $digest_len,
         ];
     }
 }

--- a/src/rsa/public_key.rs
+++ b/src/rsa/public_key.rs
@@ -61,9 +61,10 @@ impl PublicKey {
         let e_bytes = io::Positive::from_be_bytes(e_bytes)
             .map_err(|_: error::Unspecified| error::KeyRejected::unexpected_error())?;
         let serialized = der_writer::write_all(der::Tag::Sequence, &|output| {
-            der_writer::write_positive_integer(output, &n_bytes);
-            der_writer::write_positive_integer(output, &e_bytes);
-        });
+            der_writer::write_positive_integer(output, &n_bytes)?;
+            der_writer::write_positive_integer(output, &e_bytes)
+        })
+        .map_err(|_: error::Unspecified| error::KeyRejected::unexpected_error())?;
 
         Ok(Self { inner, serialized })
     }


### PR DESCRIPTION
Eliminate `as` conversions and an unreachable. See the individual commits for details.