### PR TITLE
cpu: Make `cpu::Features` be `!Send`.

### DIFF
--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -54,6 +54,7 @@ pub mod sliceutil;
 #[cfg(feature = "alloc")]
 mod leading_zeros_skipped;
 
+mod notsend;
 pub mod ptr;
 
 pub mod slice;
@@ -64,7 +65,8 @@ mod test;
 mod unwrap_const;
 
 pub use self::{
-    array_flat_map::ArrayFlatMap, array_split_map::ArraySplitMap, unwrap_const::unwrap_const,
+    array_flat_map::ArrayFlatMap, array_split_map::ArraySplitMap, notsend::NotSend,
+    unwrap_const::unwrap_const,
 };
 
 #[cfg(feature = "alloc")]

--- a/src/polyfill/notsend.rs
+++ b/src/polyfill/notsend.rs
@@ -1,0 +1,28 @@
+// Copyright 2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use crate::test;
+use core::marker::PhantomData;
+
+/// A ZST that can be added to any type to make the type `!Send`.
+#[derive(Clone, Copy)]
+pub struct NotSend(PhantomData<*mut ()>);
+
+impl NotSend {
+    pub const VALUE: Self = Self(PhantomData);
+}
+
+const _: () = test::compile_time_assert_clone::<NotSend>();
+const _: () = test::compile_time_assert_copy::<NotSend>();
+const _: () = assert!(core::mem::size_of::<NotSend>() == 0);

--- a/src/test.rs
+++ b/src/test.rs
@@ -128,28 +128,28 @@ extern crate std;
 
 /// `compile_time_assert_clone::<T>();` fails to compile if `T` doesn't
 /// implement `Clone`.
-pub fn compile_time_assert_clone<T: Clone>() {}
+pub const fn compile_time_assert_clone<T: Clone>() {}
 
 /// `compile_time_assert_copy::<T>();` fails to compile if `T` doesn't
 /// implement `Copy`.
-pub fn compile_time_assert_copy<T: Copy>() {}
+pub const fn compile_time_assert_copy<T: Copy>() {}
 
 /// `compile_time_assert_eq::<T>();` fails to compile if `T` doesn't
 /// implement `Eq`.
-pub fn compile_time_assert_eq<T: Eq>() {}
+pub const fn compile_time_assert_eq<T: Eq>() {}
 
 /// `compile_time_assert_send::<T>();` fails to compile if `T` doesn't
 /// implement `Send`.
-pub fn compile_time_assert_send<T: Send>() {}
+pub const fn compile_time_assert_send<T: Send>() {}
 
 /// `compile_time_assert_sync::<T>();` fails to compile if `T` doesn't
 /// implement `Sync`.
-pub fn compile_time_assert_sync<T: Sync>() {}
+pub const fn compile_time_assert_sync<T: Sync>() {}
 
 /// `compile_time_assert_std_error_error::<T>();` fails to compile if `T`
 /// doesn't implement `std::error::Error`.
 #[cfg(feature = "std")]
-pub fn compile_time_assert_std_error_error<T: std::error::Error>() {}
+pub const fn compile_time_assert_std_error_error<T: std::error::Error>() {}
 
 /// A test case. A test case consists of a set of named attributes. Every
 /// attribute in the test case must be consumed exactly once; this helps catch


### PR DESCRIPTION
We don't intend to put `cpu::Features` in any type that could be sent across threads. Enforce this in the type system. This way, we can potentially change the representation of `cpu::Features` to one that really couldn't be `Send` in the future.