### PR TITLE
Fix filename in crypto/fipsmodule/ec/.gitattributes.

### DIFF
--- a/crypto/fipsmodule/ec/.gitattributes
+++ b/crypto/fipsmodule/ec/.gitattributes
@@ -1,2 +1,2 @@
-p256-x86_64-table.h linguist-generated=true
+p256-nistz-table.h linguist-generated=true
 p256_table.h linguist-generated=true


### PR DESCRIPTION
`.gitattributes` wasn't updated when the file was renamed.