### PR TITLE
Reduce the number of `as` conversions for integer casts.

### DIFF
--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -14,8 +14,6 @@
 
 //! ECDSA Signatures using the P-256 and P-384 curves.
 
-#![allow(clippy::cast_possible_truncation)] // XXX
-
 use super::digest_scalar::digest_scalar;
 use crate::{
     arithmetic::montgomery::*,
@@ -414,25 +412,31 @@ fn format_rs_asn1(ops: &'static ScalarOps, r: &Scalar, s: &Scalar, out: &mut [u8
         };
         let value = &fixed[first_index..];
 
-        out[0] = der::Tag::Integer as u8;
+        out[0] = der::Tag::Integer.into();
 
         // Lengths less than 128 are encoded in one byte.
         assert!(value.len() < 128);
-        out[1] = value.len() as u8;
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            out[1] = value.len() as u8;
+        }
 
         out[2..][..value.len()].copy_from_slice(value);
 
         2 + value.len()
     }
 
-    out[0] = der::Tag::Sequence as u8;
+    out[0] = der::Tag::Sequence.into();
     let r_tlv_len = format_integer_tlv(ops, r, &mut out[2..]);
     let s_tlv_len = format_integer_tlv(ops, s, &mut out[2..][r_tlv_len..]);
 
     // Lengths less than 128 are encoded in one byte.
     let value_len = r_tlv_len + s_tlv_len;
     assert!(value_len < 128);
-    out[1] = value_len as u8;
+    #[allow(clippy::cast_possible_truncation)]
+    {
+        out[1] = value_len as u8;
+    }
 
     2 + value_len
 }

--- a/src/io/der.rs
+++ b/src/io/der.rs
@@ -44,14 +44,21 @@ pub enum Tag {
 
 impl From<Tag> for usize {
     fn from(tag: Tag) -> Self {
-        tag as Self
+        Self::from(Tag::into(tag))
     }
 }
 
 impl From<Tag> for u8 {
     fn from(tag: Tag) -> Self {
-        tag as Self
-    } // XXX: narrowing conversion.
+        Tag::into(tag)
+    }
+}
+
+// `impl From<Tag> for u8` but as a `const fn`.
+impl Tag {
+    pub const fn into(self) -> u8 {
+        self as u8
+    }
 }
 
 pub fn expect_tag_and_get_value<'a>(

--- a/src/pkcs8.rs
+++ b/src/pkcs8.rs
@@ -142,7 +142,7 @@ fn unwrap_key__<'a>(
         .map_err(|error::Unspecified| error::KeyRejected::invalid_encoding())?;
 
     // Ignore any attributes that are present.
-    if input.peek(der::Tag::ContextSpecificConstructed0 as u8) {
+    if input.peek(der::Tag::ContextSpecificConstructed0.into()) {
         let _ = der::expect_tag_and_get_value(input, der::Tag::ContextSpecificConstructed0)
             .map_err(|error::Unspecified| error::KeyRejected::invalid_encoding())?;
     }
@@ -153,17 +153,18 @@ fn unwrap_key__<'a>(
         }
 
         const INCORRECT_LEGACY: der::Tag = der::Tag::ContextSpecificConstructed1;
-        let result =
-            if options.accept_legacy_ed25519_public_key_tag && input.peek(INCORRECT_LEGACY as u8) {
-                der::nested(
-                    input,
-                    INCORRECT_LEGACY,
-                    error::Unspecified,
-                    der::bit_string_with_no_unused_bits,
-                )
-            } else {
-                der::bit_string_tagged_with_no_unused_bits(der::Tag::ContextSpecific1, input)
-            };
+        let result = if options.accept_legacy_ed25519_public_key_tag
+            && input.peek(INCORRECT_LEGACY.into())
+        {
+            der::nested(
+                input,
+                INCORRECT_LEGACY,
+                error::Unspecified,
+                der::bit_string_with_no_unused_bits,
+            )
+        } else {
+            der::bit_string_tagged_with_no_unused_bits(der::Tag::ContextSpecific1, input)
+        };
         let public_key =
             result.map_err(|error::Unspecified| error::KeyRejected::invalid_encoding())?;
         Some(public_key)

--- a/src/rsa/padding/pkcs1.rs
+++ b/src/rsa/padding/pkcs1.rs
@@ -139,11 +139,11 @@ macro_rules! pkcs1_digestinfo_prefix {
     ( $name:ident, $digest_len:expr, $digest_oid_len:expr,
       [ $( $digest_oid:expr ),* ] ) => {
         static $name: [u8; 2 + 8 + $digest_oid_len] = [
-            der::Tag::Sequence as u8, 8 + $digest_oid_len + $digest_len,
-                der::Tag::Sequence as u8, 2 + $digest_oid_len + 2,
-                    der::Tag::OID as u8, $digest_oid_len, $( $digest_oid ),*,
-                    der::Tag::Null as u8, 0,
-                der::Tag::OctetString as u8, $digest_len,
+            der::Tag::Sequence.into(), 8 + $digest_oid_len + $digest_len,
+                der::Tag::Sequence.into(), 2 + $digest_oid_len + 2,
+                    der::Tag::OID.into(), $digest_oid_len, $( $digest_oid ),*,
+                    der::Tag::Null.into(), 0,
+                der::Tag::OctetString.into(), $digest_len,
         ];
     }
 }

--- a/tests/aead_tests.rs
+++ b/tests/aead_tests.rs
@@ -459,9 +459,10 @@ fn aead_chacha20_poly1305_openssh() {
                 as_array
             };
 
-            let sequence_number = test_case.consume_usize("SEQUENCE_NUMBER");
-            assert_eq!(sequence_number as u32 as usize, sequence_number);
-            let sequence_num = sequence_number as u32;
+            let sequence_num: u32 = test_case
+                .consume_usize("SEQUENCE_NUMBER")
+                .try_into()
+                .unwrap();
             let plaintext = test_case.consume_bytes("IN");
             let ct = test_case.consume_bytes("CT");
             let expected_tag = test_case.consume_bytes("TAG");

--- a/tests/pbkdf2_tests.rs
+++ b/tests/pbkdf2_tests.rs
@@ -40,8 +40,8 @@ pub fn pbkdf2_tests() {
                 unreachable!()
             }
         };
-        let iterations = test_case.consume_usize("c");
-        let iterations = NonZeroU32::new(iterations as u32).unwrap();
+        let iterations: u32 = test_case.consume_usize("c").try_into().unwrap();
+        let iterations: NonZeroU32 = iterations.try_into().unwrap();
         let secret = test_case.consume_bytes("P");
         let salt = test_case.consume_bytes("S");
         let dk = test_case.consume_bytes("DK");


### PR DESCRIPTION
See the individual commit messages for details. This is a non-functional change.