### PR TITLE
Add "unknown" to LINUX_ABI

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -248,6 +248,7 @@ const LINUX_ABI: &[&str] = &[
     "linux",
     "redox",
     "solaris",
+    "unknown",
 ];
 
 const WIN32N: &str = "win32n";


### PR DESCRIPTION
This PR adds `unknown` to the LINUX_ABI array in build.rs. This is specifically to support `--target=x86_64-fortanix-unknown-sgx`, this target currently fails to link altogether because of the missing object files. With `unknown` added, everything works as expected.
