### PR TITLE
NFC: Simplify prefixed_item! macro.

### DIFF
--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -65,28 +65,12 @@ macro_rules! prefixed_export {
 }
 
 macro_rules! prefixed_item {
-    // Calculate the prefixed name in a separate layer of macro expansion
-    // because rustc won't currently accept a non-literal expression as
-    // the value for `#[link_name = value]`.
     {
         $attr:ident
         $name:ident
         { $item:item }
     } => {
-        prefixed_item! {
-            $attr
-            { concat!(env!("RING_CORE_PREFIX"), stringify!($name)) }
-            { $item }
-        }
-    };
-
-    // Output the item.
-    {
-        $attr:ident
-        { $prefixed_name:expr }
-        { $item:item }
-    } => {
-        #[$attr = $prefixed_name]
+        #[$attr = concat!(env!("RING_CORE_PREFIX"), stringify!($name))]
         $item
     };
 }

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -71,12 +71,12 @@ macro_rules! prefixed_item {
     {
         $attr:ident
         $name:ident
-        { $( $item:tt )+ }
+        { $item:item }
     } => {
         prefixed_item! {
             $attr
             { concat!(env!("RING_CORE_PREFIX"), stringify!($name)) }
-            { $( $item )+ }
+            { $item }
         }
     };
 
@@ -84,9 +84,9 @@ macro_rules! prefixed_item {
     {
         $attr:ident
         { $prefixed_name:expr }
-        { $( $item:tt )+ }
+        { $item:item }
     } => {
         #[$attr = $prefixed_name]
-        $( $item )+
+        $item
     };
 }


### PR DESCRIPTION
Since `extended_key_value_attributes` was stablized prior to 1.61, we can simplify this macro.