### PR TITLE
Specialize constant_time::xor to 16 bytes.

### DIFF
--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -226,7 +226,7 @@ impl Key {
     #[inline]
     pub fn encrypt_iv_xor_block(&self, iv: Iv, input: Block, cpu_features: cpu::Features) -> Block {
         let encrypted_iv = self.encrypt_block(iv.into_block_less_safe(), cpu_features);
-        constant_time::xor(encrypted_iv, input)
+        constant_time::xor_16(encrypted_iv, input)
     }
 
     #[inline]

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -298,7 +298,7 @@ fn finish(aes_key: &aes::Key, gcm_ctx: gcm::Context, tag_iv: aes::Iv) -> Tag {
     // Finalize the tag and return it.
     gcm_ctx.pre_finish(|pre_tag, cpu_features| {
         let encrypted_iv = aes_key.encrypt_block(tag_iv.into_block_less_safe(), cpu_features);
-        Tag(constant_time::xor(pre_tag, encrypted_iv))
+        Tag(constant_time::xor_16(pre_tag, encrypted_iv))
     })
 }
 

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -322,7 +322,7 @@ pub struct Xi(Block);
 impl BitXorAssign<Block> for Xi {
     #[inline]
     fn bitxor_assign(&mut self, a: Block) {
-        self.0 = constant_time::xor(self.0, a)
+        self.0 = constant_time::xor_16(self.0, a)
     }
 }
 


### PR DESCRIPTION
The compiler doesn't transform the byte-wise XORs into word-wise or SIMD XOR. Instead it generated a massive mess of instructions that did it byte-wise. WIth this implementation, it will generate word-wise XOR, at least.