### PR TITLE
Add support for 64-bit big-endian MIPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,11 @@ jobs:
           - target: i686-unknown-linux-musl
             host_os: ubuntu-22.04
 
+          - target: mips64-unknown-linux-gnu
+            mode: --release
+            rust_channel: 1.71.0 # No prebuilt toolchain for later versions.
+            host_os: ubuntu-22.04
+
           - target: mips-unknown-linux-gnu
             mode: --release
             rust_channel: 1.71.0 # No prebuilt toolchain for later versions.

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -54,6 +54,8 @@
 #define OPENSSL_64_BIT
 #elif defined(__MIPSEB__) && !defined(__LP64__)
 #define OPENSSL_32_BIT
+#elif defined(__MIPSEB__) && defined(__LP64__)
+#define OPENSSL_64_BIT
 #elif defined(__PPC64__) || defined(__powerpc64__)
 #define OPENSSL_64_BIT
 #elif (defined(__PPC__) || defined(__powerpc__)) && defined(_BIG_ENDIAN)


### PR DESCRIPTION
This seems to have partial support in the mk scripts, but missing from target.h or CI.