### PR TITLE
Add support for arch csky

### DIFF
--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -47,7 +47,7 @@
 #elif defined(__ILP32__)
 #define OPENSSL_32_BIT
 // Versions of GCC before 10.0 didn't define `__ILP32__` for all 32-bit targets.
-#elif defined(__MIPSEL__) || defined(__MIPSEB__) || defined(__PPC__) || defined(__powerpc__)
+#elif defined(__MIPSEL__) || defined(__MIPSEB__) || defined(__PPC__) || defined(__powerpc__) || defined(__csky__)
 #define OPENSSL_32_BIT
 #else
 #error "Unknown target CPU"


### PR DESCRIPTION
Add support for arch csky.
 Ref: https://github.com/rust-lang/rust/blob/master/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md