### PR TITLE
RSA/AEAD: Check for overflow during byte->bit length conversions.

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -33,7 +33,7 @@ pub(crate) trait FromUsizeBytes: Sized {
 impl FromUsizeBytes for BitLength<usize> {
     #[inline]
     fn from_usize_bytes(bytes: usize) -> Result<Self, error::Unspecified> {
-        let bits = bytes.checked_shl(3).ok_or(error::Unspecified)?;
+        let bits = bytes.checked_mul(8).ok_or(error::Unspecified)?;
         Ok(Self(bits))
     }
 }
@@ -42,7 +42,7 @@ impl FromUsizeBytes for BitLength<u64> {
     #[inline]
     fn from_usize_bytes(bytes: usize) -> Result<Self, error::Unspecified> {
         let bytes = polyfill::u64_from_usize(bytes);
-        let bits = bytes.checked_shl(3).ok_or(error::Unspecified)?;
+        let bits = bytes.checked_mul(8).ok_or(error::Unspecified)?;
         Ok(Self(bits))
     }
 }


### PR DESCRIPTION
`x.checked_shl(x)` does NOT check the result against overflow; it only checks that the shift count isn't larger than the bitlength. Use `x.checked_mul(8)` instead of `x.checked_shl(3)` to get the correct effect.

This doesn't seem to have any impact as the inputs are already constrained by additional checks by the users of `BitLength`.