### PR TITLE
Update MSRV to 1.63.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         rust_channel:
           - stable
           # Keep in sync with Cargo.toml and similar `rust_channel` sections.
-          - 1.61.0 # MSRV
+          - 1.63.0 # MSRV
           # TODO: Move these to a daily/pre-release job.
           # - nightly
           # - beta
@@ -305,11 +305,11 @@ jobs:
       # Check that all the needed symbol renaming was done.
       # TODO: Do this check on Windows too.
 
-      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.61.0') &&
+      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.63.0') &&
                 !contains(matrix.host_os, 'windows') }}
         run: rustup toolchain install --component=llvm-tools-preview ${{ matrix.rust_channel }}
 
-      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.61.0') &&
+      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.63.0') &&
                 !contains(matrix.host_os, 'windows') }}
         run: mk/check-symbol-prefixes.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
 
@@ -387,7 +387,7 @@ jobs:
           - stable
           - nightly
           # Keep in sync with Cargo.toml and similar `rust_channel` sections.
-          - 1.61.0 # MSRV
+          - 1.63.0 # MSRV
 
         include:
           - target: aarch64-unknown-linux-musl
@@ -435,11 +435,11 @@ jobs:
       # Check that all the needed symbol renaming was done.
       # TODO: Do this check on Windows too.
 
-      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.61.0') &&
+      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.63.0') &&
           !contains(matrix.host_os, 'windows') }}
         run: rustup toolchain install --component=llvm-tools-preview ${{ matrix.rust_channel }}
 
-      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.61.0') &&
+      - if: ${{ (matrix.target != 'aarch64-apple-ios' || matrix.rust_channel != '1.63.0') &&
           !contains(matrix.host_os, 'windows') }}
         run: mk/check-symbol-prefixes.sh +${{ matrix.rust_channel }} --target=${{ matrix.target }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/briansmith/ring"
 
 # Keep in sync with .github/workflows/ci.yml ("MSRV") and see the MSRV note
 # in cpu/arm.rs
-rust-version = "1.61.0"
+rust-version = "1.63.0"
 
 # Keep in sync with `links` below.
 version = "0.17.8"

--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,7 @@
 
 use std::process::Stdio;
 use std::{
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     fs::{self, DirEntry},
     io::Write,
     path::{Path, PathBuf},
@@ -721,15 +721,7 @@ fn perlasm(
 
 fn join_components_with_forward_slashes(path: &Path) -> OsString {
     let parts = path.components().map(|c| c.as_os_str()).collect::<Vec<_>>();
-    // Manually implement join here because [OsStr]::join only stabilised in 1.63.0 and ring uses 1.61.0 as MSRV.
-    let mut out = OsString::new();
-    for (i, part) in parts.iter().enumerate() {
-        if i != 0 {
-            out.push("/");
-        }
-        out.push(part)
-    }
-    out
+    parts.join(OsStr::new("/"))
 }
 
 fn get_perl_exe() -> PathBuf {


### PR DESCRIPTION
cc-rs 1.0.x increased its MSRV to 1.63.0, so do likewise, as the extra effort (mainly in ci.yml) to keep supporting 1.61.0 by using an older version of cc-rs isn't justified.