### PR TITLE
AES internals: Clarify safety of `aes::Key::new()`.

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -47,19 +47,20 @@ pub struct Key {
 }
 
 fn init_128(key: &[u8], cpu_features: cpu::Features) -> Result<aead::KeyInner, error::Unspecified> {
-    init(key, aes::Variant::AES_128, cpu_features)
+    let key = key.try_into().map_err(|_| error::Unspecified)?;
+    init(aes::KeyBytes::AES_128(key), cpu_features)
 }
 
 fn init_256(key: &[u8], cpu_features: cpu::Features) -> Result<aead::KeyInner, error::Unspecified> {
-    init(key, aes::Variant::AES_256, cpu_features)
+    let key = key.try_into().map_err(|_| error::Unspecified)?;
+    init(aes::KeyBytes::AES_256(key), cpu_features)
 }
 
 fn init(
-    key: &[u8],
-    variant: aes::Variant,
+    key: aes::KeyBytes,
     cpu_features: cpu::Features,
 ) -> Result<aead::KeyInner, error::Unspecified> {
-    let aes_key = aes::Key::new(key, variant, cpu_features)?;
+    let aes_key = aes::Key::new(key, cpu_features)?;
     let gcm_key = gcm::Key::new(
         aes_key.encrypt_block(ZERO_BLOCK, cpu_features),
         cpu_features,

--- a/src/aead/quic.rs
+++ b/src/aead/quic.rs
@@ -144,12 +144,14 @@ pub static AES_256: Algorithm = Algorithm {
 };
 
 fn aes_init_128(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, error::Unspecified> {
-    let aes_key = aes::Key::new(key, aes::Variant::AES_128, cpu_features)?;
+    let key = key.try_into().map_err(|_| error::Unspecified)?;
+    let aes_key = aes::Key::new(aes::KeyBytes::AES_128(key), cpu_features)?;
     Ok(KeyInner::Aes(aes_key))
 }
 
 fn aes_init_256(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, error::Unspecified> {
-    let aes_key = aes::Key::new(key, aes::Variant::AES_256, cpu_features)?;
+    let key = key.try_into().map_err(|_| error::Unspecified)?;
+    let aes_key = aes::Key::new(aes::KeyBytes::AES_256(key), cpu_features)?;
     Ok(KeyInner::Aes(aes_key))
 }
 


### PR DESCRIPTION
Merge `bytes` and `variant` into a single parameter that statically guarantees consistency. Use `BitLength` for bit-length parameters in extern functions. Add SAFETY comments.