### PR TITLE
{aarch64,x86_64}-apple-*: Use assembly language implementations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,8 +161,8 @@ untrusted = { version = "0.9" }
 [target.'cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86",target_arch = "x86_64"))'.dependencies]
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
 
-[target.'cfg(all(any(target_os = "android", target_os = "linux", any(target_os = "ios", target_os = "macos", target_os = "tvos")), any(target_arch = "aarch64", target_arch = "arm")))'.dependencies]
-libc = { version = "0.2.148", default-features = false }
+[target.'cfg(all(any(target_os = "android", target_os = "linux", any(target_os = "ios", target_os = "macos", target_os = "tvos", target_os = "visionos", target_os = "watchos")), any(target_arch = "aarch64", target_arch = "arm")))'.dependencies]
+libc = { version = "0.2.154", default-features = false }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
 windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/build.rs
+++ b/build.rs
@@ -190,12 +190,12 @@ const ASM_TARGETS: &[AsmTarget] = &[
         perlasm_format: "elf",
     },
     AsmTarget {
-        oss: MACOS_ABI,
+        oss: APPLE_ABI,
         arch: AARCH64,
         perlasm_format: "ios64",
     },
     AsmTarget {
-        oss: MACOS_ABI,
+        oss: APPLE_ABI,
         arch: X86_64,
         perlasm_format: "macosx",
     },
@@ -255,9 +255,8 @@ const NASM: &str = "nasm";
 
 /// Operating systems that have the same ABI as macOS on every architecture
 /// mentioned in `ASM_TARGETS`.
-const MACOS_ABI: &[&str] = &["ios", MACOS, "tvos"];
+const APPLE_ABI: &[&str] = &["ios", "macos", "tvos", "visionos", "watchos"];
 
-const MACOS: &str = "macos";
 const WINDOWS: &str = "windows";
 
 fn main() {
@@ -562,7 +561,7 @@ fn configure_cc(c: &mut cc::Build, target: &Target, c_root_dir: &Path, include_d
         let _ = c.flag(f);
     }
 
-    if target.os.as_str() == MACOS {
+    if APPLE_ABI.contains(&target.os.as_str()) {
         // ``-gfull`` is required for Darwin's |-dead_strip|.
         let _ = c.flag("-gfull");
     } else if !compiler.is_like_msvc() {

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -40,7 +40,7 @@ mod abi_assumptions {
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "aarch64",
-                 any(target_os = "ios", target_os = "macos", target_os = "tvos")))] {
+                 any(target_os = "ios", target_os = "macos", target_os = "tvos", target_os = "visionos", target_os = "watchos")))] {
         mod darwin;
         use darwin as detect;
     } else if #[cfg(all(target_arch = "aarch64", target_os = "fuchsia"))] {

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -62,7 +62,7 @@ fn x25519_public_from_private(
     let private_key: &[u8; SCALAR_LEN] = private_key.bytes_less_safe().try_into()?;
     let private_key = ops::MaskedScalar::from_bytes_masked(*private_key);
 
-    #[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+    #[cfg(all(not(target_vendor = "apple"), target_arch = "arm"))]
     {
         if cpu::arm::NEON.available(cpu_features) {
             static MONTGOMERY_BASE_POINT: [u8; 32] = [
@@ -108,7 +108,7 @@ fn x25519_ecdh(
         point: &ops::EncodedPoint,
         #[allow(unused_variables)] cpu_features: cpu::Features,
     ) {
-        #[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+        #[cfg(all(not(target_vendor = "apple"), target_arch = "arm"))]
         {
             if cpu::arm::NEON.available(cpu_features) {
                 return x25519_neon(out, scalar, point);
@@ -157,7 +157,7 @@ fn x25519_ecdh(
     Ok(())
 }
 
-#[cfg(all(not(target_os = "ios"), target_arch = "arm"))]
+#[cfg(all(not(target_vendor = "apple"), target_arch = "arm"))]
 fn x25519_neon(out: &mut ops::EncodedPoint, scalar: &ops::MaskedScalar, point: &ops::EncodedPoint) {
     prefixed_extern! {
         fn x25519_NEON(


### PR DESCRIPTION
Change visionOS and watchOS to use the assembly implementations like iOS, macOS, and tvOS were already.

Use the same C compiler options for all these targets.