### PR TITLE
CI: Add coverage measurement for armv7-unknown-linux-gnueabihf.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,9 +526,9 @@ jobs:
         target:
           - aarch64-apple-darwin           # Has assembly
           - aarch64-unknown-linux-gnu      # Has assembly
+          - armv7-unknown-linux-gnueabihf  # Has assembly
           - i686-unknown-linux-gnu         # Has assembly
           # TODO: arm-unknown-linux-gnueabi # Has assembly but doesn't build w/ clang
-          # TODO: armv7-unknown-linux-gnueabihf # Has assembly but doesn't have profiler builtins
           - powerpc-unknown-linux-gnu      # No assembly 32-bit big-endian with flags
           - powerpc64-unknown-linux-gnu    # No assembly 64-bit big-endian with flags
           - powerpc64le-unknown-linux-gnu  # No assembly 64-bit little-endian with flags
@@ -561,8 +561,11 @@ jobs:
             rust_channel: nightly
             host_os: ubuntu-22.04
 
+          - target: armv7-unknown-linux-gnueabihf
+            host_os: ubuntu-22.04
+
           - features: --features=unstable-testing-arm-no-neon,std
-            target: aarch64-unknown-linux-gnu
+            target: armv7-unknown-linux-gnueabihf
             mode: # debug
             rust_channel: nightly
             host_os: ubuntu-22.04


### PR DESCRIPTION
Add coverage testing for armv7-unknown-linux-gnueabihf. Move the "no neon" configuration from aarch64- to armv7- since we don't support aarch64-*-linux-* without NEON.