### PR TITLE
build.rs can be run from arbitrary directories

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@
 // another for the concrete logging implementation). Instead we use `eprintln!`
 // to log everything to stderr.
 
+use std::process::Stdio;
 use std::{
     ffi::OsString,
     fs::{self, DirEntry},
@@ -616,6 +617,7 @@ fn run_command_with_args(command_name: &Path, args: &[String]) {
 
 fn run_command(mut cmd: Command) {
     eprintln!("running {:?}", cmd);
+    cmd.stderr(Stdio::inherit());
     let status = cmd.status().unwrap_or_else(|e| {
         panic!("failed to execute [{:?}]: {}", cmd, e);
     });

--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,7 @@
 
 use std::process::Stdio;
 use std::{
-    ffi::{OsStr, OsString},
+    ffi::OsString,
     fs::{self, DirEntry},
     io::Write,
     path::{Path, PathBuf},
@@ -709,7 +709,15 @@ fn perlasm(
 
 fn join_components_with_forward_slashes(path: &Path) -> OsString {
     let parts = path.components().map(|c| c.as_os_str()).collect::<Vec<_>>();
-    parts.as_slice().join(OsStr::new("/"))
+    // Manually implement join here because [OsStr]::join only stabilised in 1.63.0 and ring uses 1.61.0 as MSRV.
+    let mut out = OsString::new();
+    for (i, part) in parts.iter().enumerate() {
+        if i != 0 {
+            out.push("/");
+        }
+        out.push(part)
+    }
+    out
 }
 
 fn get_perl_exe() -> PathBuf {


### PR DESCRIPTION
Currently it hard-codes an assumption that the build script is run from the $CARGO_MANIFEST_DIR. While this is true for cargo, and typically is true for other build systems, some toolchains may have other requirements.

1e1021d05bdd41cb02bbc43615c9dd7ecd35f853 started encoding that this assumption may not always hold, this commit just extends that other places the assumption is currently made.

This was tested by adding a call to
`std::env::set_current_dir("/tmp").unwrap()` at the top of the build script's `main` function, and has been used to build both the pregenerated version and the non-pregenerated version of the build script.

I agree to license my contributions to each file under the terms given
at the top of each file I changed.