### PR TITLE
digest internals: Help the compiler understand minimum/maximum output/block sizes.

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -258,7 +258,7 @@ impl Digest {
 impl AsRef<[u8]> for Digest {
     #[inline(always)]
     fn as_ref(&self) -> &[u8] {
-        &self.value.0[..self.algorithm.output_len]
+        &self.value.0[..self.algorithm.output_len()]
     }
 }
 
@@ -271,7 +271,7 @@ impl core::fmt::Debug for Digest {
 
 /// A digest algorithm.
 pub struct Algorithm {
-    output_len: usize,
+    output_len: OutputLen,
     chaining_len: usize,
     block_len: usize,
 
@@ -332,7 +332,7 @@ impl Algorithm {
 
     /// The length of a finalized digest.
     pub fn output_len(&self) -> usize {
-        self.output_len
+        self.output_len.into()
     }
 }
 
@@ -363,7 +363,7 @@ pub static SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 pub static SHA256: Algorithm = Algorithm {
-    output_len: SHA256_OUTPUT_LEN,
+    output_len: OutputLen::_256,
     chaining_len: SHA256_OUTPUT_LEN,
     block_len: SHA256_BLOCK_LEN,
     len_len: 64 / 8,
@@ -386,7 +386,7 @@ pub static SHA256: Algorithm = Algorithm {
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 pub static SHA384: Algorithm = Algorithm {
-    output_len: SHA384_OUTPUT_LEN,
+    output_len: OutputLen::_384,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,
     len_len: SHA512_LEN_LEN,
@@ -409,7 +409,7 @@ pub static SHA384: Algorithm = Algorithm {
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 pub static SHA512: Algorithm = Algorithm {
-    output_len: SHA512_OUTPUT_LEN,
+    output_len: OutputLen::_512,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,
     len_len: SHA512_LEN_LEN,
@@ -436,7 +436,7 @@ pub static SHA512: Algorithm = Algorithm {
 ///
 /// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 pub static SHA512_256: Algorithm = Algorithm {
-    output_len: SHA512_256_OUTPUT_LEN,
+    output_len: OutputLen::_256,
     chaining_len: SHA512_OUTPUT_LEN,
     block_len: SHA512_BLOCK_LEN,
     len_len: SHA512_LEN_LEN,
@@ -464,7 +464,7 @@ pub const MAX_BLOCK_LEN: usize = 1024 / 8;
 
 /// The maximum output length ([`Algorithm::output_len()`]) of all the
 /// algorithms in this module.
-pub const MAX_OUTPUT_LEN: usize = 512 / 8;
+pub const MAX_OUTPUT_LEN: usize = OutputLen::MAX.into();
 
 /// The maximum chaining length ([`Algorithm::chaining_len()`]) of all the
 /// algorithms in this module.
@@ -488,22 +488,39 @@ where
 }
 
 /// The length of the output of SHA-1, in bytes.
-pub const SHA1_OUTPUT_LEN: usize = sha1::OUTPUT_LEN;
+pub const SHA1_OUTPUT_LEN: usize = sha1::OUTPUT_LEN.into();
 
 /// The length of the output of SHA-256, in bytes.
-pub const SHA256_OUTPUT_LEN: usize = 256 / 8;
+pub const SHA256_OUTPUT_LEN: usize = OutputLen::_256.into();
 
 /// The length of the output of SHA-384, in bytes.
-pub const SHA384_OUTPUT_LEN: usize = 384 / 8;
+pub const SHA384_OUTPUT_LEN: usize = OutputLen::_384.into();
 
 /// The length of the output of SHA-512, in bytes.
-pub const SHA512_OUTPUT_LEN: usize = 512 / 8;
+pub const SHA512_OUTPUT_LEN: usize = OutputLen::_512.into();
 
 /// The length of the output of SHA-512/256, in bytes.
-pub const SHA512_256_OUTPUT_LEN: usize = 256 / 8;
+pub const SHA512_256_OUTPUT_LEN: usize = OutputLen::_256.into();
 
 /// The length of the length field for SHA-512-based algorithms, in bytes.
 const SHA512_LEN_LEN: usize = 128 / 8;
+
+#[derive(Clone, Copy)]
+enum OutputLen {
+    _160 = 160 / 8,
+    _256 = 256 / 8,
+    _384 = 384 / 8,
+    _512 = 512 / 8, // MAX
+}
+
+impl OutputLen {
+    const MAX: Self = Self::_512;
+
+    #[inline(always)]
+    const fn into(self) -> usize {
+        self as usize
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -15,12 +15,12 @@
 
 use super::{
     sha2::{ch, maj, State32, Word},
-    OutputLen,
+    BlockLen, OutputLen,
 };
 use crate::polyfill::slice;
 use core::num::Wrapping;
 
-pub const BLOCK_LEN: usize = 512 / 8;
+pub(super) const BLOCK_LEN: BlockLen = BlockLen::_512;
 pub const CHAINING_LEN: usize = 160 / 8;
 pub(super) const OUTPUT_LEN: OutputLen = OutputLen::_160;
 const CHAINING_WORDS: usize = CHAINING_LEN / 4;
@@ -36,7 +36,7 @@ fn parity(x: W32, y: W32, z: W32) -> W32 {
 type State = [W32; CHAINING_WORDS];
 const ROUNDS: usize = 80;
 
-pub(super) fn sha1_block_data_order(state: &mut State32, data: &[[u8; BLOCK_LEN]]) {
+pub fn sha1_block_data_order(state: &mut State32, data: &[[u8; BLOCK_LEN.into()]]) {
     // The unwrap won't fail because `CHAINING_WORDS` is smaller than the
     // length.
     let state: &mut State = (&mut state[..CHAINING_WORDS]).try_into().unwrap();
@@ -49,7 +49,7 @@ pub(super) fn sha1_block_data_order(state: &mut State32, data: &[[u8; BLOCK_LEN]
 #[rustfmt::skip]
 fn block_data_order(
     mut H: [W32; CHAINING_WORDS],
-    M: &[[u8; BLOCK_LEN]],
+    M: &[[u8; BLOCK_LEN.into()]],
 ) -> [W32; CHAINING_WORDS]
 {
     for M in M {

--- a/src/digest/sha1.rs
+++ b/src/digest/sha1.rs
@@ -13,13 +13,16 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::sha2::{ch, maj, State32, Word};
+use super::{
+    sha2::{ch, maj, State32, Word},
+    OutputLen,
+};
 use crate::polyfill::slice;
 use core::num::Wrapping;
 
 pub const BLOCK_LEN: usize = 512 / 8;
 pub const CHAINING_LEN: usize = 160 / 8;
-pub const OUTPUT_LEN: usize = 160 / 8;
+pub(super) const OUTPUT_LEN: OutputLen = OutputLen::_160;
 const CHAINING_WORDS: usize = CHAINING_LEN / 4;
 
 type W32 = Wrapping<u32>;

--- a/src/digest/sha2.rs
+++ b/src/digest/sha2.rs
@@ -12,6 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use super::BlockLen;
 use crate::{cpu, polyfill::slice};
 use cfg_if::cfg_if;
 use core::{
@@ -24,7 +25,7 @@ pub(super) type State64 = [Wrapping<u64>; CHAINING_WORDS];
 
 pub(super) fn block_data_order_32(
     state: &mut State32,
-    data: &[[u8; SHA256_BLOCK_LEN]],
+    data: &[[u8; SHA256_BLOCK_LEN.into()]],
     cpu_features: cpu::Features,
 ) {
     cfg_if! {
@@ -46,7 +47,7 @@ pub(super) fn block_data_order_32(
 
 pub(super) fn block_data_order_64(
     state: &mut State64,
-    data: &[[u8; SHA512_BLOCK_LEN]],
+    data: &[[u8; SHA512_BLOCK_LEN.into()]],
     cpu_features: cpu::Features,
 ) {
     cfg_if! {
@@ -200,8 +201,8 @@ trait Sha2: Word + BitXor<Output = Self> + Shr<usize, Output = Self> {
 
 const MAX_ROUNDS: usize = 80;
 pub(super) const CHAINING_WORDS: usize = 8;
-pub(super) const SHA256_BLOCK_LEN: usize = 512 / 8;
-pub(super) const SHA512_BLOCK_LEN: usize = 1024 / 8;
+pub(super) const SHA256_BLOCK_LEN: BlockLen = BlockLen::_512;
+pub(super) const SHA512_BLOCK_LEN: BlockLen = BlockLen::_1024;
 
 impl Word for Wrapping<u32> {
     const ZERO: Self = Self(0);
@@ -407,12 +408,12 @@ impl Sha2 for Wrapping<u64> {
 prefixed_extern! {
     fn sha256_block_data_order(
         state: &mut [Wrapping<u32>; CHAINING_WORDS],
-        data: *const [u8; SHA256_BLOCK_LEN],
+        data: *const [u8; SHA256_BLOCK_LEN.into()],
         num: crate::c::NonZero_size_t,
     );
     fn sha512_block_data_order(
         state: &mut [Wrapping<u64>; CHAINING_WORDS],
-        data: *const [u8; SHA512_BLOCK_LEN],
+        data: *const [u8; SHA512_BLOCK_LEN.into()],
         num: crate::c::NonZero_size_t,
     );
 }


### PR DESCRIPTION
Previously, the compiler would bounds-check the array slicing in `Digest::as_ref()`. It would also do (and still does, to a lesser extent) unnecessary bounds checks in `BlockContext::{update, finish}` and `Context::{update, finish}`. By using enums instead, the compiler is better able to understand the range (at least) of valid lengths, so it can optimize better. In particular, the compiler can elide some runtime bounds checks with these changes.