### PR TITLE
Use only predefined environment variables to compute name prefixes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,10 @@ version = "0.17.8"
 
 # Keep in sync with `version` above.
 #
-# "ring_core_" + version, replacing punctuation with underscores.
-#
-# build.rs uses this to derive the prefix for FFI symbols and the file names
-# of the FFI libraries, so it must be a valid identifier prefix and a valid
-# filename prefix.
-links = "ring_core_0_17_8"
+# build.rs verifies that this equals "ring_core_{major}_{minor}_{patch}_{pre}"
+# as keeping this in sync with the symbol prefixing is crucial for ensuring
+# the safety of multiple versions of *ring* being used in a program.
+links = "ring_core_0_17_8_"
 
 include = [
     "LICENSE",

--- a/build.rs
+++ b/build.rs
@@ -321,7 +321,7 @@ fn ring_build_rs_main(c_root_dir: &Path) {
     // we want to optimize for minimizing the build tools required: No Perl,
     // no nasm, etc.
     let generated_dir = if !is_git {
-        PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap()).join(PREGENERATED)
+        c_root_dir.join(PREGENERATED)
     } else {
         generate_sources_and_preassemble(&out_dir, asm_target.into_iter(), c_root_dir);
         out_dir.clone()

--- a/build.rs
+++ b/build.rs
@@ -252,7 +252,7 @@ const WINDOWS: &str = "windows";
 ///
 /// The name is static since we intend to only read a static set of environment
 /// variables.
-fn read_env_var(name: &'static str) -> Option<OsString> {
+fn env_var_os(name: &'static str) -> Option<OsString> {
     println!("cargo:rerun-if-env-changed={}", name);
     std::env::var_os(name)
 }
@@ -265,7 +265,7 @@ fn main() {
     );
 
     const RING_PREGENERATE_ASM: &str = "RING_PREGENERATE_ASM";
-    match read_env_var(RING_PREGENERATE_ASM).as_deref() {
+    match env_var_os(RING_PREGENERATE_ASM).as_deref() {
         Some(s) if s == "1" => {
             pregenerate_asm_main(&c_root_dir);
         }
@@ -702,7 +702,7 @@ fn get_perl_exe() -> PathBuf {
 }
 
 fn get_command(var: &'static str, default: &str) -> PathBuf {
-    PathBuf::from(read_env_var(var).unwrap_or_else(|| default.into()))
+    PathBuf::from(env_var_os(var).unwrap_or_else(|| default.into()))
 }
 
 // TODO: We should emit `cargo:rerun-if-changed-env` for the various

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -1,3 +1,27 @@
+// Keep in sync with `core_name_and_version` in build.rs.
+macro_rules! core_name_and_version {
+    () => {
+        concat!(
+            env!("CARGO_PKG_NAME"),
+            "_core_",
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            "_",
+            env!("CARGO_PKG_VERSION_MINOR"),
+            "_",
+            env!("CARGO_PKG_VERSION_PATCH"),
+            "_",
+            env!("CARGO_PKG_VERSION_PRE"), // Often empty
+        )
+    };
+}
+
+// Keep in sync with `prefix` in build.rs.
+macro_rules! prefix {
+    ( ) => {
+        concat!(core_name_and_version!(), "_")
+    };
+}
+
 macro_rules! prefixed_extern {
     // Functions.
     {
@@ -70,7 +94,7 @@ macro_rules! prefixed_item {
         $name:ident
         { $item:item }
     } => {
-        #[$attr = concat!(env!("RING_CORE_PREFIX"), stringify!($name))]
+        #[$attr = concat!(prefix!(), stringify!($name))]
         $item
     };
 }


### PR DESCRIPTION
Instead of having build.rs set a custom environment variable, just compute the value directly from environment variables that are guaranteed to be set. This way, non-Cargo build systems can avoid duplicating this custom logic.

Move the consistency check of `links` and the package version so that the check is also done during pregeneration.

Use `read_env_var()` for the relevant environment variables so that build.rs emits `cargo:rerun-if-env-changed`, as it was noticed that Cargo otherwise doesn't seem to rerun the build script when the Cargo.toml values are changed.