### PR TITLE
Enable sha512 instruction extension on Apple silicon

### DIFF
--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -172,13 +172,19 @@ fn detect_features() -> u32 {
     features
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn detect_features() -> u32 {
+    1 << 6 // sha512
+}
+
 #[cfg(all(
     any(target_arch = "aarch64", target_arch = "arm"),
     not(any(
         target_os = "android",
         target_os = "fuchsia",
         all(target_os = "linux", not(target_env = "uclibc")),
-        target_os = "windows"
+        target_os = "windows",
+        target_os = "macos"
     ))
 ))]
 fn detect_features() -> u32 {

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -96,6 +96,9 @@ fn detect_features() -> u32 {
         const HWCAP_PMULL: c_ulong = 1 << 1 + OFFSET;
         const HWCAP_SHA2: c_ulong = 1 << 3 + OFFSET;
 
+        #[cfg(target_arch = "aarch64")]
+        const HWCAP_SHA512: c_ulong = 1 << 21;
+
         if caps & HWCAP_AES == HWCAP_AES {
             features |= AES.mask;
         }
@@ -104,6 +107,11 @@ fn detect_features() -> u32 {
         }
         if caps & HWCAP_SHA2 == HWCAP_SHA2 {
             features |= SHA256.mask;
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        if caps & HWCAP_SHA512 == HWCAP_SHA512 {
+            features |= SHA512.mask;
         }
     }
 
@@ -172,9 +180,36 @@ fn detect_features() -> u32 {
     features
 }
 
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(target_os = "ios", target_arch = "aarch64"))]
 fn detect_features() -> u32 {
-    1 << 6 // sha512
+    let mut features = ARMCAP_STATIC;
+
+    extern "C" {
+        fn sysctlbyname(
+            name: *const u8,
+            oldp: *mut core::ffi::c_void,
+            oldlenp: *mut crate::c::size_t,
+            newp: *mut core::ffi::c_void,
+            newlen: crate::c::size_t,
+        ) -> core::ffi::c_int;
+    }
+
+    let mut value: core::ffi::c_int = 0;
+    let mut len = core::mem::size_of_val(&value);
+    let rc = unsafe {
+        sysctlbyname(
+            "hw.optional.armv8_2_sha512\0".as_ptr(),
+            &mut value as *mut _ as _,
+            &mut len,
+            core::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc == 0 && len == core::mem::size_of_val(&value) && value != 0 {
+        features |= SHA512.mask;
+    }
+
+    features
 }
 
 #[cfg(all(
@@ -184,7 +219,7 @@ fn detect_features() -> u32 {
         target_os = "fuchsia",
         all(target_os = "linux", not(target_env = "uclibc")),
         target_os = "windows",
-        target_os = "macos"
+        target_os = "ios"
     ))
 ))]
 fn detect_features() -> u32 {
@@ -220,7 +255,7 @@ macro_rules! features {
             )+;
 
         #[cfg(all(test, any(target_arch = "arm", target_arch = "aarch64")))]
-        const ALL_FEATURES: [Feature; 4] = [
+        const ALL_FEATURES: [Feature; 5] = [
             $(
                 $name
             ),+
@@ -286,6 +321,12 @@ features! {
     // that is supported.
     "aes" => PMULL {
         mask: 1 << 5,
+    },
+
+    // Keep in sync with `ARMV8_SHA512`.
+    // "sha3" is overloaded for both SHA-3 and SHA512.
+    "sha3" => SHA512 {
+        mask: 1 << 6,
     },
 }
 
@@ -358,6 +399,11 @@ const _AARCH64_APPLE_FEATURES: u32 = NEON.mask | AES.mask | SHA256.mask | PMULL.
 const _AARCH64_APPLE_TARGETS_EXPECTED_FEATURES: () = assert!(
     ((ARMCAP_STATIC & _AARCH64_APPLE_FEATURES) == _AARCH64_APPLE_FEATURES)
         || !cfg!(all(target_arch = "aarch64", target_vendor = "apple"))
+);
+#[allow(clippy::assertions_on_constants)]
+const _AARCH64_APPLE_DARWIN_TARGETS_EXPECTED_FEATURES: () = assert!(
+    ((ARMCAP_STATIC & SHA512.mask) == SHA512.mask)
+        || !cfg!(all(target_arch = "aarch64", target_os = "macos"))
 );
 
 #[cfg(all(test, any(target_arch = "arm", target_arch = "aarch64")))]


### PR DESCRIPTION
Tested on M1 and time consumed by sha512 is reduced to half.
```
digest::oneshot::sha512/0
                        time:   [93.800 ns 94.427 ns 95.059 ns]
                        change: [-55.464% -55.238% -55.020%] (p = 0.00 < 0.05)
                        Performance has improved.
```