### PR TITLE
CI: Use mk/install-build-tools.sh on all targets in CI, and use it for rustup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
       - run: rustup target add --toolchain=${{ matrix.rust_channel }} ${{ matrix.target }}
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
-        run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
+        run: mk/install-build-tools.sh --target=${{ matrix.target }}
 
       - if: ${{ contains(matrix.host_os, 'windows') }}
         run: ./mk/install-build-tools.ps1
@@ -413,7 +413,7 @@ jobs:
       - run: rustup target add --toolchain=${{ matrix.rust_channel }} ${{ matrix.target }}
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
-        run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
+        run: mk/install-build-tools.sh --target=${{ matrix.target }}
 
       - if: ${{ contains(matrix.host_os, 'windows') }}
         run: ./mk/install-build-tools.ps1
@@ -496,7 +496,7 @@ jobs:
 
       - run: cargo +${{ matrix.rust_channel }} generate-lockfile
 
-      - run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
+      - run: mk/install-build-tools.sh --target=${{ matrix.target }}
 
       - run: |
           ${{ matrix.webdriver }} mk/cargo.sh +${{ matrix.rust_channel }} test -vv --target=${{ matrix.target }} ${{ matrix.features }} ${{ matrix.mode }}
@@ -600,7 +600,7 @@ jobs:
       - run: rustup target add --toolchain=${{ matrix.rust_channel }} ${{ matrix.target }}
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
-        run: RING_COVERAGE=1 mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
+        run: RING_COVERAGE=1 mk/install-build-tools.sh --target=${{ matrix.target }}
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,11 +283,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup toolchain add --profile=minimal ${{ matrix.rust_channel }}
-      - run: rustup target add --toolchain=${{ matrix.rust_channel }} ${{ matrix.target }}
-
-      - if: ${{ !contains(matrix.host_os, 'windows') }}
-        run: mk/install-build-tools.sh --target=${{ matrix.target }}
+      - run: mk/install-build-tools.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
+        shell: sh
 
       - if: ${{ contains(matrix.host_os, 'windows') }}
         run: ./mk/install-build-tools.ps1
@@ -329,7 +326,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: mk/install-build-tools.sh --target=x86_64-unknown-linux-gnu
+      - run: mk/install-build-tools.sh +stable --target=x86_64-unknown-linux-gnu
+        shell: sh
 
       - run: rustup --version
 
@@ -409,11 +407,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup toolchain add --profile=minimal ${{ matrix.rust_channel }}
-      - run: rustup target add --toolchain=${{ matrix.rust_channel }} ${{ matrix.target }}
-
-      - if: ${{ !contains(matrix.host_os, 'windows') }}
-        run: mk/install-build-tools.sh --target=${{ matrix.target }}
+      - run: mk/install-build-tools.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
+        shell: sh
 
       - if: ${{ contains(matrix.host_os, 'windows') }}
         run: ./mk/install-build-tools.ps1
@@ -491,12 +486,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup toolchain add --profile=minimal ${{ matrix.rust_channel }}
-      - run: rustup target add --toolchain=${{ matrix.rust_channel }} ${{ matrix.target }}
+      - run: mk/install-build-tools.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
+        shell: sh
+
+      - if: ${{ contains(matrix.host_os, 'windows') }}
+        run: ./mk/install-build-tools.ps1
 
       - run: cargo +${{ matrix.rust_channel }} generate-lockfile
-
-      - run: mk/install-build-tools.sh --target=${{ matrix.target }}
 
       - run: |
           ${{ matrix.webdriver }} mk/cargo.sh +${{ matrix.rust_channel }} test -vv --target=${{ matrix.target }} ${{ matrix.features }} ${{ matrix.mode }}
@@ -596,11 +592,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup toolchain add --profile=minimal ${{ matrix.rust_channel }} --component llvm-tools-preview
-      - run: rustup target add --toolchain=${{ matrix.rust_channel }} ${{ matrix.target }}
+      - run: RING_COVERAGE=1 mk/install-build-tools.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
+        shell: sh
 
-      - if: ${{ !contains(matrix.host_os, 'windows') }}
-        run: RING_COVERAGE=1 mk/install-build-tools.sh --target=${{ matrix.target }}
+      - if: ${{ contains(matrix.host_os, 'windows') }}
+        run: ./mk/install-build-tools.ps1
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -17,7 +17,15 @@
 set -eux -o pipefail
 IFS=$'\n\t'
 
-target=$1
+for arg in $*; do
+  case $arg in
+    --target=*)
+      target=${arg#*=}
+      ;;
+    *)
+      ;;
+  esac
+done
 
 function install_packages {
   sudo apt-get -yq --no-install-suggests --no-install-recommends install "$@"
@@ -25,7 +33,7 @@ function install_packages {
 
 use_clang=
 case $target in
---target*android*)
+*android*)
   # https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html says
   # "Going forward the Android platform will target the most recent LTS NDK,
   # allowing Rust developers to access platform features sooner. These updates
@@ -56,7 +64,7 @@ case $target in
 esac
 
 case $target in
---target=aarch64-unknown-linux-gnu)
+aarch64-unknown-linux-gnu)
   # Clang is needed for code coverage.
   use_clang=1
   install_packages \
@@ -64,88 +72,88 @@ case $target in
     gcc-aarch64-linux-gnu \
     libc6-dev-arm64-cross
   ;;
---target=aarch64-unknown-linux-musl|--target=armv7-unknown-linux-musleabihf)
+aarch64-unknown-linux-musl|armv7-unknown-linux-musleabihf)
   use_clang=1
   install_packages \
     qemu-user
   ;;
---target=arm-unknown-linux-gnueabi)
+arm-unknown-linux-gnueabi)
   install_packages \
     qemu-user \
     gcc-arm-linux-gnueabi \
     libc6-dev-armel-cross
   ;;
---target=arm-unknown-linux-gnueabihf|--target=armv7-unknown-linux-gnueabihf)
+arm-unknown-linux-gnueabihf|armv7-unknown-linux-gnueabihf)
   install_packages \
     qemu-user \
     gcc-arm-linux-gnueabihf \
     libc6-dev-armhf-cross
   ;;
---target=i686-unknown-linux-gnu)
+i686-unknown-linux-gnu)
   use_clang=1
   install_packages \
     gcc-multilib \
     libc6-dev-i386
   ;;
---target=i686-unknown-linux-musl|--target=x86_64-unknown-linux-musl)
+i686-unknown-linux-musl|x86_64-unknown-linux-musl)
   use_clang=1
   ;;
---target=loongarch64-unknown-linux-gnu)
+loongarch64-unknown-linux-gnu)
   use_clang=1
   ;;
---target=mips-unknown-linux-gnu)
+mips-unknown-linux-gnu)
   install_packages \
     gcc-mips-linux-gnu \
     libc6-dev-mips-cross \
     qemu-user
   ;;
---target=mips64-unknown-linux-gnuabi64)
+mips64-unknown-linux-gnuabi64)
   install_packages \
     gcc-mips64-linux-gnuabi64 \
     libc6-dev-mips64-cross \
     qemu-user
   ;;
---target=mips64el-unknown-linux-gnuabi64)
+mips64el-unknown-linux-gnuabi64)
   install_packages \
     gcc-mips64el-linux-gnuabi64 \
     libc6-dev-mips64el-cross \
     qemu-user
   ;;
---target=mipsel-unknown-linux-gnu)
+mipsel-unknown-linux-gnu)
   install_packages \
     gcc-mipsel-linux-gnu \
     libc6-dev-mipsel-cross \
     qemu-user
   ;;
---target=powerpc-unknown-linux-gnu)
+powerpc-unknown-linux-gnu)
   use_clang=1
   install_packages \
     gcc-powerpc-linux-gnu \
     libc6-dev-powerpc-cross \
     qemu-user
   ;;
---target=powerpc64-unknown-linux-gnu)
+powerpc64-unknown-linux-gnu)
   use_clang=1
   install_packages \
     gcc-powerpc64-linux-gnu \
     libc6-dev-ppc64-cross \
     qemu-user
   ;;
---target=powerpc64le-unknown-linux-gnu)
+powerpc64le-unknown-linux-gnu)
   use_clang=1
   install_packages \
     gcc-powerpc64le-linux-gnu \
     libc6-dev-ppc64el-cross \
     qemu-user
   ;;
---target=riscv64gc-unknown-linux-gnu)
+riscv64gc-unknown-linux-gnu)
   use_clang=1
   install_packages \
     gcc-riscv64-linux-gnu \
     libc6-dev-riscv64-cross \
     qemu-user
   ;;
---target=s390x-unknown-linux-gnu)
+s390x-unknown-linux-gnu)
   # Clang is needed for code coverage.
   use_clang=1
   install_packages \
@@ -153,11 +161,11 @@ case $target in
     gcc-s390x-linux-gnu \
     libc6-dev-s390x-cross
   ;;
---target=wasm32-unknown-unknown)
+wasm32-unknown-unknown)
   cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner
   use_clang=1
   ;;
---target=wasm32-wasi)
+wasm32-wasi)
   use_clang=1
   git clone \
       --branch linux-x86_64 \
@@ -165,7 +173,7 @@ case $target in
       https://github.com/briansmith/ring-toolchain \
       target/tools/linux-x86_64
   ;;
---target=*)
+*)
   ;;
 esac
 

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -18,7 +18,6 @@ set -eux -o pipefail
 IFS=$'\n\t'
 
 target=$1
-features=${2-}
 
 function install_packages {
   sudo apt-get -yq --no-install-suggests --no-install-recommends install "$@"


### PR DESCRIPTION
De-duplicate the logic in ci.yml regarding rustup.