### PR TITLE
AES-GCM: Clarify GHASH assembly safety.

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{
     aead, constant_time, cpu, error,
-    polyfill::{sliceutil::overwrite_at_start, usize_from_u64_saturated},
+    polyfill::{slice, sliceutil::overwrite_at_start, usize_from_u64_saturated},
 };
 use core::ops::RangeFrom;
 
@@ -158,14 +158,10 @@ fn aes_gcm_seal(
         }
     };
 
-    let (whole, remainder) = {
-        let in_out_len = in_out.len();
-        let whole_len = in_out_len - (in_out_len % BLOCK_LEN);
-        in_out.split_at_mut(whole_len)
-    };
+    let (whole, remainder) = slice::as_chunks_mut(in_out);
 
-    for chunk in whole.chunks_mut(CHUNK_BLOCKS * BLOCK_LEN) {
-        aes_key.ctr32_encrypt_within(chunk, 0.., &mut ctr, cpu_features);
+    for chunk in whole.chunks_mut(CHUNK_BLOCKS) {
+        aes_key.ctr32_encrypt_within(slice::flatten_mut(chunk), 0.., &mut ctr, cpu_features);
         auth.update_blocks(chunk);
     }
 
@@ -291,11 +287,15 @@ fn aes_gcm_open(
             if whole_len - output < chunk_len {
                 chunk_len = whole_len - output;
             }
-            if chunk_len == 0 {
+
+            let ciphertext = &in_out[input..][..chunk_len];
+            let (ciphertext, leftover) = slice::as_chunks(ciphertext);
+            debug_assert_eq!(leftover.len(), 0);
+            if ciphertext.is_empty() {
                 break;
             }
+            auth.update_blocks(ciphertext);
 
-            auth.update_blocks(&in_out[input..][..chunk_len]);
             aes_key.ctr32_encrypt_within(
                 &mut in_out[output..][..(chunk_len + in_prefix_len)],
                 in_prefix_len..,

--- a/src/polyfill/slice.rs
+++ b/src/polyfill/slice.rs
@@ -36,3 +36,47 @@ pub fn as_chunks<T, const N: usize>(slice: &[T]) -> (&[[T; N]], &[T]) {
     let chunked = unsafe { core::slice::from_raw_parts(multiple_of_n.as_ptr().cast(), len) };
     (chunked, remainder)
 }
+
+// TODO(MSRV feature(slice_as_chunks)): Use `slice::as_chunks_mut` instead.
+// This is adapted from above implementation of `slice::as_chunks`, as the
+// libcore implementation uses other unstable APIs.
+pub fn as_chunks_mut<T, const N: usize>(slice: &mut [T]) -> (&mut [[T; N]], &mut [T]) {
+    assert!(N != 0, "chunk size must be non-zero");
+    let len = slice.len() / N;
+    let (multiple_of_n, remainder) = slice.split_at_mut(len * N);
+    // SAFETY: We already panicked for zero, and ensured by construction
+    // that the length of the subslice is a multiple of N.
+    // SAFETY: We cast a slice of `new_len * N` elements into
+    // a slice of `new_len` many `N` elements chunks.
+    let chunked =
+        unsafe { core::slice::from_raw_parts_mut(multiple_of_n.as_mut_ptr().cast(), len) };
+    (chunked, remainder)
+}
+
+// TODO(MSRV feature(slice_flatten)): Use `slice::flatten` instead.
+// This is derived from the libcore implementation, using only stable APIs.
+pub fn flatten<T, const N: usize>(slice: &[[T; N]]) -> &[T] {
+    let len = if core::mem::size_of::<T>() == 0 {
+        slice.len().checked_mul(N).expect("slice len overflow")
+    } else {
+        // SAFETY: `slice.len() * N` cannot overflow because `slice` is
+        // already in the address space.
+        slice.len() * N
+    };
+    // SAFETY: `[T]` is layout-identical to `[T; N]`
+    unsafe { core::slice::from_raw_parts(slice.as_ptr().cast(), len) }
+}
+
+// TODO(MSRV feature(slice_flatten)): Use `slice::flatten_mut` instead.
+// This is derived from the libcore implementation, using only stable APIs.
+pub fn flatten_mut<T, const N: usize>(slice: &mut [[T; N]]) -> &mut [T] {
+    let len = if core::mem::size_of::<T>() == 0 {
+        slice.len().checked_mul(N).expect("slice len overflow")
+    } else {
+        // SAFETY: `slice.len() * N` cannot overflow because `slice` is
+        // already in the address space.
+        slice.len() * N
+    };
+    // SAFETY: `[T]` is layout-identical to `[T; N]`
+    unsafe { core::slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), len) }
+}


### PR DESCRIPTION
Create polyfills for recently-added slice methods and use them to clarify the safety of `gcm::Context::update_blocks()`. Encapsulate the declarations in a macro and add SAFETY to document the interface.