### PR TITLE
cpu arm/aarch64: Make unstable-testing-arm-no-hw filter SHA512 too.

### DIFF
--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -270,7 +270,6 @@ macro_rules! features {
             !0
         };
 
-        #[cfg(test)]
         const ALL_FEATURES: [Feature; 5] = [
             $(
                 $name
@@ -337,7 +336,10 @@ features! {
 pub unsafe fn init_global_shared_with_assembly() {
     let detected = detect_features();
     let filtered = (if cfg!(feature = "unstable-testing-arm-no-hw") {
-        AES.mask | SHA256.mask | PMULL.mask
+        ALL_FEATURES
+            .iter()
+            .fold(0, |acc, feature| acc | feature.mask)
+            & !NEON.mask
     } else {
         0
     }) | (if cfg!(feature = "unstable-testing-arm-no-neon") {


### PR DESCRIPTION
unstable-testing-arm-no-hw is intended to disable all feature detection except for NEON. Have the code do exactly that. This way, SHA512 is also handled appropriately, where it wasn't before.