### PR TITLE
aes-gcm: Clarify CPU feature detection.

### DIFF
--- a/src/aead/aes/bs.rs
+++ b/src/aead/aes/bs.rs
@@ -1,0 +1,62 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg(target_arch = "arm")]
+
+use super::{Counter, AES_KEY};
+use core::ops::RangeFrom;
+
+/// SAFETY:
+///   * The caller must ensure that if blocks > 0 then either `input` and
+///     `output` do not overlap at all, or input == output.add(n) for some
+///     (nonnegative) n.
+///   * if blocks > 0, The caller must ensure `input` points to `blocks` blocks
+///     and that `output` points to writable space for `blocks` blocks.
+///   * The caller must ensure that `vpaes_key` was initialized with
+///     `vpaes_set_encrypt_key`.
+///   * Upon returning, `blocks` blocks will have been read from `input` and
+///     written to `output`.
+pub(super) unsafe fn ctr32_encrypt_blocks_with_vpaes_key(
+    in_out: &mut [u8],
+    src: RangeFrom<usize>,
+    vpaes_key: &AES_KEY,
+    ctr: &mut Counter,
+) {
+    prefixed_extern! {
+        // bsaes_ctr32_encrypt_blocks requires transformation of an existing
+        // VPAES key; there is no `bsaes_set_encrypt_key`.
+        fn vpaes_encrypt_key_to_bsaes(bsaes_key: *mut AES_KEY, vpaes_key: &AES_KEY);
+    }
+
+    // SAFETY:
+    //   * The caller ensures `vpaes_key` was initialized by
+    //     `vpaes_set_encrypt_key`.
+    //   * `bsaes_key was zeroed above, and `vpaes_encrypt_key_to_bsaes`
+    //     is assumed to initialize `bsaes_key`.
+    let bsaes_key = unsafe { AES_KEY::derive(vpaes_encrypt_key_to_bsaes, vpaes_key) };
+
+    // The code for `vpaes_encrypt_key_to_bsaes` notes "vpaes stores one
+    // fewer round count than bsaes, but the number of keys is the same,"
+    // so use this as a sanity check.
+    debug_assert_eq!(bsaes_key.rounds(), vpaes_key.rounds() + 1);
+
+    // SAFETY:
+    //  * `bsaes_key` is in bsaes format after calling
+    //    `vpaes_encrypt_key_to_bsaes`.
+    //  * `bsaes_ctr32_encrypt_blocks` satisfies the contract for
+    //    `ctr32_encrypt_blocks`.
+    unsafe {
+        ctr32_encrypt_blocks!(bsaes_ctr32_encrypt_blocks, in_out, src, &bsaes_key, ctr);
+    }
+}

--- a/src/aead/aes/fallback.rs
+++ b/src/aead/aes/fallback.rs
@@ -1,0 +1,47 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, AES_KEY};
+use crate::error;
+use core::ops::RangeFrom;
+
+#[derive(Clone)]
+pub struct Key {
+    inner: AES_KEY,
+}
+
+impl Key {
+    pub(in super::super) fn new(bytes: KeyBytes<'_>) -> Result<Self, error::Unspecified> {
+        let inner = unsafe { set_encrypt_key!(aes_nohw_set_encrypt_key, bytes) }?;
+        Ok(Self { inner })
+    }
+}
+
+impl EncryptBlock for Key {
+    fn encrypt_block(&self, block: Block) -> Block {
+        unsafe { encrypt_block!(aes_nohw_encrypt, block, &self.inner) }
+    }
+
+    fn encrypt_iv_xor_block(&self, iv: Iv, block: Block) -> Block {
+        super::encrypt_iv_xor_block_using_encrypt_block(self, iv, block)
+    }
+}
+
+impl EncryptCtr32 for Key {
+    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+        unsafe {
+            ctr32_encrypt_blocks!(aes_nohw_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr)
+        }
+    }
+}

--- a/src/aead/aes/hw.rs
+++ b/src/aead/aes/hw.rs
@@ -1,0 +1,64 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
+
+use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, AES_KEY};
+use crate::{cpu, error};
+use core::ops::RangeFrom;
+
+#[cfg(target_arch = "aarch64")]
+pub(in super::super) type RequiredCpuFeatures = cpu::arm::Aes;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(in super::super) type RequiredCpuFeatures = cpu::intel::Aes;
+
+#[derive(Clone)]
+pub struct Key {
+    inner: AES_KEY,
+}
+
+impl Key {
+    pub(in super::super) fn new(
+        bytes: KeyBytes<'_>,
+        _cpu: RequiredCpuFeatures,
+    ) -> Result<Self, error::Unspecified> {
+        let inner = unsafe { set_encrypt_key!(aes_hw_set_encrypt_key, bytes) }?;
+        Ok(Self { inner })
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[must_use]
+    pub(in super::super) fn inner_less_safe(&self) -> &AES_KEY {
+        &self.inner
+    }
+}
+
+impl EncryptBlock for Key {
+    fn encrypt_block(&self, block: Block) -> Block {
+        super::encrypt_block_using_encrypt_iv_xor_block(self, block)
+    }
+
+    fn encrypt_iv_xor_block(&self, iv: Iv, block: Block) -> Block {
+        super::encrypt_iv_xor_block_using_ctr32(self, iv, block)
+    }
+}
+
+impl EncryptCtr32 for Key {
+    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+        #[cfg(target_arch = "x86_64")]
+        let _: cpu::Features = cpu::features();
+        unsafe { ctr32_encrypt_blocks!(aes_hw_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr) }
+    }
+}

--- a/src/aead/aes/vp.rs
+++ b/src/aead/aes/vp.rs
@@ -1,0 +1,130 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg(any(
+    target_arch = "aarch64",
+    target_arch = "arm",
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
+
+use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, AES_KEY};
+use crate::{cpu, error};
+use core::ops::RangeFrom;
+
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+type RequiredCpuFeatures = cpu::arm::Neon;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+type RequiredCpuFeatures = cpu::intel::Ssse3;
+
+#[derive(Clone)]
+pub(in super::super) struct Key {
+    inner: AES_KEY,
+}
+
+impl Key {
+    pub(in super::super) fn new(
+        bytes: KeyBytes<'_>,
+        _cpu: RequiredCpuFeatures,
+    ) -> Result<Self, error::Unspecified> {
+        let inner = unsafe { set_encrypt_key!(vpaes_set_encrypt_key, bytes) }?;
+        Ok(Self { inner })
+    }
+}
+
+#[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64"))]
+impl EncryptBlock for Key {
+    fn encrypt_block(&self, block: Block) -> Block {
+        super::encrypt_block_using_encrypt_iv_xor_block(self, block)
+    }
+
+    fn encrypt_iv_xor_block(&self, iv: Iv, block: Block) -> Block {
+        super::encrypt_iv_xor_block_using_ctr32(self, iv, block)
+    }
+}
+
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+impl EncryptCtr32 for Key {
+    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+        unsafe { ctr32_encrypt_blocks!(vpaes_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr) }
+    }
+}
+
+#[cfg(target_arch = "arm")]
+impl EncryptCtr32 for Key {
+    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+        use super::{bs, BLOCK_LEN};
+
+        let in_out = {
+            let blocks = in_out[src.clone()].len() / BLOCK_LEN;
+
+            // bsaes operates in batches of 8 blocks.
+            let bsaes_blocks = if blocks >= 8 && (blocks % 8) < 6 {
+                // It's faster to use bsaes for all the full batches and then
+                // switch to vpaes for the last partial batch (if any).
+                blocks - (blocks % 8)
+            } else if blocks >= 8 {
+                // It's faster to let bsaes handle everything including
+                // the last partial batch.
+                blocks
+            } else {
+                // It's faster to let vpaes handle everything.
+                0
+            };
+            let bsaes_in_out_len = bsaes_blocks * BLOCK_LEN;
+
+            // SAFETY:
+            //  * self.inner was initialized with `vpaes_set_encrypt_key` above,
+            //    as required by `bsaes_ctr32_encrypt_blocks_with_vpaes_key`.
+            unsafe {
+                bs::ctr32_encrypt_blocks_with_vpaes_key(
+                    &mut in_out[..(src.start + bsaes_in_out_len)],
+                    src.clone(),
+                    &self.inner,
+                    ctr,
+                );
+            }
+
+            &mut in_out[bsaes_in_out_len..]
+        };
+
+        // SAFETY:
+        //  * self.inner was initialized with `vpaes_set_encrypt_key` above,
+        //    as required by `vpaes_ctr32_encrypt_blocks`.
+        //  * `vpaes_ctr32_encrypt_blocks` satisfies the contract for
+        //    `ctr32_encrypt_blocks`.
+        unsafe { ctr32_encrypt_blocks!(vpaes_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr) }
+    }
+}
+
+#[cfg(target_arch = "x86")]
+impl EncryptBlock for Key {
+    fn encrypt_block(&self, block: Block) -> Block {
+        unsafe { encrypt_block!(vpaes_encrypt, block, &self.inner) }
+    }
+
+    fn encrypt_iv_xor_block(&self, iv: Iv, block: Block) -> Block {
+        super::encrypt_iv_xor_block_using_encrypt_block(self, iv, block)
+    }
+}
+
+#[cfg(target_arch = "x86")]
+impl EncryptCtr32 for Key {
+    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+        super::super::shift::shift_full_blocks(in_out, src, |input| {
+            self.encrypt_iv_xor_block(ctr.increment(), *input)
+        });
+    }
+}

--- a/src/aead/algorithm.rs
+++ b/src/aead/algorithm.rs
@@ -187,13 +187,13 @@ fn aes_gcm_seal(
     nonce: Nonce,
     aad: Aad<&[u8]>,
     in_out: &mut [u8],
-    cpu_features: cpu::Features,
+    _cpu_features: cpu::Features,
 ) -> Result<Tag, error::Unspecified> {
     let key = match key {
         KeyInner::AesGcm(key) => key,
         _ => unreachable!(),
     };
-    aes_gcm::seal(key, nonce, aad, in_out, cpu_features)
+    aes_gcm::seal(key, nonce, aad, in_out)
 }
 
 pub(super) fn aes_gcm_open(
@@ -202,13 +202,13 @@ pub(super) fn aes_gcm_open(
     aad: Aad<&[u8]>,
     in_out: &mut [u8],
     src: RangeFrom<usize>,
-    cpu_features: cpu::Features,
+    _cpu_features: cpu::Features,
 ) -> Result<Tag, error::Unspecified> {
     let key = match key {
         KeyInner::AesGcm(key) => key,
         _ => unreachable!(),
     };
-    aes_gcm::open(key, nonce, aad, in_out, src, cpu_features)
+    aes_gcm::open(key, nonce, aad, in_out, src)
 }
 
 /// ChaCha20-Poly1305 as described in [RFC 8439].

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Brian Smith.
+// Copyright 2018-2024 Brian Smith.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -16,10 +16,12 @@ use self::ffi::{Block, BLOCK_LEN, ZERO_BLOCK};
 use super::{aes_gcm, Aad};
 use crate::{
     bits::{BitLength, FromByteLen as _},
-    cpu, error,
-    polyfill::{sliceutil::overwrite_at_start, ArraySplitMap as _},
+    error,
+    polyfill::{sliceutil::overwrite_at_start, NotSend},
 };
 use cfg_if::cfg_if;
+
+pub(super) use ffi::KeyValue;
 
 cfg_if! {
     if #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))] {
@@ -31,48 +33,26 @@ cfg_if! {
 
 #[macro_use]
 mod ffi;
-mod gcm_nohw;
 
-#[derive(Clone)]
-pub struct Key {
-    h_table: HTable,
-}
+pub(super) mod clmul;
+pub(super) mod clmulavxmovbe;
+pub(super) mod fallback;
+pub(super) mod neon;
 
-impl Key {
-    pub(super) fn new(h_be: Block, cpu_features: cpu::Features) -> Self {
-        let h: [u64; 2] = h_be.array_split_map(u64::from_be_bytes);
-        let h_table = match detect_implementation(cpu_features) {
-            #[cfg(target_arch = "x86_64")]
-            Implementation::CLMUL if has_avx_movbe(cpu_features) => unsafe {
-                htable_new!(gcm_init_avx, &h, cou_features)
-            },
-
-            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
-            Implementation::CLMUL => unsafe { htable_new!(gcm_init_clmul, &h, cpu_features) },
-
-            #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-            Implementation::NEON => unsafe { htable_new!(gcm_init_neon, &h, cpu_features) },
-
-            Implementation::Fallback => HTable::new_single_entry(gcm_nohw::init(h)),
-        };
-        Self { h_table }
-    }
-}
-
-pub struct Context<'key> {
+pub(super) struct Context<'key, K> {
     Xi: Xi,
-    h_table: &'key HTable,
+    key: &'key K,
     aad_len: BitLength<u64>,
     in_out_len: BitLength<u64>,
-    cpu_features: cpu::Features,
+    _not_send: NotSend,
 }
 
-impl<'key> Context<'key> {
+impl<'key, K: Gmult> Context<'key, K> {
+    #[inline(always)]
     pub(crate) fn new(
-        key: &'key Key,
+        key: &'key K,
         aad: Aad<&[u8]>,
         in_out_len: usize,
-        cpu_features: cpu::Features,
     ) -> Result<Self, error::Unspecified> {
         if in_out_len > aes_gcm::MAX_IN_OUT_LEN {
             return Err(error::Unspecified);
@@ -86,10 +66,10 @@ impl<'key> Context<'key> {
 
         let mut ctx = Self {
             Xi: Xi(ZERO_BLOCK),
-            h_table: &key.h_table,
+            key,
             aad_len,
             in_out_len,
-            cpu_features,
+            _not_send: NotSend::VALUE,
         };
 
         for ad in aad.0.chunks(BLOCK_LEN) {
@@ -100,8 +80,10 @@ impl<'key> Context<'key> {
 
         Ok(ctx)
     }
+}
 
-    #[cfg(all(target_arch = "aarch64", target_pointer_width = "64"))]
+#[cfg(all(target_arch = "aarch64", target_pointer_width = "64"))]
+impl<K> Context<'_, K> {
     pub(super) fn in_out_whole_block_bits(&self) -> BitLength<usize> {
         use crate::polyfill::usize_from_u64;
         const WHOLE_BLOCK_BITS_MASK: usize = !0b111_1111;
@@ -110,160 +92,57 @@ impl<'key> Context<'key> {
             assert!(WHOLE_BLOCK_BITS_MASK == !((BLOCK_LEN * 8) - 1));
         BitLength::from_bits(usize_from_u64(self.in_out_len.as_bits()) & WHOLE_BLOCK_BITS_MASK)
     }
+}
 
-    /// Access to `inner` for the integrated AES-GCM implementations only.
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
+/// Access to `inner` for the integrated AES-GCM implementations only.
+impl Context<'_, clmul::Key> {
     #[inline]
     pub(super) fn inner(&mut self) -> (&HTable, &mut Xi) {
-        (self.h_table, &mut self.Xi)
+        (&self.key.inner(), &mut self.Xi)
     }
+}
 
+#[cfg(target_arch = "x86_64")]
+impl Context<'_, clmulavxmovbe::Key> {
+    /// Access to `inner` for the integrated AES-GCM implementations only.
+    #[inline]
+    pub(super) fn inner(&mut self) -> (&HTable, &mut Xi) {
+        (self.key.inner(), &mut self.Xi)
+    }
+}
+
+impl<K: UpdateBlocks> Context<'_, K> {
+    #[inline(always)]
     pub fn update_blocks(&mut self, input: &[[u8; BLOCK_LEN]]) {
-        let xi = &mut self.Xi;
-        let h_table = self.h_table;
-
-        match detect_implementation(self.cpu_features) {
-            #[cfg(target_arch = "x86_64")]
-            // SAFETY: gcm_ghash_avx satisfies the ghash! contract.
-            Implementation::CLMUL if has_avx_movbe(self.cpu_features) => unsafe {
-                ghash!(gcm_ghash_avx, xi, h_table, input, self.cpu_features);
-            },
-
-            #[cfg(target_arch = "aarch64")]
-            // If we have CLMUL then we probably have AES, so the integrated
-            // implementation will take care of everything except any final
-            // partial block. Thus, we avoid having an optimized implementation
-            // here.
-            Implementation::CLMUL => self.update_blocks_1x(input),
-
-            #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-            // SAFETY: gcm_ghash_clmul satisfies the ghash! contract on these
-            // targets.
-            Implementation::CLMUL => unsafe {
-                ghash!(gcm_ghash_clmul, xi, h_table, input, self.cpu_features);
-            },
-
-            #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-            // SAFETY: gcm_ghash_neon satisfies the ghash! contract on these
-            // targets.
-            Implementation::NEON => unsafe {
-                ghash!(gcm_ghash_neon, xi, h_table, input, self.cpu_features);
-            },
-
-            Implementation::Fallback => {
-                gcm_nohw::ghash(xi, h_table.first_entry(), input);
-            }
-        }
+        self.key.update_blocks(&mut self.Xi, input);
     }
+}
 
-    #[cfg(target_arch = "aarch64")]
-    #[inline(never)]
-    fn update_blocks_1x(&mut self, input: &[[u8; BLOCK_LEN]]) {
-        for input in input {
-            self.update_block(*input);
-        }
-    }
-
+impl<K: Gmult> Context<'_, K> {
     pub fn update_block(&mut self, a: Block) {
         self.Xi.bitxor_assign(a);
-
-        let xi = &mut self.Xi;
-        let h_table = self.h_table;
-
-        match detect_implementation(self.cpu_features) {
-            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
-            Implementation::CLMUL => unsafe {
-                gmult!(gcm_gmult_clmul, xi, h_table, self.cpu_features)
-            },
-
-            #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-            Implementation::NEON => unsafe {
-                gmult!(gcm_gmult_neon, xi, h_table, self.cpu_features)
-            },
-
-            Implementation::Fallback => {
-                gcm_nohw::gmult(xi, h_table.first_entry());
-            }
-        }
+        self.key.gmult(&mut self.Xi);
     }
 
+    #[inline(always)]
     pub(super) fn pre_finish<F>(mut self, f: F) -> super::Tag
     where
-        F: FnOnce(Block, cpu::Features) -> super::Tag,
+        F: FnOnce(Block) -> super::Tag,
     {
         let mut block = [0u8; BLOCK_LEN];
         let (alen, clen) = block.split_at_mut(BLOCK_LEN / 2);
         alen.copy_from_slice(&BitLength::<u64>::to_be_bytes(self.aad_len));
         clen.copy_from_slice(&BitLength::<u64>::to_be_bytes(self.in_out_len));
         self.update_block(block);
-        f(self.Xi.into_block(), self.cpu_features)
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    pub(super) fn is_avx(&self) -> bool {
-        match detect_implementation(self.cpu_features) {
-            Implementation::CLMUL => has_avx_movbe(self.cpu_features),
-            _ => false,
-        }
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    pub(super) fn is_clmul(&self) -> bool {
-        matches!(
-            detect_implementation(self.cpu_features),
-            Implementation::CLMUL
-        )
+        f(self.Xi.0)
     }
 }
 
-#[allow(clippy::upper_case_acronyms)]
-enum Implementation {
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
-    CLMUL,
-
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-    NEON,
-
-    Fallback,
+pub(super) trait Gmult {
+    fn gmult(&self, xi: &mut Xi);
 }
 
-#[inline]
-fn detect_implementation(cpu_features: cpu::Features) -> Implementation {
-    // `cpu_features` is only used for specific platforms.
-    #[cfg(not(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
-        target_arch = "x86_64",
-        target_arch = "x86"
-    )))]
-    let _cpu_features = cpu_features;
-
-    #[cfg(target_arch = "aarch64")]
-    {
-        if cpu::arm::PMULL.available(cpu_features) {
-            return Implementation::CLMUL;
-        }
-    }
-
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    {
-        if cpu::intel::FXSR.available(cpu_features) && cpu::intel::PCLMULQDQ.available(cpu_features)
-        {
-            return Implementation::CLMUL;
-        }
-    }
-
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-    {
-        if cpu::arm::NEON.available(cpu_features) {
-            return Implementation::NEON;
-        }
-    }
-
-    Implementation::Fallback
-}
-
-#[cfg(target_arch = "x86_64")]
-fn has_avx_movbe(cpu_features: cpu::Features) -> bool {
-    cpu::intel::AVX.available(cpu_features) && cpu::intel::MOVBE.available(cpu_features)
+pub(super) trait UpdateBlocks {
+    fn update_blocks(&self, xi: &mut Xi, input: &[[u8; BLOCK_LEN]]);
 }

--- a/src/aead/gcm/clmul.rs
+++ b/src/aead/gcm/clmul.rs
@@ -1,0 +1,66 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
+
+use super::{ffi::KeyValue, Gmult, HTable, Xi};
+use crate::cpu;
+
+#[cfg(target_arch = "aarch64")]
+pub(in super::super) type RequiredCpuFeatures = cpu::arm::PMull;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(in super::super) type RequiredCpuFeatures = (cpu::intel::ClMul, cpu::intel::Fxsr);
+
+#[derive(Clone)]
+pub struct Key {
+    h_table: HTable,
+}
+
+impl Key {
+    pub(in super::super) fn new(value: KeyValue, _cpu: RequiredCpuFeatures) -> Self {
+        Self {
+            h_table: unsafe { htable_new!(gcm_init_clmul, value) },
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub(super) fn new_avx(
+        value: KeyValue,
+        _cpu_features: super::clmulavxmovbe::RequiredCpuFeatures,
+    ) -> Self {
+        Self {
+            h_table: unsafe { htable_new!(gcm_init_avx, value) },
+        }
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    pub(super) fn inner(&self) -> &HTable {
+        &self.h_table
+    }
+}
+
+impl Gmult for Key {
+    fn gmult(&self, xi: &mut Xi) {
+        unsafe { gmult!(gcm_gmult_clmul, xi, &self.h_table) }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl super::UpdateBlocks for Key {
+    fn update_blocks(&self, xi: &mut Xi, input: &[[u8; super::BLOCK_LEN]]) {
+        let _: cpu::Features = cpu::features();
+        unsafe { ghash!(gcm_ghash_clmul, xi, &self.h_table, input) }
+    }
+}

--- a/src/aead/gcm/clmulavxmovbe.rs
+++ b/src/aead/gcm/clmulavxmovbe.rs
@@ -1,0 +1,53 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg(target_arch = "x86_64")]
+
+use super::{clmul, Gmult, HTable, KeyValue, UpdateBlocks, Xi, BLOCK_LEN};
+use crate::cpu;
+
+pub(in super::super) type RequiredCpuFeatures = (
+    clmul::RequiredCpuFeatures,
+    cpu::intel::Avx,
+    cpu::intel::Movbe,
+);
+
+#[derive(Clone)]
+pub struct Key {
+    inner: clmul::Key,
+}
+
+impl Key {
+    pub(in super::super) fn new(key_value: KeyValue, cpu: RequiredCpuFeatures) -> Self {
+        Self {
+            inner: clmul::Key::new_avx(key_value, cpu),
+        }
+    }
+
+    pub(super) fn inner(&self) -> &HTable {
+        self.inner.inner()
+    }
+}
+
+impl Gmult for Key {
+    fn gmult(&self, xi: &mut Xi) {
+        self.inner.gmult(xi)
+    }
+}
+
+impl UpdateBlocks for Key {
+    fn update_blocks(&self, xi: &mut Xi, input: &[[u8; BLOCK_LEN]]) {
+        unsafe { ghash!(gcm_ghash_avx, xi, &self.inner.inner(), input) }
+    }
+}

--- a/src/aead/gcm/neon.rs
+++ b/src/aead/gcm/neon.rs
@@ -1,0 +1,45 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+
+use super::{Gmult, HTable, KeyValue, UpdateBlocks, Xi, BLOCK_LEN};
+use crate::cpu;
+
+pub(in super::super) type RequiredCpuFeatures = cpu::arm::Neon;
+
+#[derive(Clone)]
+pub struct Key {
+    h_table: HTable,
+}
+
+impl Key {
+    pub(in super::super) fn new(value: KeyValue, _cpu: RequiredCpuFeatures) -> Self {
+        Self {
+            h_table: unsafe { htable_new!(gcm_init_neon, value) },
+        }
+    }
+}
+
+impl Gmult for Key {
+    fn gmult(&self, xi: &mut Xi) {
+        unsafe { gmult!(gcm_gmult_neon, xi, &self.h_table) }
+    }
+}
+
+impl UpdateBlocks for Key {
+    fn update_blocks(&self, xi: &mut Xi, input: &[[u8; BLOCK_LEN]]) {
+        unsafe { ghash!(gcm_ghash_neon, xi, &self.h_table, input) }
+    }
+}

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -14,6 +14,54 @@
 
 pub(crate) use self::features::Features;
 
+macro_rules! impl_get_feature {
+    { $feature:path => $T:ident } => {
+        #[derive(Clone, Copy)]
+        pub(crate) struct $T(crate::cpu::Features);
+
+        impl crate::cpu::GetFeature<$T> for super::Features {
+            fn get_feature(&self) -> Option<$T> {
+                if $feature.available(*self) {
+                    Some($T(*self))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+pub(crate) trait GetFeature<T> {
+    fn get_feature(&self) -> Option<T>;
+}
+
+impl<A, B, T> GetFeature<(A, B)> for T
+where
+    T: GetFeature<A>,
+    T: GetFeature<B>,
+{
+    fn get_feature(&self) -> Option<(A, B)> {
+        match (self.get_feature(), self.get_feature()) {
+            (Some(a), Some(b)) => Some((a, b)),
+            _ => None,
+        }
+    }
+}
+
+impl<A, B, C, T> GetFeature<(A, B, C)> for T
+where
+    T: GetFeature<A>,
+    T: GetFeature<B>,
+    T: GetFeature<C>,
+{
+    fn get_feature(&self) -> Option<(A, B, C)> {
+        match (self.get_feature(), self.get_feature(), self.get_feature()) {
+            (Some(a), Some(b), Some(c)) => Some((a, b, c)),
+            _ => None,
+        }
+    }
+}
+
 #[inline(always)]
 pub(crate) fn features() -> Features {
     get_or_init_feature_flags()

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -63,7 +63,7 @@ cfg_if::cfg_if! {
 macro_rules! features {
     {
         $(
-            $target_feature_name:expr => $name:ident {
+            $target_feature_name:expr => $TyName:ident($name:ident) {
                 mask: $mask:expr,
             }
         ),+
@@ -74,6 +74,7 @@ macro_rules! features {
             pub(crate) const $name: Feature = Feature {
                 mask: $mask,
             };
+            impl_get_feature!{ $name => $TyName }
         )+
 
         // See const assertions below.
@@ -115,17 +116,17 @@ impl Feature {
 #[cfg(target_arch = "aarch64")]
 features! {
     // Keep in sync with `ARMV7_NEON`.
-    "neon" => NEON {
+    "neon" => Neon(NEON) {
         mask: 1 << 0,
     },
 
     // Keep in sync with `ARMV8_AES`.
-    "aes" => AES {
+    "aes" => Aes(AES) {
         mask: 1 << 2,
     },
 
     // Keep in sync with `ARMV8_SHA256`.
-    "sha2" => SHA256 {
+    "sha2" => Sha256(SHA256) {
         mask: 1 << 4,
     },
 
@@ -137,13 +138,13 @@ features! {
     // https://developer.arm.com/downloads/-/exploration-tools/feature-names-for-a-profile
     // "Features introduced prior to 2020." Change this to use "pmull" when
     // that is supported.
-    "aes" => PMULL {
+    "aes" => PMull(PMULL) {
         mask: 1 << 5,
     },
 
     // Keep in sync with `ARMV8_SHA512`.
     // "sha3" is overloaded for both SHA-3 and SHA512.
-    "sha3" => SHA512 {
+    "sha3" => Sha512(SHA512) {
         mask: 1 << 6,
     },
 }
@@ -151,7 +152,7 @@ features! {
 #[cfg(target_arch = "arm")]
 features! {
     // Keep in sync with `ARMV7_NEON`.
-    "neon" => NEON {
+    "neon" => Neon(NEON) {
         mask: 1 << 0,
     },
 }

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -12,6 +12,8 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use cfg_if::cfg_if;
+
 mod abi_assumptions {
     // TOOD: Support targets that do not have SSE and SSE2 enabled, such as
     // x86_64-unknown-linux-none. See
@@ -118,22 +120,32 @@ pub(crate) const SSE41: Feature = Feature {
     mask: 1 << 19,
 };
 
-#[cfg(target_arch = "x86_64")]
-pub(crate) const MOVBE: Feature = Feature {
-    word: 1,
-    mask: 1 << 22,
-};
-
 pub(crate) const AES: Feature = Feature {
     word: 1,
     mask: 1 << 25,
 };
 
-#[cfg(target_arch = "x86_64")]
-pub(crate) const AVX: Feature = Feature {
-    word: 1,
-    mask: 1 << 28,
-};
+impl_get_feature! { AES => Aes }
+impl_get_feature! { FXSR => Fxsr }
+impl_get_feature! { PCLMULQDQ => ClMul }
+impl_get_feature! { SSSE3 => Ssse3 }
+
+cfg_if! {
+    if #[cfg(any(target_arch = "x86_64"))] {
+        pub(crate) const MOVBE: Feature = Feature {
+            word: 1,
+            mask: 1 << 22,
+        };
+
+        pub(crate) const AVX: Feature = Feature {
+            word: 1,
+            mask: 1 << 28,
+        };
+
+        impl_get_feature!{ MOVBE => Movbe }
+        impl_get_feature!{ AVX => Avx }
+    }
+}
 
 #[cfg(all(target_arch = "x86_64", test))]
 mod x86_64_tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,15 @@
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )]
+#![cfg_attr(
+    not(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    )),
+    allow(dead_code, unused_imports, unused_macros)
+)]
 #![no_std]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Although every key has been represented with the same types `aes::AES_KEY` and `gcm::HTable` regardless of which implementation is used, in reality those types are polymorphic in ways that aren't captured by the type system currently. Thus, the
`set_encrypt_key!` function must be matched with the corresponding `encrypt_block!` and/or `ctr32_encrypt_blocks!` function. Previously, we did CPU feature detection for each function call and assumed that CPU feature detection is idempotent. Now, we do CPU feature detection during key construction and make the lesser assumption that at least those same CPU features are available as long as the key exists.

This is a step towards making further improvements in CPU-feature-based dispatching.

One side-effect of this change is that GCM keys (and thus AES-GCM keys) are now much smaller on targets that don't support any assembly implementation, as they now just store a single `U128` instead of a whole `HTable`.