### PR TITLE
EC: Thread CPU features through higher-level operations.

### DIFF
--- a/mk/generate_curves.py
+++ b/mk/generate_curves.py
@@ -108,8 +108,8 @@ pub static SCALAR_OPS: ScalarOps = ScalarOps {
 pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
     scalar_ops: &SCALAR_OPS,
     public_key_ops: &PUBLIC_KEY_OPS,
-    twin_mul: |g_scalar, p_scalar, p_xy| {
-        twin_mul_inefficient(&PRIVATE_KEY_OPS, g_scalar, p_scalar, p_xy)
+    twin_mul: |g_scalar, p_scalar, p_xy, cpu| {
+        twin_mul_inefficient(&PRIVATE_KEY_OPS, g_scalar, p_scalar, p_xy, cpu)
     },
 
     q_minus_n: Elem::from_hex("%(q_minus_n)x"),

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use crate::{error, rand};
+use crate::{cpu, error, rand};
 
 pub use self::keys::{KeyPair, PublicKey, Seed};
 
@@ -28,8 +28,11 @@ pub struct Curve {
     generate_private_key:
         fn(rng: &dyn rand::SecureRandom, &mut [u8]) -> Result<(), error::Unspecified>,
 
-    public_from_private:
-        fn(public_out: &mut [u8], private_key: &Seed) -> Result<(), error::Unspecified>,
+    public_from_private: fn(
+        public_out: &mut [u8],
+        private_key: &Seed,
+        cpu: cpu::Features,
+    ) -> Result<(), error::Unspecified>,
 }
 
 derive_debug_via_id!(Curve);

--- a/src/ec/curve25519/ops.rs
+++ b/src/ec/curve25519/ops.rs
@@ -101,11 +101,11 @@ impl ExtPoint {
         Result::from(unsafe { x25519_ge_frombytes_vartime(&mut point, encoded) }).map(|()| point)
     }
 
-    pub fn into_encoded_point(self) -> EncodedPoint {
-        encode_point(self.x, self.y, self.z)
+    pub(super) fn into_encoded_point(self, cpu_features: cpu::Features) -> EncodedPoint {
+        encode_point(self.x, self.y, self.z, cpu_features)
     }
 
-    pub fn invert_vartime(&mut self) {
+    pub(super) fn invert_vartime(&mut self) {
         self.x.negate();
         self.t.negate();
     }
@@ -128,12 +128,12 @@ impl Point {
         }
     }
 
-    pub fn into_encoded_point(self) -> EncodedPoint {
-        encode_point(self.x, self.y, self.z)
+    pub(super) fn into_encoded_point(self, cpu_features: cpu::Features) -> EncodedPoint {
+        encode_point(self.x, self.y, self.z, cpu_features)
     }
 }
 
-fn encode_point(x: Elem<T>, y: Elem<T>, z: Elem<T>) -> EncodedPoint {
+fn encode_point(x: Elem<T>, y: Elem<T>, z: Elem<T>, _cpu_features: cpu::Features) -> EncodedPoint {
     let mut bytes = [0; ELEM_LEN];
 
     let sign_bit: u8 = unsafe {

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -55,10 +55,9 @@ fn x25519_generate_private_key(
 fn x25519_public_from_private(
     public_out: &mut [u8],
     private_key: &ec::Seed,
+    cpu_features: cpu::Features,
 ) -> Result<(), error::Unspecified> {
     let public_out = public_out.try_into()?;
-
-    let cpu_features = private_key.cpu_features;
 
     let private_key: &[u8; SCALAR_LEN] = private_key.bytes_less_safe().try_into()?;
     let private_key = ops::MaskedScalar::from_bytes_masked(*private_key);
@@ -97,8 +96,8 @@ fn x25519_ecdh(
     out: &mut [u8],
     my_private_key: &ec::Seed,
     peer_public_key: untrusted::Input,
+    cpu_features: cpu::Features,
 ) -> Result<(), error::Unspecified> {
-    let cpu_features = my_private_key.cpu_features;
     let my_private_key: &[u8; SCALAR_LEN] = my_private_key.bytes_less_safe().try_into()?;
     let my_private_key = ops::MaskedScalar::from_bytes_masked(*my_private_key);
     let peer_public_key: &[u8; PUBLIC_KEY_LEN] = peer_public_key.as_slice_less_safe().try_into()?;
@@ -227,7 +226,7 @@ mod tests {
                 ec::Seed::from_bytes(&CURVE25519, Input::from(&test_case.private), cpu_features)
                     .unwrap();
             let mut output = [0u8; 32];
-            x25519_public_from_private(&mut output, &seed).unwrap();
+            x25519_public_from_private(&mut output, &seed, cpu_features).unwrap();
             assert_eq!(output, test_case.public);
         }
     }

--- a/src/ec/suite_b.rs
+++ b/src/ec/suite_b.rs
@@ -218,7 +218,7 @@ pub(crate) fn key_pair_from_bytes(
     let seed = ec::Seed::from_bytes(curve, private_key_bytes, cpu_features)
         .map_err(|error::Unspecified| error::KeyRejected::invalid_component())?;
 
-    let r = ec::KeyPair::derive(seed)
+    let r = ec::KeyPair::derive(seed, cpu_features)
         .map_err(|error::Unspecified| error::KeyRejected::unexpected_error())?;
     if public_key_bytes.as_slice_less_safe() != r.public_key().as_ref() {
         return Err(error::KeyRejected::inconsistent_components());

--- a/src/ec/suite_b/curve.rs
+++ b/src/ec/suite_b/curve.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use crate::{ec, error, rand};
+use crate::{cpu, ec, error, rand};
 
 /// A key agreement algorithm.
 macro_rules! suite_b_curve {
@@ -56,8 +56,14 @@ macro_rules! suite_b_curve {
         fn $public_from_private(
             public_out: &mut [u8],
             private_key: &ec::Seed,
+            cpu_features: cpu::Features,
         ) -> Result<(), error::Unspecified> {
-            ec::suite_b::private_key::public_from_private($private_key_ops, public_out, private_key)
+            ec::suite_b::private_key::public_from_private(
+                $private_key_ops,
+                public_out,
+                private_key,
+                cpu_features,
+            )
         }
     };
 }


### PR DESCRIPTION
Prepare for refactoring how CPU feature detection is done in low-level ECC operations.

In particular, avoid storing CPU features in ec::Seed.