### PR TITLE
CI: Use `--no-self-update` during `rustup install`.

### DIFF
--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -198,7 +198,7 @@ linux*)
   ;;
 esac
 
-rustup toolchain install --profile=minimal ${toolchain}
+rustup toolchain install --no-self-update --profile=minimal ${toolchain}
 if [ -n "${target-}" ]; then
   rustup target add --toolchain=${toolchain} ${target}
 fi


### PR DESCRIPTION
Most immediately, work around a problem in GitHub actions where CI jobs fail on Windows hosts with "rustup: Device or resource busy" (see below).

Regardless, we didn't intend install-build-tools.sh to upgrade rustup.

```
Run mk/install-build-tools.sh +stable --target=aarch64-pc-windows-msvc
+ rustup toolchain install --profile=minimal stable
info: syncing channel updates for 'stable-x86_64-pc-windows-msvc'

  stable-x86_64-pc-windows-msvc unchanged - rustc 1.76.0 (07dca489a 2024-02-04)
info: checking for self-update

info: downloading self-update
+ '[' -n aarch64-pc-windows-msvc ']'
+ rustup target add --toolchain=stable aarch64-pc-windows-msvc
mk/install-build-tools.sh: line 203: /c/Users/runneradmin/.cargo/bin/rustup: Device or resource busy
warning: tool `rust-analyzer` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.
warning: tool `rustfmt` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.
warning: tool `cargo-fmt` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.
Error: Process completed with exit code 126.
```