### PR TITLE
digest internals: Refactor to clarify safety

### DIFF
--- a/src/c.rs
+++ b/src/c.rs
@@ -25,9 +25,12 @@
 
 // Keep in sync with the checks in base.h that verify these assumptions.
 
+use core::num::NonZeroUsize;
+
 pub(crate) type int = i32;
 pub(crate) type uint = u32;
 pub(crate) type size_t = usize;
+pub(crate) type NonZero_size_t = NonZeroUsize;
 
 #[cfg(all(test, any(unix, windows)))]
 mod tests {

--- a/src/c.rs
+++ b/src/c.rs
@@ -25,6 +25,8 @@
 
 // Keep in sync with the checks in base.h that verify these assumptions.
 
+#![allow(dead_code)]
+
 use core::num::NonZeroUsize;
 
 pub(crate) type int = i32;

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -114,7 +114,7 @@ impl BlockContext {
 
         Digest {
             algorithm: self.algorithm,
-            value: (self.algorithm.format_output)(self.state),
+            value: unsafe { (self.algorithm.format_output)(self.state) },
         }
     }
 
@@ -290,7 +290,7 @@ pub struct Algorithm {
 
     block_data_order:
         unsafe extern "C" fn(state: &mut State, data: *const u8, num: c::NonZero_size_t),
-    format_output: fn(input: State) -> Output,
+    format_output: unsafe fn(input: State) -> Output,
 
     initial_state: State,
 
@@ -490,12 +490,12 @@ pub const MAX_OUTPUT_LEN: usize = 512 / 8;
 /// algorithms in this module.
 pub const MAX_CHAINING_LEN: usize = MAX_OUTPUT_LEN;
 
-fn sha256_format_output(input: State) -> Output {
+unsafe fn sha256_format_output(input: State) -> Output {
     let input = unsafe { input.as32 };
     format_output::<_, _, { core::mem::size_of::<u32>() }>(input, u32::to_be_bytes)
 }
 
-fn sha512_format_output(input: State) -> Output {
+unsafe fn sha512_format_output(input: State) -> Output {
     let input = unsafe { input.as64 };
     format_output::<_, _, { core::mem::size_of::<u64>() }>(input, u64::to_be_bytes)
 }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -24,6 +24,7 @@
 // The goal for this implementation is to drive the overhead as close to zero
 // as possible.
 
+use self::sha2::{SHA256_BLOCK_LEN, SHA512_BLOCK_LEN};
 use crate::{c, cpu, debug, polyfill};
 use core::num::Wrapping;
 
@@ -340,7 +341,7 @@ pub static SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
     chaining_len: sha1::CHAINING_LEN,
     block_len: sha1::BLOCK_LEN,
     len_len: 64 / 8,
-    block_data_order: sha1::block_data_order,
+    block_data_order: sha1::sha1_block_data_order,
     format_output: sha256_format_output,
     initial_state: State {
         as32: [
@@ -363,7 +364,7 @@ pub static SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
 pub static SHA256: Algorithm = Algorithm {
     output_len: SHA256_OUTPUT_LEN,
     chaining_len: SHA256_OUTPUT_LEN,
-    block_len: 512 / 8,
+    block_len: SHA256_BLOCK_LEN,
     len_len: 64 / 8,
     block_data_order: sha2::sha256_block_data_order,
     format_output: sha256_format_output,
@@ -524,9 +525,6 @@ pub const SHA512_OUTPUT_LEN: usize = 512 / 8;
 
 /// The length of the output of SHA-512/256, in bytes.
 pub const SHA512_256_OUTPUT_LEN: usize = 256 / 8;
-
-/// The length of a block for SHA-512-based algorithms, in bytes.
-const SHA512_BLOCK_LEN: usize = 1024 / 8;
 
 /// The length of the length field for SHA-512-based algorithms, in bytes.
 const SHA512_LEN_LEN: usize = 128 / 8;

--- a/src/digest/dynstate.rs
+++ b/src/digest/dynstate.rs
@@ -12,47 +12,95 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{format_output, sha2, Output};
+use super::{format_output, sha1, sha2, Output};
+use core::num::NonZeroUsize;
 
-// SAFETY: When constructed with `new32` (resp. `new64`), `as32` (resp. `as64`)
-// is fully initialized and is the active field. The active field never changes
-// after initialization.
-#[derive(Clone, Copy)] // XXX: Why do we need to be `Copy`?
-#[repr(C)]
-pub(super) union DynState {
-    as64: sha2::State64,
-    as32: sha2::State32,
+// Invariant: When constructed with `new32` (resp. `new64`), `As32` (resp.
+// `As64`) is the active variant.
+// Invariant: The active variant never changes after initialization.
+#[derive(Clone)]
+pub(super) enum DynState {
+    As64(sha2::State64),
+    As32(sha2::State32),
 }
 
 impl DynState {
     pub const fn new32(initial_state: sha2::State32) -> Self {
-        Self {
-            as32: initial_state,
-        }
+        Self::As32(initial_state)
     }
 
     pub const fn new64(initial_state: sha2::State64) -> Self {
-        Self {
-            as64: initial_state,
+        Self::As64(initial_state)
+    }
+}
+
+pub(super) unsafe fn sha1_block_data_order(
+    state: &mut DynState,
+    data: *const u8,
+    num: NonZeroUsize,
+) {
+    let state = match state {
+        DynState::As32(state) => state,
+        _ => {
+            unreachable!();
         }
-    }
+    };
 
-    pub(super) unsafe fn as32(&mut self) -> &mut sha2::State32 {
-        unsafe { &mut self.as32 }
-    }
-
-    #[allow(dead_code)]
-    pub(super) unsafe fn as64(&mut self) -> &mut sha2::State64 {
-        unsafe { &mut self.as64 }
-    }
+    // SAFETY: The caller guarantees that this is called with data pointing to `num`
+    // `sha1::BLOCK_LEN`-long blocks.
+    sha1::sha1_block_data_order(state, data, num);
 }
 
-pub(super) unsafe fn sha256_format_output(input: DynState) -> Output {
-    let input = unsafe { input.as32 };
-    format_output::<_, _, { core::mem::size_of::<u32>() }>(input, u32::to_be_bytes)
+pub(super) unsafe fn sha256_block_data_order(
+    state: &mut DynState,
+    data: *const u8,
+    num: NonZeroUsize,
+) {
+    let state = match state {
+        DynState::As32(state) => state,
+        _ => {
+            unreachable!();
+        }
+    };
+
+    // SAFETY: The caller guarantees that this is called with data pointing to `num`
+    // `SHA256_BLOCK_LEN`-long blocks.
+    sha2::sha256_block_data_order(state, data, num);
 }
 
-pub(super) unsafe fn sha512_format_output(input: DynState) -> Output {
-    let input = unsafe { input.as64 };
-    format_output::<_, _, { core::mem::size_of::<u64>() }>(input, u64::to_be_bytes)
+pub(super) unsafe fn sha512_block_data_order(
+    state: &mut DynState,
+    data: *const u8,
+    num: NonZeroUsize,
+) {
+    let state = match state {
+        DynState::As64(state) => state,
+        _ => {
+            unreachable!();
+        }
+    };
+
+    // SAFETY: The caller guarantees that this is called with data pointing to `num`
+    // `SHA512_BLOCK_LEN`-long blocks.
+    sha2::sha512_block_data_order(state, data, num);
+}
+
+pub(super) fn sha256_format_output(state: DynState) -> Output {
+    let state = match state {
+        DynState::As32(state) => state,
+        _ => {
+            unreachable!();
+        }
+    };
+    format_output::<_, _, { core::mem::size_of::<u32>() }>(state, u32::to_be_bytes)
+}
+
+pub(super) fn sha512_format_output(state: DynState) -> Output {
+    let state = match state {
+        DynState::As64(state) => state,
+        _ => {
+            unreachable!();
+        }
+    };
+    format_output::<_, _, { core::mem::size_of::<u64>() }>(state, u64::to_be_bytes)
 }

--- a/src/digest/dynstate.rs
+++ b/src/digest/dynstate.rs
@@ -1,0 +1,58 @@
+// Copyright 2015-2019 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use super::{format_output, sha2, Output};
+
+// SAFETY: When constructed with `new32` (resp. `new64`), `as32` (resp. `as64`)
+// is fully initialized and is the active field. The active field never changes
+// after initialization.
+#[derive(Clone, Copy)] // XXX: Why do we need to be `Copy`?
+#[repr(C)]
+pub(super) union DynState {
+    as64: sha2::State64,
+    as32: sha2::State32,
+}
+
+impl DynState {
+    pub const fn new32(initial_state: sha2::State32) -> Self {
+        Self {
+            as32: initial_state,
+        }
+    }
+
+    pub const fn new64(initial_state: sha2::State64) -> Self {
+        Self {
+            as64: initial_state,
+        }
+    }
+
+    pub(super) unsafe fn as32(&mut self) -> &mut sha2::State32 {
+        unsafe { &mut self.as32 }
+    }
+
+    #[allow(dead_code)]
+    pub(super) unsafe fn as64(&mut self) -> &mut sha2::State64 {
+        unsafe { &mut self.as64 }
+    }
+}
+
+pub(super) unsafe fn sha256_format_output(input: DynState) -> Output {
+    let input = unsafe { input.as32 };
+    format_output::<_, _, { core::mem::size_of::<u32>() }>(input, u32::to_be_bytes)
+}
+
+pub(super) unsafe fn sha512_format_output(input: DynState) -> Output {
+    let input = unsafe { input.as64 };
+    format_output::<_, _, { core::mem::size_of::<u64>() }>(input, u64::to_be_bytes)
+}

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -34,11 +34,11 @@ type State = [W32; CHAINING_WORDS];
 const ROUNDS: usize = 80;
 
 pub(super) extern "C" fn sha1_block_data_order(
-    state: &mut super::State,
+    state: &mut super::DynState,
     data: *const u8,
     num: NonZeroUsize,
 ) {
-    let state = unsafe { &mut state.as32 };
+    let state = unsafe { state.as32() };
     // The unwrap won't fail because `CHAINING_WORDS` is smaller than the
     // length.
     let state: &mut State = (&mut state[..CHAINING_WORDS]).try_into().unwrap();

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -14,8 +14,8 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::sha2::{ch, maj, Word};
-use crate::{c, polyfill::slice};
-use core::num::Wrapping;
+use crate::polyfill::slice;
+use core::num::{NonZeroUsize, Wrapping};
 
 pub const BLOCK_LEN: usize = 512 / 8;
 pub const CHAINING_LEN: usize = 160 / 8;
@@ -36,7 +36,7 @@ const ROUNDS: usize = 80;
 pub(super) extern "C" fn sha1_block_data_order(
     state: &mut super::State,
     data: *const u8,
-    num: c::size_t,
+    num: NonZeroUsize,
 ) {
     let state = unsafe { &mut state.as32 };
     // The unwrap won't fail because `CHAINING_WORDS` is smaller than the
@@ -45,7 +45,7 @@ pub(super) extern "C" fn sha1_block_data_order(
     // SAFETY: The caller guarantees that this is called with data pointing to `num`
     // `BLOCK_LEN`-long blocks.
     let data = data.cast::<[u8; BLOCK_LEN]>();
-    let data = unsafe { core::slice::from_raw_parts(data, num) };
+    let data = unsafe { core::slice::from_raw_parts(data, num.get()) };
     *state = block_data_order(*state, data)
 }
 

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -15,7 +15,7 @@
 
 use super::sha2::{ch, maj, State32, Word};
 use crate::polyfill::slice;
-use core::num::{NonZeroUsize, Wrapping};
+use core::num::Wrapping;
 
 pub const BLOCK_LEN: usize = 512 / 8;
 pub const CHAINING_LEN: usize = 160 / 8;
@@ -33,18 +33,12 @@ fn parity(x: W32, y: W32, z: W32) -> W32 {
 type State = [W32; CHAINING_WORDS];
 const ROUNDS: usize = 80;
 
-pub(super) unsafe fn sha1_block_data_order(
-    state: &mut State32,
-    data: *const u8,
-    num: NonZeroUsize,
-) {
+pub(super) fn sha1_block_data_order(state: &mut State32, data: &[[u8; BLOCK_LEN]]) {
     // The unwrap won't fail because `CHAINING_WORDS` is smaller than the
     // length.
     let state: &mut State = (&mut state[..CHAINING_WORDS]).try_into().unwrap();
     // SAFETY: The caller guarantees that this is called with data pointing to `num`
     // `BLOCK_LEN`-long blocks.
-    let data = data.cast::<[u8; BLOCK_LEN]>();
-    let data = unsafe { core::slice::from_raw_parts(data, num.get()) };
     *state = block_data_order(*state, data)
 }
 

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -13,7 +13,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::sha2::{ch, maj, Word};
+use super::sha2::{ch, maj, State32, Word};
 use crate::polyfill::slice;
 use core::num::{NonZeroUsize, Wrapping};
 
@@ -33,12 +33,11 @@ fn parity(x: W32, y: W32, z: W32) -> W32 {
 type State = [W32; CHAINING_WORDS];
 const ROUNDS: usize = 80;
 
-pub(super) extern "C" fn sha1_block_data_order(
-    state: &mut super::DynState,
+pub(super) unsafe fn sha1_block_data_order(
+    state: &mut State32,
     data: *const u8,
     num: NonZeroUsize,
 ) {
-    let state = unsafe { state.as32() };
     // The unwrap won't fail because `CHAINING_WORDS` is smaller than the
     // length.
     let state: &mut State = (&mut state[..CHAINING_WORDS]).try_into().unwrap();

--- a/src/digest/sha2.rs
+++ b/src/digest/sha2.rs
@@ -22,13 +22,11 @@ pub(super) type State32 = [Wrapping<u32>; CHAINING_WORDS];
 pub(super) type State64 = [Wrapping<u64>; CHAINING_WORDS];
 
 #[cfg(not(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64")))]
-pub(super) extern "C" fn sha256_block_data_order(
-    state: &mut super::DynState,
+pub(super) unsafe fn sha256_block_data_order(
+    state: &mut State32,
     data: *const u8,
     num: core::num::NonZeroUsize,
 ) {
-    let state = unsafe { state.as32() };
-
     // SAFETY: The caller guarantees that this is called with data pointing to `num`
     // `SHA256_BLOCK_LEN`-long blocks.
     let data = data.cast::<[u8; SHA256_BLOCK_LEN]>();
@@ -37,13 +35,11 @@ pub(super) extern "C" fn sha256_block_data_order(
 }
 
 #[cfg(not(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64")))]
-pub(super) extern "C" fn sha512_block_data_order(
-    state: &mut super::DynState,
+pub(super) unsafe fn sha512_block_data_order(
+    state: &mut State64,
     data: *const u8,
     num: core::num::NonZeroUsize,
 ) {
-    let state = unsafe { state.as64() };
-
     // SAFETY: The caller guarantees that this is called with data pointing to `num`
     // `SHA512_BLOCK_LEN`-long blocks.
     let data = data.cast::<[u8; SHA512_BLOCK_LEN]>();
@@ -391,12 +387,12 @@ impl Sha2 for Wrapping<u64> {
 #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64"))]
 prefixed_extern! {
     pub(super) fn sha256_block_data_order(
-        state: &mut super::DynState,
+        state: &mut [Wrapping<u32>; CHAINING_WORDS],
         data: *const u8,
         num: crate::c::NonZero_size_t,
     );
     pub(super) fn sha512_block_data_order(
-        state: &mut super::DynState,
+        state: &mut [Wrapping<u64>; CHAINING_WORDS],
         data: *const u8,
         num: crate::c::NonZero_size_t,
     );

--- a/src/digest/sha2.rs
+++ b/src/digest/sha2.rs
@@ -18,13 +18,16 @@ use core::{
     ops::{Add, AddAssign, BitAnd, BitOr, BitXor, Not, Shr},
 };
 
+pub(super) type State32 = [Wrapping<u32>; CHAINING_WORDS];
+pub(super) type State64 = [Wrapping<u64>; CHAINING_WORDS];
+
 #[cfg(not(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64")))]
 pub(super) extern "C" fn sha256_block_data_order(
-    state: &mut super::State,
+    state: &mut super::DynState,
     data: *const u8,
     num: core::num::NonZeroUsize,
 ) {
-    let state = unsafe { &mut state.as32 };
+    let state = unsafe { state.as32() };
 
     // SAFETY: The caller guarantees that this is called with data pointing to `num`
     // `SHA256_BLOCK_LEN`-long blocks.
@@ -35,11 +38,11 @@ pub(super) extern "C" fn sha256_block_data_order(
 
 #[cfg(not(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64")))]
 pub(super) extern "C" fn sha512_block_data_order(
-    state: &mut super::State,
+    state: &mut super::DynState,
     data: *const u8,
     num: core::num::NonZeroUsize,
 ) {
-    let state = unsafe { &mut state.as64 };
+    let state = unsafe { state.as64() };
 
     // SAFETY: The caller guarantees that this is called with data pointing to `num`
     // `SHA512_BLOCK_LEN`-long blocks.
@@ -388,12 +391,12 @@ impl Sha2 for Wrapping<u64> {
 #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64"))]
 prefixed_extern! {
     pub(super) fn sha256_block_data_order(
-        state: &mut super::State,
+        state: &mut super::DynState,
         data: *const u8,
         num: crate::c::NonZero_size_t,
     );
     pub(super) fn sha512_block_data_order(
-        state: &mut super::State,
+        state: &mut super::DynState,
         data: *const u8,
         num: crate::c::NonZero_size_t,
     );

--- a/src/digest/sha2.rs
+++ b/src/digest/sha2.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use crate::{c, polyfill::slice};
+use crate::polyfill::slice;
 use core::{
     num::Wrapping,
     ops::{Add, AddAssign, BitAnd, BitOr, BitXor, Not, Shr},
@@ -22,14 +22,14 @@ use core::{
 pub(super) extern "C" fn sha256_block_data_order(
     state: &mut super::State,
     data: *const u8,
-    num: c::size_t,
+    num: core::num::NonZeroUsize,
 ) {
     let state = unsafe { &mut state.as32 };
 
     // SAFETY: The caller guarantees that this is called with data pointing to `num`
     // `SHA256_BLOCK_LEN`-long blocks.
     let data = data.cast::<[u8; SHA256_BLOCK_LEN]>();
-    let data = unsafe { core::slice::from_raw_parts(data, num) };
+    let data = unsafe { core::slice::from_raw_parts(data, num.get()) };
     *state = block_data_order(*state, data)
 }
 
@@ -37,14 +37,14 @@ pub(super) extern "C" fn sha256_block_data_order(
 pub(super) extern "C" fn sha512_block_data_order(
     state: &mut super::State,
     data: *const u8,
-    num: c::size_t,
+    num: core::num::NonZeroUsize,
 ) {
     let state = unsafe { &mut state.as64 };
 
     // SAFETY: The caller guarantees that this is called with data pointing to `num`
     // `SHA512_BLOCK_LEN`-long blocks.
     let data = data.cast::<[u8; SHA512_BLOCK_LEN]>();
-    let data = unsafe { core::slice::from_raw_parts(data, num) };
+    let data = unsafe { core::slice::from_raw_parts(data, num.get()) };
     *state = block_data_order(*state, data)
 }
 
@@ -390,11 +390,11 @@ prefixed_extern! {
     pub(super) fn sha256_block_data_order(
         state: &mut super::State,
         data: *const u8,
-        num: c::size_t,
+        num: crate::c::NonZero_size_t,
     );
     pub(super) fn sha512_block_data_order(
         state: &mut super::State,
         data: *const u8,
-        num: c::size_t,
+        num: crate::c::NonZero_size_t,
     );
 }

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -53,6 +53,8 @@ mod leading_zeros_skipped;
 
 pub mod ptr;
 
+pub mod slice;
+
 #[cfg(test)]
 mod test;
 

--- a/src/polyfill/slice.rs
+++ b/src/polyfill/slice.rs
@@ -1,0 +1,38 @@
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+// TODO(MSRV feature(slice_as_chunks)): Use `slice::as_chunks` instead.
+// This is copied from the libcore implementation of `slice::as_chunks`.
+#[inline(always)]
+pub fn as_chunks<T, const N: usize>(slice: &[T]) -> (&[[T; N]], &[T]) {
+    assert!(N != 0, "chunk size must be non-zero");
+    let len = slice.len() / N;
+    let (multiple_of_n, remainder) = slice.split_at(len * N);
+    // SAFETY: We already panicked for zero, and ensured by construction
+    // that the length of the subslice is a multiple of N.
+    // SAFETY: We cast a slice of `new_len * N` elements into
+    // a slice of `new_len` many `N` elements chunks.
+    let chunked = unsafe { core::slice::from_raw_parts(multiple_of_n.as_ptr().cast(), len) };
+    (chunked, remainder)
+}


### PR DESCRIPTION
Refactor `ring::digest` to minimize the use of `unsafe`.