### PR TITLE
style: address shellcheck warnings

### DIFF
--- a/bench/data/rsa-generate.sh
+++ b/bench/data/rsa-generate.sh
@@ -34,20 +34,20 @@ rm rsa-2048-65537.p8
 m=(2048 3072 4096 8192)
 for i in "${m[@]}"
 do
-    echo $i
+    echo "$i"
     openssl genpkey -algorithm RSA \
         -pkeyopt rsa_keygen_bits:2048 \
         -pkeyopt rsa_keygen_pubexp:3 | \
-      openssl pkcs8 -topk8 -nocrypt -outform der > rsa-$i-3.p8
+      openssl pkcs8 -topk8 -nocrypt -outform der > "rsa-$i-3.p8"
 
     openssl pkey -pubout -inform der -outform der \
-        -in rsa-$i-3.p8 | \
+        -in "rsa-$i-3.p8" | \
       openssl rsa -pubin -RSAPublicKey_out -inform DER -outform DER \
-        -out rsa-$i-3-public-key.der
+        -out "rsa-$i-3-public-key.der"
 
-    openssl dgst -sha256 -sign rsa-$i-3.p8 -out rsa-$i-3-signature.bin empty_message
+    openssl dgst -sha256 -sign "rsa-$i-3.p8" -out "rsa-$i-3-signature.bin" empty_message
 
-    rm rsa-$i-3.p8
+    rm "rsa-$i-3.p8"
 done
 
 rm empty_message

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -43,7 +43,7 @@ if [ -n "${ANDROID_NDK_ROOT-}" ]; then
   android_tools=${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin
 fi
 
-for arg in $*; do
+for arg in "$@"; do
   case $arg in
     --target=*)
       target=${arg#*=}

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -255,9 +255,9 @@ if [ -n "${RING_COVERAGE-}" ]; then
 
   while read -r executable; do
     basename=$(basename "$executable")
-    "${llvm_root}"/llvm-profdata merge -sparse "$coverage_dir/$basename.profraw" -o "$coverage_dir/$basename.profdata"
+    "${llvm_root}/llvm-profdata" merge -sparse "$coverage_dir/$basename.profraw" -o "$coverage_dir/$basename.profdata"
     mkdir -p "$coverage_dir"/reports
-    "${llvm_root}"/llvm-cov export \
+    "${llvm_root}/llvm-cov" export \
       --instr-profile "$coverage_dir/$basename.profdata" \
       --format lcov \
       "$executable" \

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -215,7 +215,7 @@ if [ -n "${RING_COVERAGE-}" ]; then
   # something similar but different.
   # export LLVM_PROFILE_FILE="$coverage_dir/%m.profraw"
 
-  target_upper=$(echo ${target_lower} | tr '[:lower:]' '[:upper:]')
+  target_upper=$(echo "${target_lower}" | tr '[:lower:]' '[:upper:]')
 
   case "$OSTYPE" in
     linux*)
@@ -251,16 +251,16 @@ cargo "$@"
 if [ -n "${RING_COVERAGE-}" ]; then
   # Keep in sync with check-symbol-prefixes.sh.
   # Use the host target-libdir, not the target target-libdir.
-  llvm_root="$(rustc +${toolchain} --print target-libdir)/../bin"
+  llvm_root="$(rustc +"${toolchain}" --print target-libdir)/../bin"
 
   while read executable; do
     basename=$(basename "$executable")
-    ${llvm_root}/llvm-profdata merge -sparse "$coverage_dir/$basename.profraw" -o "$coverage_dir/$basename.profdata"
+    "${llvm_root}"/llvm-profdata merge -sparse "$coverage_dir/$basename.profraw" -o "$coverage_dir/$basename.profdata"
     mkdir -p "$coverage_dir"/reports
-    ${llvm_root}/llvm-cov export \
-      --instr-profile "$coverage_dir"/$basename.profdata \
+    "${llvm_root}"/llvm-cov export \
+      --instr-profile "$coverage_dir/$basename.profdata" \
       --format lcov \
       "$executable" \
-    > "$coverage_dir"/reports/coverage-$basename.txt
+    > "$coverage_dir/reports/coverage-$basename.txt"
   done < "$RING_BUILD_EXECUTABLE_LIST"
 fi

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -251,7 +251,7 @@ cargo "$@"
 if [ -n "${RING_COVERAGE-}" ]; then
   # Keep in sync with check-symbol-prefixes.sh.
   # Use the host target-libdir, not the target target-libdir.
-  llvm_root="$(rustc +"${toolchain}" --print target-libdir)/../bin"
+  llvm_root=$(rustc +"${toolchain}" --print target-libdir)/../bin
 
   while read -r executable; do
     basename=$(basename "$executable")

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -253,7 +253,7 @@ if [ -n "${RING_COVERAGE-}" ]; then
   # Use the host target-libdir, not the target target-libdir.
   llvm_root="$(rustc +"${toolchain}" --print target-libdir)/../bin"
 
-  while read executable; do
+  while read -r executable; do
     basename=$(basename "$executable")
     "${llvm_root}"/llvm-profdata merge -sparse "$coverage_dir/$basename.profraw" -o "$coverage_dir/$basename.profdata"
     mkdir -p "$coverage_dir"/reports

--- a/mk/check-symbol-prefixes.sh
+++ b/mk/check-symbol-prefixes.sh
@@ -32,7 +32,7 @@ done
 
 # Keep in sync with cargo.sh.
 # Use the host target-libdir, not the target target-libdir.
-llvm_root="$(rustc +${toolchain} --print target-libdir)/../bin"
+llvm_root="$(rustc +"${toolchain}" --print target-libdir)/../bin"
 
 nm_exe="${llvm_root}/llvm-nm"
 
@@ -44,7 +44,7 @@ nm_exe="${llvm_root}/llvm-nm"
 #
 # This is very liberal in filtering out symbols that "look like"
 # Rust-compiler-generated symbols.
-find target/$target -type f -name libring-*.rlib | while read -r infile; do
+find "target/$target" -type f -name libring-*.rlib | while read -r infile; do
   bad=$($nm_exe --defined-only --extern-only --print-file-name "$infile" \
     | ( grep -v -E " . _?(__imp__ZN4ring|ring_core_|__rustc|_ZN|DW.ref.rust_eh_personality)" || [[ $? == 1 ]] ))
   if [ ! -z "${bad-}" ]; then

--- a/mk/check-symbol-prefixes.sh
+++ b/mk/check-symbol-prefixes.sh
@@ -17,7 +17,7 @@
 set -eux -o pipefail
 IFS=$'\n\t'
 
-for arg in $*; do
+for arg in "$@"; do
   case $arg in
     --target=*)
       target=${arg#*=}

--- a/mk/check-symbol-prefixes.sh
+++ b/mk/check-symbol-prefixes.sh
@@ -44,7 +44,7 @@ nm_exe="${llvm_root}/llvm-nm"
 #
 # This is very liberal in filtering out symbols that "look like"
 # Rust-compiler-generated symbols.
-find "target/$target" -type f -name libring-*.rlib | while read -r infile; do
+find "target/$target" -type f -name "libring-*.rlib" | while read -r infile; do
   bad=$($nm_exe --defined-only --extern-only --print-file-name "$infile" \
     | ( grep -v -E " . _?(__imp__ZN4ring|ring_core_|__rustc|_ZN|DW.ref.rust_eh_personality)" || [[ $? == 1 ]] ))
   if [ -n "${bad-}" ]; then

--- a/mk/check-symbol-prefixes.sh
+++ b/mk/check-symbol-prefixes.sh
@@ -47,7 +47,7 @@ nm_exe="${llvm_root}/llvm-nm"
 find "target/$target" -type f -name libring-*.rlib | while read -r infile; do
   bad=$($nm_exe --defined-only --extern-only --print-file-name "$infile" \
     | ( grep -v -E " . _?(__imp__ZN4ring|ring_core_|__rustc|_ZN|DW.ref.rust_eh_personality)" || [[ $? == 1 ]] ))
-  if [ ! -z "${bad-}" ]; then
+  if [ -n "${bad-}" ]; then
     echo "$bad"
     exit 1
   fi

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -24,4 +24,4 @@ cargo clippy \
   --deny missing_docs \
   --deny unused_qualifications \
   --deny warnings \
-  $NULL
+  "$NULL"

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -18,7 +18,7 @@ set -eux -o pipefail
 IFS=$'\n\t'
 
 toolchain=stable
-for arg in $*; do
+for arg in "$@"; do
   case $arg in
     --target=*)
       target=${arg#*=}

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -62,7 +62,7 @@ case ${target-} in
 
   # XXX: Older Rust toolchain versions link with `-lgcc` instead of `-lunwind`;
   # see https://github.com/rust-lang/rust/pull/85806.
-  find -L ${ANDROID_NDK_ROOT:-${ANDROID_HOME}/ndk/$ndk_version} -name libunwind.a \
+  find -L "${ANDROID_NDK_ROOT:-${ANDROID_HOME}/ndk/$ndk_version}" -name libunwind.a \
           -execdir sh -c 'echo "INPUT(-lunwind)" > libgcc.a' \;
   ;;
 esac
@@ -198,10 +198,10 @@ linux*)
   ;;
 esac
 
-rustup toolchain install --no-self-update --profile=minimal ${toolchain}
+rustup toolchain install --no-self-update --profile=minimal "${toolchain}"
 if [ -n "${target-}" ]; then
-  rustup target add --toolchain=${toolchain} ${target}
+  rustup target add --toolchain="${toolchain}" "${target}"
 fi
 if [ -n "${RING_COVERAGE-}" ]; then
-  rustup toolchain install --profile=minimal ${toolchain} --component llvm-tools-preview
+  rustup toolchain install --profile=minimal "${toolchain}" --component llvm-tools-preview
 fi


### PR DESCRIPTION
Addressing the warnings raised by [shellcheck](https://www.shellcheck.net/).

Using shellcheck (slightly) improves the style consistency and reduces the chance of subtle errors.

There are still two shellcheck warnings for missing shebangs (in `mk/package.sh` and `mk/publish.sh`, however looking at the scripts it seems these might be for windows environments running MinGW, where shebangs might be incompatible.