### PR TITLE
aead internals: Eliminate dependency on `KeyInner` from implementations.

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -22,14 +22,12 @@
 //! [`crypto.cipher.AEAD`]: https://golang.org/pkg/crypto/cipher/#AEAD
 
 use crate::{
-    cpu, error, hkdf,
+    cpu, error,
     polyfill::{u64_from_usize, usize_from_u64_saturated},
 };
-use core::ops::RangeFrom;
 
 pub use self::{
-    aes_gcm::{AES_128_GCM, AES_256_GCM},
-    chacha20_poly1305::CHACHA20_POLY1305,
+    algorithm::{Algorithm, AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305},
     less_safe_key::LessSafeKey,
     nonce::{Nonce, NONCE_LEN},
     opening_key::OpeningKey,
@@ -126,37 +124,6 @@ enum KeyInner {
     ChaCha20Poly1305(chacha20_poly1305::Key),
 }
 
-impl hkdf::KeyType for &'static Algorithm {
-    #[inline]
-    fn len(&self) -> usize {
-        self.key_len()
-    }
-}
-
-/// An AEAD Algorithm.
-pub struct Algorithm {
-    init: fn(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, error::Unspecified>,
-
-    seal: fn(
-        key: &KeyInner,
-        nonce: Nonce,
-        aad: Aad<&[u8]>,
-        in_out: &mut [u8],
-        cpu_features: cpu::Features,
-    ) -> Result<Tag, error::Unspecified>,
-    open: fn(
-        key: &KeyInner,
-        nonce: Nonce,
-        aad: Aad<&[u8]>,
-        in_out: &mut [u8],
-        src: RangeFrom<usize>,
-        cpu_features: cpu::Features,
-    ) -> Result<Tag, error::Unspecified>,
-
-    key_len: usize,
-    id: AlgorithmID,
-}
-
 const fn max_input_len(block_len: usize, overhead_blocks_per_nonce: usize) -> usize {
     // Each of our AEADs use a 32-bit block counter so the maximum is the
     // largest input that will not overflow the counter.
@@ -164,45 +131,6 @@ const fn max_input_len(block_len: usize, overhead_blocks_per_nonce: usize) -> us
         ((1u64 << 32) - u64_from_usize(overhead_blocks_per_nonce)) * u64_from_usize(block_len),
     )
 }
-
-impl Algorithm {
-    /// The length of the key.
-    #[inline(always)]
-    pub fn key_len(&self) -> usize {
-        self.key_len
-    }
-
-    /// The length of a tag.
-    ///
-    /// See also `MAX_TAG_LEN`.
-    #[inline(always)]
-    pub fn tag_len(&self) -> usize {
-        TAG_LEN
-    }
-
-    /// The length of the nonces.
-    #[inline(always)]
-    pub fn nonce_len(&self) -> usize {
-        NONCE_LEN
-    }
-}
-
-derive_debug_via_id!(Algorithm);
-
-#[derive(Debug, Eq, PartialEq)]
-enum AlgorithmID {
-    AES_128_GCM,
-    AES_256_GCM,
-    CHACHA20_POLY1305,
-}
-
-impl PartialEq for Algorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl Eq for Algorithm {}
 
 /// A possibly valid authentication tag.
 #[must_use]
@@ -242,6 +170,7 @@ pub const MAX_TAG_LEN: usize = TAG_LEN;
 
 mod aes;
 mod aes_gcm;
+mod algorithm;
 mod chacha;
 mod chacha20_poly1305;
 pub mod chacha20_poly1305_openssh;

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -381,9 +381,12 @@ pub(super) struct AES_KEY {
 // Keep this in sync with `AES_MAXNR` in aes.h.
 const MAX_ROUNDS: usize = 14;
 
+pub const AES_128_KEY_LEN: usize = 128 / 8;
+pub const AES_256_KEY_LEN: usize = 256 / 8;
+
 pub enum KeyBytes<'a> {
-    AES_128(&'a [u8; 128 / 8]),
-    AES_256(&'a [u8; 256 / 8]),
+    AES_128(&'a [u8; AES_128_KEY_LEN]),
+    AES_256(&'a [u8; AES_256_KEY_LEN]),
 }
 
 /// nonce || big-endian counter.

--- a/src/aead/algorithm.rs
+++ b/src/aead/algorithm.rs
@@ -1,0 +1,263 @@
+// Copyright 2015-2021 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use crate::{constant_time, cpu, error, hkdf};
+use core::ops::RangeFrom;
+
+use super::{
+    aes, aes_gcm, chacha20_poly1305,
+    nonce::{Nonce, NONCE_LEN},
+    Aad, KeyInner, Tag, TAG_LEN,
+};
+
+impl hkdf::KeyType for &'static Algorithm {
+    #[inline]
+    fn len(&self) -> usize {
+        self.key_len()
+    }
+}
+
+/// An AEAD Algorithm.
+pub struct Algorithm {
+    init: fn(key: &[u8], cpu_features: cpu::Features) -> Result<KeyInner, error::Unspecified>,
+
+    seal: fn(
+        key: &KeyInner,
+        nonce: Nonce,
+        aad: Aad<&[u8]>,
+        in_out: &mut [u8],
+        cpu_features: cpu::Features,
+    ) -> Result<Tag, error::Unspecified>,
+    open: fn(
+        key: &KeyInner,
+        nonce: Nonce,
+        aad: Aad<&[u8]>,
+        in_out: &mut [u8],
+        src: RangeFrom<usize>,
+        cpu_features: cpu::Features,
+    ) -> Result<Tag, error::Unspecified>,
+
+    key_len: usize,
+    id: AlgorithmID,
+}
+
+impl Algorithm {
+    /// The length of the key.
+    #[inline(always)]
+    pub fn key_len(&self) -> usize {
+        self.key_len
+    }
+
+    /// The length of a tag.
+    ///
+    /// See also `MAX_TAG_LEN`.
+    #[inline(always)]
+    pub fn tag_len(&self) -> usize {
+        TAG_LEN
+    }
+
+    /// The length of the nonces.
+    #[inline(always)]
+    pub fn nonce_len(&self) -> usize {
+        NONCE_LEN
+    }
+
+    pub(super) fn new_key(
+        &self,
+        key_bytes: &[u8],
+        cpu_features: cpu::Features,
+    ) -> Result<KeyInner, error::Unspecified> {
+        (self.init)(key_bytes, cpu_features)
+    }
+
+    pub(super) fn open_within<'io>(
+        &self,
+        key: &KeyInner,
+        nonce: Nonce,
+        aad: Aad<&[u8]>,
+        received_tag: Tag,
+        in_out: &'io mut [u8],
+        src: RangeFrom<usize>,
+        cpu_features: cpu::Features,
+    ) -> Result<&'io mut [u8], error::Unspecified> {
+        let ciphertext_len = in_out.get(src.clone()).ok_or(error::Unspecified)?.len();
+
+        let Tag(calculated_tag) = (self.open)(key, nonce, aad, in_out, src, cpu_features)?;
+
+        if constant_time::verify_slices_are_equal(calculated_tag.as_ref(), received_tag.as_ref())
+            .is_err()
+        {
+            // Zero out the plaintext so that it isn't accidentally leaked or used
+            // after verification fails. It would be safest if we could check the
+            // tag before decrypting, but some `open` implementations interleave
+            // authentication with decryption for performance.
+            for b in &mut in_out[..ciphertext_len] {
+                *b = 0;
+            }
+            return Err(error::Unspecified);
+        }
+
+        // `ciphertext_len` is also the plaintext length.
+        Ok(&mut in_out[..ciphertext_len])
+    }
+
+    #[inline]
+    pub(super) fn seal(
+        &self,
+        key: &KeyInner,
+        nonce: Nonce,
+        aad: Aad<&[u8]>,
+        in_out: &mut [u8],
+        cpu_features: cpu::Features,
+    ) -> Result<Tag, error::Unspecified> {
+        (self.seal)(key, nonce, aad, in_out, cpu_features)
+    }
+}
+
+derive_debug_via_id!(Algorithm);
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum AlgorithmID {
+    AES_128_GCM,
+    AES_256_GCM,
+    CHACHA20_POLY1305,
+}
+
+impl PartialEq for Algorithm {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for Algorithm {}
+
+/// AES-128 in GCM mode with 128-bit tags and 96 bit nonces.
+pub static AES_128_GCM: Algorithm = Algorithm {
+    key_len: aes::AES_128_KEY_LEN,
+    init: aes_gcm_init_128,
+    seal: aes_gcm_seal,
+    open: aes_gcm_open,
+    id: AlgorithmID::AES_128_GCM,
+};
+
+/// AES-256 in GCM mode with 128-bit tags and 96 bit nonces.
+pub static AES_256_GCM: Algorithm = Algorithm {
+    key_len: aes::AES_256_KEY_LEN,
+    init: aes_gcm_init_256,
+    seal: aes_gcm_seal,
+    open: aes_gcm_open,
+    id: AlgorithmID::AES_256_GCM,
+};
+
+fn aes_gcm_init_128(
+    key: &[u8],
+    cpu_features: cpu::Features,
+) -> Result<KeyInner, error::Unspecified> {
+    let key = key.try_into().map_err(|_| error::Unspecified)?;
+    Ok(KeyInner::AesGcm(aes_gcm::Key::new(
+        aes::KeyBytes::AES_128(key),
+        cpu_features,
+    )?))
+}
+
+fn aes_gcm_init_256(
+    key: &[u8],
+    cpu_features: cpu::Features,
+) -> Result<KeyInner, error::Unspecified> {
+    let key = key.try_into().map_err(|_| error::Unspecified)?;
+    Ok(KeyInner::AesGcm(aes_gcm::Key::new(
+        aes::KeyBytes::AES_256(key),
+        cpu_features,
+    )?))
+}
+
+fn aes_gcm_seal(
+    key: &KeyInner,
+    nonce: Nonce,
+    aad: Aad<&[u8]>,
+    in_out: &mut [u8],
+    cpu_features: cpu::Features,
+) -> Result<Tag, error::Unspecified> {
+    let key = match key {
+        KeyInner::AesGcm(key) => key,
+        _ => unreachable!(),
+    };
+    aes_gcm::seal(key, nonce, aad, in_out, cpu_features)
+}
+
+pub(super) fn aes_gcm_open(
+    key: &KeyInner,
+    nonce: Nonce,
+    aad: Aad<&[u8]>,
+    in_out: &mut [u8],
+    src: RangeFrom<usize>,
+    cpu_features: cpu::Features,
+) -> Result<Tag, error::Unspecified> {
+    let key = match key {
+        KeyInner::AesGcm(key) => key,
+        _ => unreachable!(),
+    };
+    aes_gcm::open(key, nonce, aad, in_out, src, cpu_features)
+}
+
+/// ChaCha20-Poly1305 as described in [RFC 8439].
+///
+/// The keys are 256 bits long and the nonces are 96 bits long.
+///
+/// [RFC 8439]: https://tools.ietf.org/html/rfc8439
+pub static CHACHA20_POLY1305: Algorithm = Algorithm {
+    key_len: chacha20_poly1305::KEY_LEN,
+    init: chacha20_poly1305_init,
+    seal: chacha20_poly1305_seal,
+    open: chacha20_poly1305_open,
+    id: AlgorithmID::CHACHA20_POLY1305,
+};
+
+/// Copies |key| into |ctx_buf|.
+fn chacha20_poly1305_init(
+    key: &[u8],
+    _cpu_features: cpu::Features,
+) -> Result<KeyInner, error::Unspecified> {
+    let key: [u8; chacha20_poly1305::KEY_LEN] = key.try_into()?;
+    Ok(KeyInner::ChaCha20Poly1305(chacha20_poly1305::Key::new(key)))
+}
+
+fn chacha20_poly1305_seal(
+    key: &KeyInner,
+    nonce: Nonce,
+    aad: Aad<&[u8]>,
+    in_out: &mut [u8],
+    cpu_features: cpu::Features,
+) -> Result<Tag, error::Unspecified> {
+    let key = match key {
+        KeyInner::ChaCha20Poly1305(key) => key,
+        _ => unreachable!(),
+    };
+    chacha20_poly1305::seal(key, nonce, aad, in_out, cpu_features)
+}
+
+fn chacha20_poly1305_open(
+    key: &KeyInner,
+    nonce: Nonce,
+    aad: Aad<&[u8]>,
+    in_out: &mut [u8],
+    src: RangeFrom<usize>,
+    cpu_features: cpu::Features,
+) -> Result<Tag, error::Unspecified> {
+    let key = match key {
+        KeyInner::ChaCha20Poly1305(key) => key,
+        _ => unreachable!(),
+    };
+    chacha20_poly1305::open(key, nonce, aad, in_out, src, cpu_features)
+}

--- a/src/aead/less_safe_key.rs
+++ b/src/aead/less_safe_key.rs
@@ -13,7 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{Aad, Algorithm, KeyInner, Nonce, Tag, UnboundKey, TAG_LEN};
-use crate::{constant_time, cpu, error};
+use crate::{cpu, error};
 use core::ops::RangeFrom;
 
 /// Immutable keys for use in situations where `OpeningKey`/`SealingKey` and
@@ -36,10 +36,10 @@ impl LessSafeKey {
     pub(super) fn new_(
         algorithm: &'static Algorithm,
         key_bytes: &[u8],
+        cpu_features: cpu::Features,
     ) -> Result<Self, error::Unspecified> {
-        let cpu_features = cpu::features();
         Ok(Self {
-            inner: (algorithm.init)(key_bytes, cpu_features)?,
+            inner: algorithm.new_key(key_bytes, cpu_features)?,
             algorithm,
         })
     }
@@ -59,7 +59,15 @@ impl LessSafeKey {
         A: AsRef<[u8]>,
     {
         let aad = Aad::from(aad.as_ref());
-        open_within_(self, nonce, aad, tag, in_out, ciphertext)
+        self.algorithm.open_within(
+            &self.inner,
+            nonce,
+            aad,
+            tag,
+            in_out,
+            ciphertext,
+            cpu::features(),
+        )
     }
 
     /// Like [`super::OpeningKey::open_in_place()`], except it accepts an
@@ -140,7 +148,13 @@ impl LessSafeKey {
     where
         A: AsRef<[u8]>,
     {
-        seal_in_place_separate_tag_(self, nonce, Aad::from(aad.as_ref()), in_out)
+        self.algorithm.seal(
+            &self.inner,
+            nonce,
+            Aad::from(aad.as_ref()),
+            in_out,
+            cpu::features(),
+        )
     }
 
     /// The key's AEAD algorithm.
@@ -158,46 +172,6 @@ impl LessSafeKey {
             .field("algorithm", &self.algorithm())
             .finish()
     }
-}
-
-fn open_within_<'in_out>(
-    key: &LessSafeKey,
-    nonce: Nonce,
-    aad: Aad<&[u8]>,
-    received_tag: Tag,
-    in_out: &'in_out mut [u8],
-    src: RangeFrom<usize>,
-) -> Result<&'in_out mut [u8], error::Unspecified> {
-    let ciphertext_len = in_out.get(src.clone()).ok_or(error::Unspecified)?.len();
-
-    let Tag(calculated_tag) =
-        (key.algorithm.open)(&key.inner, nonce, aad, in_out, src, cpu::features())?;
-
-    if constant_time::verify_slices_are_equal(calculated_tag.as_ref(), received_tag.as_ref())
-        .is_err()
-    {
-        // Zero out the plaintext so that it isn't accidentally leaked or used
-        // after verification fails. It would be safest if we could check the
-        // tag before decrypting, but some `open` implementations interleave
-        // authentication with decryption for performance.
-        for b in &mut in_out[..ciphertext_len] {
-            *b = 0;
-        }
-        return Err(error::Unspecified);
-    }
-
-    // `ciphertext_len` is also the plaintext length.
-    Ok(&mut in_out[..ciphertext_len])
-}
-
-#[inline]
-pub(super) fn seal_in_place_separate_tag_(
-    key: &LessSafeKey,
-    nonce: Nonce,
-    aad: Aad<&[u8]>,
-    in_out: &mut [u8],
-) -> Result<Tag, error::Unspecified> {
-    (key.algorithm.seal)(&key.inner, nonce, aad, in_out, cpu::features())
 }
 
 impl core::fmt::Debug for LessSafeKey {


### PR DESCRIPTION
Remove all uses of `KeyInner` and `Algorithm` from the AES-GCM and ChaCha20-Poly1305 implementation submodules, so that both modules become fully statically typed. Encapsulate access to the "methods" of `Algorithm` by moving `Algorithm` and the "implementations" of `Algorithm` to a new submodule that does all the dynamic dispatching.