### PR TITLE
Include Windows .asm source files in packaged releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # pregenerated/ cannot be here because we need `cargo package` to package stuff
-# in it. However, we don't need/want `cargo package` to package pregenerated/tmp,
-# so that can be here.
-pregenerated/tmp
+# in it.
 
 build/
 ssl/test/runner/runner

--- a/build.rs
+++ b/build.rs
@@ -352,23 +352,17 @@ fn pregenerate_asm_main() {
 
     let pregenerated = PathBuf::from(PREGENERATED);
     std::fs::create_dir(&pregenerated).unwrap();
-    let pregenerated_tmp = pregenerated.join("tmp");
-    std::fs::create_dir(&pregenerated_tmp).unwrap();
 
-    generate_prefix_symbols_asm_headers(&pregenerated_tmp, &ring_core_prefix()).unwrap();
+    generate_prefix_symbols_asm_headers(&pregenerated, &ring_core_prefix()).unwrap();
 
     let perl_exe = get_perl_exe();
 
     for asm_target in ASM_TARGETS {
-        // For Windows, package pregenerated object files instead of
+        // For Windows, package pregenerated object files in addition to
         // pregenerated assembly language source files, so that the user
         // doesn't need to install the assembler.
-        let asm_dir = if asm_target.preassemble {
-            &pregenerated_tmp
-        } else {
-            &pregenerated
-        };
-        let perlasm_src_dsts = perlasm_src_dsts(asm_dir, asm_target);
+
+        let perlasm_src_dsts = perlasm_src_dsts(&pregenerated, asm_target);
         perlasm(&perl_exe, &perlasm_src_dsts, asm_target);
 
         if asm_target.preassemble {
@@ -386,9 +380,9 @@ fn pregenerate_asm_main() {
                 force_warnings_into_errors: true,
             };
 
-            let b = new_build(&target, &pregenerated_tmp);
+            let b = new_build(&target, &pregenerated);
             for src in srcs {
-                win_asm(&b, &src, &target, &pregenerated_tmp, &pregenerated);
+                win_asm(&b, &src, &target, &pregenerated, &pregenerated);
             }
         }
     }


### PR DESCRIPTION
Pregenerate .asm files to pregenerated/ instead of pregenerated/tmp.

This simplifies the future prepackaging the symbol prefixing headers for cargo-vendor users.

This also makes progress towards allowing users of `cargo vendor` to eventually assemble the assembly sources on Windows themselves if they prefer.