### PR TITLE
Introduce SPARC64 support

### DIFF
--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -60,6 +60,8 @@
 #define OPENSSL_32_BIT
 #elif defined(__s390x__)
 #define OPENSSL_64_BIT
+#elif defined(__sparc_v9__) && defined(__LP64__)
+#define OPENSSL_64_BIT
 #else
 #error "Unknown target CPU"
 #endif

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -30,6 +30,7 @@ qemu_powerpc64="qemu-ppc64 -L /usr/powerpc64-linux-gnu"
 qemu_powerpc64le="qemu-ppc64le -L /usr/powerpc64le-linux-gnu"
 qemu_riscv64="qemu-riscv64 -L /usr/riscv64-linux-gnu"
 qemu_s390x="qemu-s390x -L /usr/s390x-linux-gnu"
+qemu_sparc64="qemu-sparc64 -L /usr/sparc64-linux-gnu"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may
@@ -169,6 +170,11 @@ case $target in
     export CFLAGS_s390x_unknown_linux_gnu="--sysroot=/usr/s390x-linux-gnu -march=zEC12"
     export CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc
     export CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="$qemu_s390x"
+    ;;
+  sparc64-unknown-linux-gnu)
+    export CFLAGS_sparc64_unknown_linux_gnu="--sysroot=/usr/sparc64-linux-gnu"
+    export CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER=sparc64-linux-gnu-gcc
+    export CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="$qemu_sparc64"
     ;;
   x86_64-unknown-linux-musl)
     use_clang=1

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -165,6 +165,12 @@ s390x-unknown-linux-gnu)
     gcc-s390x-linux-gnu \
     libc6-dev-s390x-cross
   ;;
+sparc64-unknown-linux-gnu)
+  install_packages \
+    qemu-user \
+    gcc-sparc64-linux-gnu \
+    libc6-dev-sparc64-cross
+  ;;
 wasm32-unknown-unknown)
   cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner
   use_clang=1


### PR DESCRIPTION
Adds the minimum information to build on sparc64 / sparcv9. Tests pass 100%.

Finally a sore in my conscience gone. Much thanks to the devs from Gentoo and Debian who work very hard to keep these machines in the shape they're in.

For end users: remember to `CFLAGS="-mcpu=ultrasparc" CXXFLAGS="-mcpu=ultrasparc" RUSTFLAGS="-C target-cpu=ultrasparc"`. If you want to build for a higher target, the C/CXX target can be found in `man gcc`, where for rust you can find it with `rustc --print target-cpus`.

Closes: #1512