### PR TITLE
Enable js feature automatically on WASM platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,9 @@ cfg-if = { version = "1.0.0", default-features = false }
 getrandom = { version = "0.2.10" }
 untrusted = { version = "0.9" }
 
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2.10", features = ["js"] }
+
 [target.'cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86",target_arch = "x86_64"))'.dependencies]
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
 


### PR DESCRIPTION
As of today ring support the web platform by allowing users to enable the `wasm32_unknown_unknown_js` feature. The issue is that it might be difficult for users when `ring` is used by a dependency (ex: by rustls). The dependency you add to your project might not have included any way of a enabling ring's feature. As of today, you would have to fork rustls to enable the feature on ring.

The good thing is that all this feature does is enabling the `js` feature on `getrandom`. This can be done without a feature on `ring` ! Note that there is no scenario when you wouldn't want `getrandom/js` enabled when building on `wasm32-unknown-unknown`, because any build of `getrandom` without its `js` feature on `wasm32-unknown-unknown` will fail anyway.