### PR TITLE
bssl::Result doesn't need to be Copy/Clone/Debug.

### DIFF
--- a/src/bssl.rs
+++ b/src/bssl.rs
@@ -17,7 +17,6 @@ use crate::{c, error};
 /// An `int` returned from a foreign function containing **1** if the function
 /// was successful or **0** if an error occurred. This is the convention used by
 /// C code in `ring`.
-#[derive(Clone, Copy, Debug)]
 #[must_use]
 #[repr(transparent)]
 pub struct Result(c::int);


### PR DESCRIPTION
It is immediately converted into a `Result` whenever created.