### PR TITLE
AES-GCM: Clarify GHASH assembly code slice types.

### DIFF
--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -145,21 +145,13 @@ impl Context {
         (&self.inner.Htable, &mut self.inner.Xi)
     }
 
-    pub fn update_blocks(&mut self, input: &[u8]) {
-        // Th assembly functions take the input length in bytes, not blocks.
-        let input_bytes = input.len();
+    pub fn update_blocks(&mut self, input: &[[u8; BLOCK_LEN]]) {
+        // The assembly functions take the input length in bytes, not blocks.
+        // This multiplication cannot overflow because the byte length of an
+        // object must fit within a `usize`.
+        let input_bytes = input.len() * BLOCK_LEN;
 
-        debug_assert_eq!(input_bytes % BLOCK_LEN, 0);
         debug_assert!(input_bytes > 0);
-
-        let input = input.as_ptr().cast::<[u8; BLOCK_LEN]>();
-        // SAFETY:
-        // - `[[u8; BLOCK_LEN]]` has the same bit validity as `[u8]`.
-        // - `[[u8; BLOCK_LEN]]` has the same alignment requirement as `[u8]`.
-        // - `input_bytes / BLOCK_LEN` ensures that the total length in bytes of
-        //   the new `[[u8; BLOCK_LEN]]` will not be longer than the original
-        //   `[u8]`.
-        let input = unsafe { core::slice::from_raw_parts(input, input_bytes / BLOCK_LEN) };
 
         let xi = &mut self.inner.Xi;
         let h_table = &self.inner.Htable;

--- a/src/polyfill/slice.rs
+++ b/src/polyfill/slice.rs
@@ -36,3 +36,33 @@ pub fn as_chunks<T, const N: usize>(slice: &[T]) -> (&[[T; N]], &[T]) {
     let chunked = unsafe { core::slice::from_raw_parts(multiple_of_n.as_ptr().cast(), len) };
     (chunked, remainder)
 }
+
+// TODO(MSRV feature(slice_as_chunks)): Use `slice::as_chunks` instead.
+// This is adapted from above implementation of `slice::as_chunks`, as the
+// libcore implementation uses other unstable APIs.
+pub fn as_chunks_mut<T, const N: usize>(slice: &mut [T]) -> (&mut [[T; N]], &mut [T]) {
+    assert!(N != 0, "chunk size must be non-zero");
+    let len = slice.len() / N;
+    let (multiple_of_n, remainder) = slice.split_at_mut(len * N);
+    // SAFETY: We already panicked for zero, and ensured by construction
+    // that the length of the subslice is a multiple of N.
+    // SAFETY: We cast a slice of `new_len * N` elements into
+    // a slice of `new_len` many `N` elements chunks.
+    let chunked =
+        unsafe { core::slice::from_raw_parts_mut(multiple_of_n.as_mut_ptr().cast(), len) };
+    (chunked, remainder)
+}
+
+// TODO(MSRV feature(slice_flatten)): Use `slice::flatten_mut` instead.
+// This is derived from the libcore implementation, using only stable APIs.
+pub fn flatten_mut<T, const N: usize>(slice: &mut [[T; N]]) -> &mut [T] {
+    let len = if core::mem::size_of::<T>() == 0 {
+        slice.len().checked_mul(N).expect("slice len overflow")
+    } else {
+        // SAFETY: `slice.len() * N` cannot overflow because `slice` is
+        // already in the address space.
+        slice.len() * N
+    };
+    // SAFETY: `[T]` is layout-identical to `[T; N]`
+    unsafe { core::slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), len) }
+}


### PR DESCRIPTION
Create polyfills for recently-added slice methods and use them to clarify the safety of `gcm::Context::update_blocks()`.