### PR TITLE
bigint: Remove useless `#[allow(deprecated)]`.

### DIFF
--- a/src/arithmetic/montgomery.rs
+++ b/src/arithmetic/montgomery.rs
@@ -132,7 +132,6 @@ unsafe fn mul_mont(
     target_arch = "x86_64"
 )))]
 // TODO: Stop calling this from C and un-export it.
-#[allow(deprecated)]
 prefixed_export! {
     unsafe fn bn_mul_mont(
         r: *mut Limb,


### PR DESCRIPTION
Not only does it not work in this usage, but it actually generated an additional warning about it not working, thus doubling the number of warnings instead.