### PR TITLE
AES-GCM ARM: Don't use hardware AES/GCM on 32-bit ARM.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -92,9 +92,6 @@ const RING_SRCS: &[(&[&str], &str)] = &[
 
     (&[AARCH64, X86_64], "crypto/fipsmodule/ec/p256-nistz.c"),
 
-    (&[AARCH64, ARM], "crypto/fipsmodule/aes/asm/aesv8-armx.pl"),
-    (&[AARCH64, ARM], "crypto/fipsmodule/modes/asm/ghashv8-armx.pl"),
-
     (&[ARM], "crypto/fipsmodule/aes/asm/bsaes-armv7.pl"),
     (&[ARM], "crypto/fipsmodule/aes/asm/vpaes-armv7.pl"),
     (&[ARM], "crypto/fipsmodule/bn/asm/armv4-mont.pl"),
@@ -108,11 +105,13 @@ const RING_SRCS: &[(&[&str], &str)] = &[
 
     (&[AARCH64], "crypto/chacha/asm/chacha-armv8.pl"),
     (&[AARCH64], "crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl"),
+    (&[AARCH64], "crypto/fipsmodule/aes/asm/aesv8-armx.pl"),
     (&[AARCH64], "crypto/fipsmodule/aes/asm/vpaes-armv8.pl"),
     (&[AARCH64], "crypto/fipsmodule/bn/asm/armv8-mont.pl"),
     (&[AARCH64], "crypto/fipsmodule/ec/asm/p256-armv8-asm.pl"),
-    (&[AARCH64], "crypto/fipsmodule/modes/asm/ghash-neon-armv8.pl"),
     (&[AARCH64], "crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl"),
+    (&[AARCH64], "crypto/fipsmodule/modes/asm/ghash-neon-armv8.pl"),
+    (&[AARCH64], "crypto/fipsmodule/modes/asm/ghashv8-armx.pl"),
     (&[AARCH64], SHA512_ARMV8),
 ];
 

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -176,12 +176,7 @@ impl Key {
         };
 
         match detect_implementation(cpu_features) {
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "arm",
-                target_arch = "x86_64",
-                target_arch = "x86"
-            ))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
             // SAFETY: `aes_hw_set_encrypt_key` satisfies the `set_encrypt_key!`
             // contract for these target architectures.
             Implementation::HWAES => unsafe {
@@ -213,12 +208,7 @@ impl Key {
     #[inline]
     pub fn encrypt_block(&self, a: Block, cpu_features: cpu::Features) -> Block {
         match detect_implementation(cpu_features) {
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "arm",
-                target_arch = "x86_64",
-                target_arch = "x86"
-            ))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
             Implementation::HWAES => encrypt_block!(aes_hw_encrypt, a, self),
 
             #[cfg(any(
@@ -248,12 +238,7 @@ impl Key {
         cpu_features: cpu::Features,
     ) {
         match detect_implementation(cpu_features) {
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "arm",
-                target_arch = "x86_64",
-                target_arch = "x86"
-            ))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
             // SAFETY:
             //  * self.inner was initialized with `aes_hw_set_encrypt_key` above,
             //    as required by `aes_hw_ctr32_encrypt_blocks`.
@@ -439,12 +424,7 @@ pub(super) const ZERO_BLOCK: Block = [0u8; BLOCK_LEN];
 #[derive(Clone, Copy)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Implementation {
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
-        target_arch = "x86_64",
-        target_arch = "x86"
-    ))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
     HWAES,
 
     // On "arm" only, this indicates that the bsaes implementation may be used.
@@ -469,7 +449,7 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
     )))]
     let _cpu_features = cpu_features;
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    #[cfg(target_arch = "aarch64")]
     {
         if cpu::arm::AES.available(cpu_features) {
             return Implementation::HWAES;

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -53,12 +53,7 @@ impl Key {
                 }
             }
 
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "arm",
-                target_arch = "x86_64",
-                target_arch = "x86"
-            ))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
             Implementation::CLMUL => {
                 prefixed_extern! {
                     fn gcm_init_clmul(Htable: &mut HTable, h: &[u64; 2]);
@@ -222,12 +217,7 @@ impl<'key> Context<'key> {
                 ghash!(gcm_ghash_avx, xi, h_table, input, self.cpu_features);
             },
 
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "arm",
-                target_arch = "x86_64",
-                target_arch = "x86"
-            ))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
             // SAFETY: gcm_ghash_clmul satisfies the ghash! contract on these
             // targets.
             Implementation::CLMUL => unsafe {
@@ -254,12 +244,7 @@ impl<'key> Context<'key> {
         let h_table = &self.h_table;
 
         match detect_implementation(self.cpu_features) {
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "arm",
-                target_arch = "x86_64",
-                target_arch = "x86"
-            ))]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
             Implementation::CLMUL => {
                 prefixed_extern! {
                     fn gcm_gmult_clmul(xi: &mut Xi, Htable: &HTable);
@@ -343,12 +328,7 @@ impl BitXorAssign<Block> for Xi {
 
 #[allow(clippy::upper_case_acronyms)]
 enum Implementation {
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
-        target_arch = "x86_64",
-        target_arch = "x86"
-    ))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
     CLMUL,
 
     #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
@@ -368,7 +348,7 @@ fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
     )))]
     let _cpu_features = cpu_features;
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    #[cfg(target_arch = "aarch64")]
     {
         if cpu::arm::PMULL.available(cpu_features) {
             return Implementation::CLMUL;


### PR DESCRIPTION
It used to be somewhat common to run 32-bit ARM apps on Aarch64 CPUs, especially for Android, but nowadays that is not the case. Thus the hardware implementations are pretty much dead code. Having them enabled also complicated the testing situation.