### PR TITLE
aes: Clarify counter overflow checking.

### DIFF
--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{nonce::Nonce, quic::Sample, NONCE_LEN};
+use super::quic::Sample;
 use crate::{
     constant_time,
     cpu::{self, GetFeature as _},
@@ -21,12 +21,13 @@ use crate::{
 use cfg_if::cfg_if;
 use core::ops::RangeFrom;
 
-pub(super) use ffi::Counter;
+pub(super) use self::{counter::Iv, ffi::Counter};
 
 #[macro_use]
 mod ffi;
 
 mod bs;
+mod counter;
 pub(super) mod fallback;
 pub(super) mod hw;
 pub(super) mod vp;
@@ -111,41 +112,6 @@ pub const AES_256_KEY_LEN: usize = 256 / 8;
 pub enum KeyBytes<'a> {
     AES_128(&'a [u8; AES_128_KEY_LEN]),
     AES_256(&'a [u8; AES_256_KEY_LEN]),
-}
-
-// `Counter` is `ffi::Counter` as its representation is dictated by its use in
-// the FFI.
-impl Counter {
-    pub fn one(nonce: Nonce) -> Self {
-        let mut value = [0u8; BLOCK_LEN];
-        value[..NONCE_LEN].copy_from_slice(nonce.as_ref());
-        value[BLOCK_LEN - 1] = 1;
-        Self(value)
-    }
-
-    pub fn increment(&mut self) -> Iv {
-        let iv = Iv(self.0);
-        self.increment_by_less_safe(1);
-        iv
-    }
-
-    fn increment_by_less_safe(&mut self, increment_by: u32) {
-        let [.., c0, c1, c2, c3] = &mut self.0;
-        let old_value: u32 = u32::from_be_bytes([*c0, *c1, *c2, *c3]);
-        let new_value = old_value + increment_by;
-        [*c0, *c1, *c2, *c3] = u32::to_be_bytes(new_value);
-    }
-}
-
-/// The IV for a single block encryption.
-///
-/// Intentionally not `Clone` to ensure each is used only once.
-pub struct Iv(Block);
-
-impl From<Counter> for Iv {
-    fn from(counter: Counter) -> Self {
-        Self(counter.0)
-    }
 }
 
 pub(super) type Block = [u8; BLOCK_LEN];

--- a/src/aead/aes/bs.rs
+++ b/src/aead/aes/bs.rs
@@ -14,7 +14,7 @@
 
 #![cfg(target_arch = "arm")]
 
-use super::{Counter, AES_KEY};
+use super::{IvBlock, AES_KEY};
 use core::ops::RangeFrom;
 
 /// SAFETY:
@@ -31,8 +31,8 @@ pub(super) unsafe fn ctr32_encrypt_blocks_with_vpaes_key(
     in_out: &mut [u8],
     src: RangeFrom<usize>,
     vpaes_key: &AES_KEY,
-    ctr: &mut Counter,
-) {
+    iv_block: IvBlock,
+) -> Result<(), super::InOutLenInconsistentWithIvBlockLenError> {
     prefixed_extern! {
         // bsaes_ctr32_encrypt_blocks requires transformation of an existing
         // VPAES key; there is no `bsaes_set_encrypt_key`.
@@ -57,6 +57,12 @@ pub(super) unsafe fn ctr32_encrypt_blocks_with_vpaes_key(
     //  * `bsaes_ctr32_encrypt_blocks` satisfies the contract for
     //    `ctr32_encrypt_blocks`.
     unsafe {
-        ctr32_encrypt_blocks!(bsaes_ctr32_encrypt_blocks, in_out, src, &bsaes_key, ctr);
+        ctr32_encrypt_blocks!(
+            bsaes_ctr32_encrypt_blocks,
+            in_out,
+            src,
+            &bsaes_key,
+            iv_block
+        )
     }
 }

--- a/src/aead/aes/counter.rs
+++ b/src/aead/aes/counter.rs
@@ -1,0 +1,54 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use super::{
+    super::nonce::{Nonce, NONCE_LEN},
+    ffi::Counter,
+    Block, BLOCK_LEN,
+};
+
+// `Counter` is `ffi::Counter` as its representation is dictated by its use in
+// the FFI.
+impl Counter {
+    pub fn one(nonce: Nonce) -> Self {
+        let mut value = [0u8; BLOCK_LEN];
+        value[..NONCE_LEN].copy_from_slice(nonce.as_ref());
+        value[BLOCK_LEN - 1] = 1;
+        Self(value)
+    }
+
+    pub fn increment(&mut self) -> Iv {
+        let iv = Iv(self.0);
+        self.increment_by_less_safe(1);
+        iv
+    }
+
+    pub(super) fn increment_by_less_safe(&mut self, increment_by: u32) {
+        let [.., c0, c1, c2, c3] = &mut self.0;
+        let old_value: u32 = u32::from_be_bytes([*c0, *c1, *c2, *c3]);
+        let new_value = old_value + increment_by;
+        [*c0, *c1, *c2, *c3] = u32::to_be_bytes(new_value);
+    }
+}
+
+/// The IV for a single block encryption.
+///
+/// Intentionally not `Clone` to ensure each is used only once.
+pub struct Iv(pub(super) Block);
+
+impl From<Counter> for Iv {
+    fn from(counter: Counter) -> Self {
+        Self(counter.0)
+    }
+}

--- a/src/aead/aes/counter.rs
+++ b/src/aead/aes/counter.rs
@@ -45,7 +45,17 @@ impl Counter {
 /// The IV for a single block encryption.
 ///
 /// Intentionally not `Clone` to ensure each is used only once.
-pub struct Iv(pub(super) Block);
+pub struct Iv(Block);
+
+impl Iv {
+    pub(super) fn new_less_safe(value: Block) -> Self {
+        Self(value)
+    }
+
+    pub(super) fn into_block_less_safe(self) -> Block {
+        self.0
+    }
+}
 
 impl From<Counter> for Iv {
     fn from(counter: Counter) -> Self {

--- a/src/aead/aes/counter.rs
+++ b/src/aead/aes/counter.rs
@@ -17,48 +17,376 @@ use super::{
     ffi::Counter,
     Block, BLOCK_LEN,
 };
+use crate::polyfill::{nonzerousize_from_nonzerou32, unwrap_const};
+use core::num::{NonZeroU32, NonZeroUsize};
 
 // `Counter` is `ffi::Counter` as its representation is dictated by its use in
 // the FFI.
 impl Counter {
-    pub fn one(nonce: Nonce) -> Self {
+    pub fn one_two(nonce: Nonce) -> (Iv, Self) {
         let mut value = [0u8; BLOCK_LEN];
         value[..NONCE_LEN].copy_from_slice(nonce.as_ref());
         value[BLOCK_LEN - 1] = 1;
-        Self(value)
+        let iv = Iv::new_less_safe(value);
+        value[BLOCK_LEN - 1] = 2;
+        (iv, Self(value))
     }
 
-    pub fn increment(&mut self) -> Iv {
+    pub fn try_into_iv(self) -> Result<Iv, CounterOverflowError> {
         let iv = Iv(self.0);
-        self.increment_by_less_safe(1);
-        iv
+        let [.., c0, c1, c2, c3] = &self.0;
+        let old_value: u32 = u32::from_be_bytes([*c0, *c1, *c2, *c3]);
+        if old_value == 0 {
+            return Err(CounterOverflowError::new());
+        }
+        Ok(iv)
     }
 
-    pub(super) fn increment_by_less_safe(&mut self, increment_by: u32) {
+    pub fn increment_by(
+        &mut self,
+        increment_by: NonZeroUsize,
+    ) -> Result<IvBlock, CounterOverflowError> {
+        #[cold]
+        #[inline(never)]
+        fn overflowed(sum: u32) -> Result<u32, CounterOverflowError> {
+            match sum {
+                0 => Ok(0),
+                _ => Err(CounterOverflowError::new()),
+            }
+        }
+
+        let iv = Iv(self.0);
+
+        let increment_by = match NonZeroU32::try_from(increment_by) {
+            Ok(value) => value,
+            _ => return Err(CounterOverflowError::new()),
+        };
+
         let [.., c0, c1, c2, c3] = &mut self.0;
         let old_value: u32 = u32::from_be_bytes([*c0, *c1, *c2, *c3]);
-        let new_value = old_value + increment_by;
+        if old_value == 0 {
+            return Err(CounterOverflowError::new());
+        }
+        let new_value = match old_value.overflowing_add(increment_by.get()) {
+            (sum, false) => sum,
+            (sum, true) => overflowed(sum)?,
+        };
         [*c0, *c1, *c2, *c3] = u32::to_be_bytes(new_value);
+
+        Ok(IvBlock {
+            initial_iv: iv,
+            len: increment_by,
+        })
+    }
+
+    #[cfg(target_arch = "x86")]
+    pub(super) fn increment_unchecked_less_safe(&mut self) -> Iv {
+        let iv = Iv(self.0);
+
+        let [.., c0, c1, c2, c3] = &mut self.0;
+        let old_value: u32 = u32::from_be_bytes([*c0, *c1, *c2, *c3]);
+        debug_assert_ne!(old_value, 0);
+        // TODO: unchecked_add?
+        let new_value = old_value.wrapping_add(1);
+        // Note that it *is* valid for new_value to be zero!
+        [*c0, *c1, *c2, *c3] = u32::to_be_bytes(new_value);
+
+        iv
+    }
+}
+
+pub(in super::super) struct CounterOverflowError(());
+
+impl CounterOverflowError {
+    #[cold]
+    fn new() -> Self {
+        Self(())
+    }
+}
+
+pub(in super::super) struct IvBlock {
+    initial_iv: Iv,
+    // invariant: 0 < len && len <= u32::MAX
+    len: NonZeroU32,
+}
+
+impl IvBlock {
+    pub(super) fn from_iv(iv: Iv) -> Self {
+        const _1: NonZeroU32 = unwrap_const(NonZeroU32::new(1));
+        Self {
+            initial_iv: iv,
+            len: _1,
+        }
+    }
+
+    // This conversion cannot fail.
+    pub fn len(&self) -> NonZeroUsize {
+        nonzerousize_from_nonzerou32(self.len)
+    }
+
+    // "Less safe" because this subverts the IV reuse prevention machinery. The
+    // caller must ensure the IV is used only once.
+    pub(super) fn into_initial_iv(self) -> Iv {
+        self.initial_iv
+    }
+
+    #[cfg(any(target_arch = "arm", test))]
+    pub(super) fn split_at(
+        self,
+        num_blocks: usize,
+    ) -> Result<(Option<IvBlock>, Option<IvBlock>), super::InOutLenInconsistentWithIvBlockLenError>
+    {
+        use super::InOutLenInconsistentWithIvBlockLenError;
+        let num_before = u32::try_from(num_blocks)
+            .map_err(|_| InOutLenInconsistentWithIvBlockLenError::new())?;
+        let num_after = self
+            .len
+            .get()
+            .checked_sub(num_before)
+            .ok_or_else(InOutLenInconsistentWithIvBlockLenError::new)?;
+
+        let num_before = match NonZeroU32::new(num_before) {
+            Some(num_blocks) => num_blocks,
+            None => return Ok((None, Some(self))),
+        };
+        let num_after = match NonZeroU32::new(num_after) {
+            Some(num_after) => num_after,
+            None => return Ok((Some(self), None)),
+        };
+        let mut ctr = Counter(self.initial_iv.0);
+        let before = ctr
+            .increment_by(nonzerousize_from_nonzerou32(num_before))
+            .map_err(|_: CounterOverflowError| InOutLenInconsistentWithIvBlockLenError::new())?;
+        let after = Self {
+            initial_iv: Iv::new_less_safe(ctr.0),
+            len: num_after,
+        };
+        Ok((Some(before), Some(after)))
+    }
+
+    #[cfg(target_arch = "x86")]
+    pub(super) fn into_counter_less_safe(
+        self,
+        input_blocks: usize,
+    ) -> Result<Counter, super::InOutLenInconsistentWithIvBlockLenError> {
+        if input_blocks != self.len().get() {
+            return Err(super::InOutLenInconsistentWithIvBlockLenError::new());
+        }
+        Ok(Counter(self.initial_iv.0))
     }
 }
 
 /// The IV for a single block encryption.
 ///
 /// Intentionally not `Clone` to ensure each is used only once.
-pub struct Iv(Block);
+pub(in super::super) struct Iv(Block);
 
 impl Iv {
+    // This is "less safe" because it subverts the counter reuse protection.
+    // The caller needs to ensure that the IV isn't reused.
     pub(super) fn new_less_safe(value: Block) -> Self {
         Self(value)
     }
 
+    /// "Less safe" because it defeats attempts to use the type system to prevent reuse of the IV.
+    #[inline]
     pub(super) fn into_block_less_safe(self) -> Block {
         self.0
     }
 }
 
-impl From<Counter> for Iv {
-    fn from(counter: Counter) -> Self {
-        Self(counter.0)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::polyfill::usize_from_u32;
+
+    const DUMMY_ONCE_VALUE: [u8; NONCE_LEN] = [
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
+    ];
+    fn dummy_nonce() -> Nonce {
+        Nonce::assume_unique_for_key(DUMMY_ONCE_VALUE)
+    }
+
+    fn dummy_value(counter: [u8; 4]) -> [u8; BLOCK_LEN] {
+        let mut value = [0u8; BLOCK_LEN];
+        value[..NONCE_LEN].copy_from_slice(&DUMMY_ONCE_VALUE);
+        value[NONCE_LEN..].copy_from_slice(&counter);
+        value
+    }
+
+    const _1: NonZeroUsize = unwrap_const(NonZeroUsize::new(1));
+    const _2: NonZeroUsize = unwrap_const(NonZeroUsize::new(2));
+    const MAX: NonZeroUsize = unwrap_const(NonZeroUsize::new(usize_from_u32(u32::MAX)));
+    const MAX_MINUS_1: NonZeroUsize = unwrap_const(NonZeroUsize::new(MAX.get() - 1));
+    const MAX_MINUS_2: NonZeroUsize = unwrap_const(NonZeroUsize::new(MAX.get() - 2));
+
+    const USIZE_MAX: NonZeroUsize = unwrap_const(NonZeroUsize::new(usize::MAX));
+
+    #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
+    const MAX_PLUS_1: NonZeroUsize = unwrap_const(NonZeroUsize::new(MAX.get() + 1));
+
+    #[test]
+    fn one_is_one() {
+        let (one, _two) = Counter::one_two(dummy_nonce());
+        let as_block = one.into_block_less_safe();
+        assert_eq!(as_block, dummy_value([0, 0, 0, 1]));
+    }
+
+    #[test]
+    fn two_is_two() {
+        let (_one, two) = Counter::one_two(dummy_nonce());
+        let as_block = two.try_into_iv().ok().unwrap().into_block_less_safe();
+        assert_eq!(as_block, dummy_value([0, 0, 0, 2]));
+    }
+
+    #[test]
+    fn smallest_increment() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let _: IvBlock = ctr.increment_by(_1).ok().unwrap();
+        assert_eq!(
+            ctr.try_into_iv().ok().unwrap().into_block_less_safe(),
+            dummy_value([0, 0, 0, 3])
+        );
+    }
+
+    #[test]
+    fn carries() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let iv_block: IvBlock = ctr
+            .increment_by(NonZeroUsize::new(0xfe).unwrap())
+            .ok()
+            .unwrap();
+        assert_eq!(
+            iv_block.into_initial_iv().into_block_less_safe(),
+            dummy_value([0, 0, 0, 2])
+        );
+        let iv_block = ctr
+            .increment_by(NonZeroUsize::new(0xff_00).unwrap())
+            .ok()
+            .unwrap();
+        assert_eq!(
+            iv_block.into_initial_iv().into_block_less_safe(),
+            dummy_value([0, 0, 1, 0])
+        );
+        let iv_block = ctr
+            .increment_by(NonZeroUsize::new(0xff_00_00).unwrap())
+            .ok()
+            .unwrap();
+        assert_eq!(
+            iv_block.into_initial_iv().into_block_less_safe(),
+            dummy_value([0, 1, 0, 0])
+        );
+        let iv_block = ctr
+            .increment_by(NonZeroUsize::new(0xff_00_00_00).unwrap())
+            .ok()
+            .unwrap();
+        assert_eq!(
+            iv_block.into_initial_iv().into_block_less_safe(),
+            dummy_value([1, 0, 0, 0])
+        );
+        assert_eq!(&ctr.0[..], dummy_value([0, 0, 0, 0]));
+        assert!(ctr.try_into_iv().is_err()); // Because it is zero
+    }
+
+    #[test]
+    fn large_increment() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let _: IvBlock = ctr.increment_by(MAX_MINUS_2).ok().unwrap();
+        let iv_block = ctr.increment_by(_1).ok().unwrap();
+        assert_eq!(
+            iv_block.into_initial_iv().into_block_less_safe(),
+            dummy_value([0xff, 0xff, 0xff, 0xff])
+        );
+        assert!(ctr.increment_by(_1).is_err());
+    }
+
+    #[test]
+    fn larger_increment_then_increment() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let _: IvBlock = ctr.increment_by(MAX_MINUS_1).ok().unwrap();
+        assert_eq!(&ctr.0[..], dummy_value([0, 0, 0, 0]));
+        assert!(ctr.increment_by(MAX_MINUS_1).is_err());
+    }
+
+    #[test]
+    fn larger_increment_then_into_iv() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let _: IvBlock = ctr.increment_by(MAX_MINUS_1).ok().unwrap();
+        assert_eq!(&ctr.0[..], dummy_value([0, 0, 0, 0]));
+        assert!(ctr.try_into_iv().is_err());
+    }
+
+    #[test]
+    fn even_larger_increment() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        assert!(ctr.increment_by(MAX).is_err());
+    }
+
+    #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
+    #[test]
+    fn even_larger_still_increment() {
+        const MAX_PLUS_1: NonZeroUsize = unwrap_const(NonZeroUsize::new(MAX.get() + 1));
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        assert!(ctr.increment_by(MAX_PLUS_1).is_err());
+    }
+
+    #[test]
+    fn way_too_large_increment() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        assert!(ctr.increment_by(USIZE_MAX).is_err());
+    }
+
+    #[test]
+    fn split_at_start() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let iv_block = ctr.increment_by(_1).ok().unwrap();
+        let (a, b) = iv_block.split_at(0).ok().unwrap();
+        assert!(a.is_none());
+        assert_eq!(
+            b.unwrap().into_initial_iv().into_block_less_safe(),
+            dummy_value([0, 0, 0, 2])
+        );
+    }
+
+    #[test]
+    fn split_at_end() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let iv_block = ctr.increment_by(_1).ok().unwrap();
+        let (a, b) = iv_block.split_at(1).ok().unwrap();
+        assert_eq!(
+            a.unwrap().into_initial_iv().into_block_less_safe(),
+            dummy_value([0, 0, 0, 2])
+        );
+        assert!(b.is_none());
+    }
+
+    #[test]
+    fn split_at_middle() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let iv_block = ctr.increment_by(_2).ok().unwrap();
+        let (a, b) = iv_block.split_at(1).ok().unwrap();
+        assert_eq!(
+            a.unwrap().into_initial_iv().into_block_less_safe(),
+            dummy_value([0, 0, 0, 2])
+        );
+        assert_eq!(
+            b.unwrap().into_initial_iv().into_block_less_safe(),
+            dummy_value([0, 0, 0, 3])
+        );
+    }
+
+    #[test]
+    fn split_at_overflow() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let iv_block = ctr.increment_by(_1).ok().unwrap();
+        assert!(iv_block.split_at(2).is_err());
+    }
+
+    #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
+    #[test]
+    fn split_at_u32_max_plus_1() {
+        let (_, mut ctr) = Counter::one_two(dummy_nonce());
+        let iv_block = ctr.increment_by(MAX_MINUS_2).ok().unwrap();
+        assert!(iv_block.split_at(MAX_PLUS_1.get()).is_err());
     }
 }

--- a/src/aead/aes/fallback.rs
+++ b/src/aead/aes/fallback.rs
@@ -12,7 +12,10 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, AES_KEY};
+use super::{
+    Block, EncryptBlock, EncryptCtr32, InOutLenInconsistentWithIvBlockLenError, Iv, IvBlock,
+    KeyBytes, AES_KEY,
+};
 use crate::error;
 use core::ops::RangeFrom;
 
@@ -39,9 +42,20 @@ impl EncryptBlock for Key {
 }
 
 impl EncryptCtr32 for Key {
-    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+    fn ctr32_encrypt_within(
+        &self,
+        in_out: &mut [u8],
+        src: RangeFrom<usize>,
+        iv_block: IvBlock,
+    ) -> Result<(), InOutLenInconsistentWithIvBlockLenError> {
         unsafe {
-            ctr32_encrypt_blocks!(aes_nohw_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr)
+            ctr32_encrypt_blocks!(
+                aes_nohw_ctr32_encrypt_blocks,
+                in_out,
+                src,
+                &self.inner,
+                iv_block
+            )
         }
     }
 }

--- a/src/aead/aes/vp.rs
+++ b/src/aead/aes/vp.rs
@@ -19,7 +19,10 @@
     target_arch = "x86_64"
 ))]
 
-use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, AES_KEY};
+use super::{
+    Block, EncryptBlock, EncryptCtr32, InOutLenInconsistentWithIvBlockLenError, Iv, IvBlock,
+    KeyBytes, AES_KEY,
+};
 use crate::{cpu, error};
 use core::ops::RangeFrom;
 
@@ -57,34 +60,53 @@ impl EncryptBlock for Key {
 
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 impl EncryptCtr32 for Key {
-    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
-        unsafe { ctr32_encrypt_blocks!(vpaes_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr) }
+    fn ctr32_encrypt_within(
+        &self,
+        in_out: &mut [u8],
+        src: RangeFrom<usize>,
+        iv_block: IvBlock,
+    ) -> Result<(), InOutLenInconsistentWithIvBlockLenError> {
+        unsafe {
+            ctr32_encrypt_blocks!(
+                vpaes_ctr32_encrypt_blocks,
+                in_out,
+                src,
+                &self.inner,
+                iv_block
+            )
+        }
     }
 }
 
 #[cfg(target_arch = "arm")]
 impl EncryptCtr32 for Key {
-    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+    fn ctr32_encrypt_within(
+        &self,
+        in_out: &mut [u8],
+        src: RangeFrom<usize>,
+        iv_block: IvBlock,
+    ) -> Result<(), InOutLenInconsistentWithIvBlockLenError> {
         use super::{bs, BLOCK_LEN};
 
-        let in_out = {
-            let blocks = in_out[src.clone()].len() / BLOCK_LEN;
+        let blocks = in_out[src.clone()].len() / BLOCK_LEN;
 
-            // bsaes operates in batches of 8 blocks.
-            let bsaes_blocks = if blocks >= 8 && (blocks % 8) < 6 {
-                // It's faster to use bsaes for all the full batches and then
-                // switch to vpaes for the last partial batch (if any).
-                blocks - (blocks % 8)
-            } else if blocks >= 8 {
-                // It's faster to let bsaes handle everything including
-                // the last partial batch.
-                blocks
-            } else {
-                // It's faster to let vpaes handle everything.
-                0
-            };
-            let bsaes_in_out_len = bsaes_blocks * BLOCK_LEN;
+        // bsaes operates in batches of 8 blocks.
+        let bsaes_blocks = if blocks >= 8 && (blocks % 8) < 6 {
+            // It's faster to use bsaes for all the full batches and then
+            // switch to vpaes for the last partial batch (if any).
+            blocks - (blocks % 8)
+        } else if blocks >= 8 {
+            // It's faster to let bsaes handle everything including
+            // the last partial batch.
+            blocks
+        } else {
+            // It's faster to let vpaes handle everything.
+            0
+        };
+        let (bsaes_iv_block, vpaes_iv_block) = iv_block.split_at(bsaes_blocks)?;
+        let bsaes_in_out_len = bsaes_blocks * BLOCK_LEN;
 
+        if let Some(iv_block) = bsaes_iv_block {
             // SAFETY:
             //  * self.inner was initialized with `vpaes_set_encrypt_key` above,
             //    as required by `bsaes_ctr32_encrypt_blocks_with_vpaes_key`.
@@ -93,19 +115,30 @@ impl EncryptCtr32 for Key {
                     &mut in_out[..(src.start + bsaes_in_out_len)],
                     src.clone(),
                     &self.inner,
-                    ctr,
-                );
-            }
+                    iv_block,
+                )
+            }?;
+        }
 
-            &mut in_out[bsaes_in_out_len..]
-        };
+        if let Some(iv_block) = vpaes_iv_block {
+            let in_out = &mut in_out[bsaes_in_out_len..];
+            // SAFETY:
+            //  * self.inner was initialized with `vpaes_set_encrypt_key` above,
+            //    as required by `vpaes_ctr32_encrypt_blocks`.
+            //  * `vpaes_ctr32_encrypt_blocks` satisfies the contract for
+            //    `ctr32_encrypt_blocks`.
+            unsafe {
+                ctr32_encrypt_blocks!(
+                    vpaes_ctr32_encrypt_blocks,
+                    in_out,
+                    src,
+                    &self.inner,
+                    iv_block
+                )
+            }?;
+        }
 
-        // SAFETY:
-        //  * self.inner was initialized with `vpaes_set_encrypt_key` above,
-        //    as required by `vpaes_ctr32_encrypt_blocks`.
-        //  * `vpaes_ctr32_encrypt_blocks` satisfies the contract for
-        //    `ctr32_encrypt_blocks`.
-        unsafe { ctr32_encrypt_blocks!(vpaes_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr) }
+        Ok(())
     }
 }
 
@@ -122,9 +155,19 @@ impl EncryptBlock for Key {
 
 #[cfg(target_arch = "x86")]
 impl EncryptCtr32 for Key {
-    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+    fn ctr32_encrypt_within(
+        &self,
+        in_out: &mut [u8],
+        src: RangeFrom<usize>,
+        iv_block: IvBlock,
+    ) -> Result<(), InOutLenInconsistentWithIvBlockLenError> {
+        let (input_blocks, leftover): (&[[u8; super::BLOCK_LEN]], _) =
+            crate::polyfill::slice::as_chunks(&in_out[src.clone()]);
+        debug_assert_eq!(leftover.len(), 0);
+        let mut ctr = iv_block.into_counter_less_safe(input_blocks.len())?;
         super::super::shift::shift_full_blocks(in_out, src, |input| {
-            self.encrypt_iv_xor_block(ctr.increment(), *input)
+            self.encrypt_iv_xor_block(ctr.increment_unchecked_less_safe(), *input)
         });
+        Ok(())
     }
 }

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -120,7 +120,7 @@ pub(super) fn seal(
     nonce: Nonce,
     aad: Aad<&[u8]>,
     in_out: &mut [u8],
-) -> Result<Tag, error::Unspecified> {
+) -> Result<Tag, SealError> {
     let (tag_iv, ctr) = Counter::one_two(nonce);
 
     #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -130,7 +130,8 @@ pub(super) fn seal(
         #[cfg(target_arch = "x86_64")]
         DynKey::AesHwClMulAvxMovbe(Combo { aes_key, gcm_key }) => {
             use crate::c;
-            let mut auth = gcm::Context::new(gcm_key, aad, in_out.len())?;
+            let mut auth =
+                gcm::Context::new(gcm_key, aad, in_out.len()).map_err(SealError::from_gcm_error)?;
             let (htable, xi) = auth.inner();
             prefixed_extern! {
                 // `HTable` and `Xi` should be 128-bit aligned. TODO: Can we shrink `HTable`? The
@@ -168,7 +169,7 @@ pub(super) fn seal(
             if let Some(whole_len) = NonZeroUsize::new(whole.len()) {
                 let iv_block = ctr
                     .increment_by(whole_len)
-                    .map_err(|_: CounterOverflowError| error::Unspecified)?;
+                    .map_err(SealError::counter_overflow)?;
                 match aes_key.ctr32_encrypt_within(slice::flatten_mut(whole), 0.., iv_block) {
                     Ok(()) => {}
                     Result::<_, InOutLenInconsistentWithIvBlockLenError>::Err(_) => unreachable!(),
@@ -182,7 +183,8 @@ pub(super) fn seal(
         DynKey::AesHwClMul(Combo { aes_key, gcm_key }) => {
             use crate::bits::BitLength;
 
-            let mut auth = gcm::Context::new(gcm_key, aad, in_out.len())?;
+            let mut auth =
+                gcm::Context::new(gcm_key, aad, in_out.len()).map_err(SealError::from_gcm_error)?;
 
             let (whole, remainder) = slice::as_chunks_mut(in_out);
             let whole_block_bits = auth.in_out_whole_block_bits();
@@ -247,8 +249,9 @@ fn seal_strided<A: aes::EncryptBlock + aes::EncryptCtr32, G: gcm::UpdateBlocks +
     in_out: &mut [u8],
     mut ctr: Counter,
     tag_iv: aes::Iv,
-) -> Result<Tag, error::Unspecified> {
-    let mut auth = gcm::Context::new(gcm_key, aad, in_out.len())?;
+) -> Result<Tag, SealError> {
+    let mut auth =
+        gcm::Context::new(gcm_key, aad, in_out.len()).map_err(SealError::from_gcm_error)?;
 
     let (whole, remainder) = slice::as_chunks_mut(in_out);
 
@@ -256,7 +259,7 @@ fn seal_strided<A: aes::EncryptBlock + aes::EncryptCtr32, G: gcm::UpdateBlocks +
         let chunk_len = NonZeroUsize::new(chunk.len()).unwrap(); // Guaranteed by chunks_mut
         let iv_block = ctr
             .increment_by(chunk_len)
-            .map_err(|_: CounterOverflowError| error::Unspecified)?;
+            .map_err(SealError::counter_overflow)?;
         match aes_key.ctr32_encrypt_within(slice::flatten_mut(chunk), 0.., iv_block) {
             Ok(_) => {}
             Err(_) => unreachable!(),
@@ -273,11 +276,11 @@ fn seal_finish<A: aes::EncryptBlock, G: gcm::Gmult>(
     remainder: &mut [u8],
     ctr: Counter,
     tag_iv: aes::Iv,
-) -> Result<Tag, error::Unspecified> {
+) -> Result<Tag, SealError> {
     if !remainder.is_empty() {
         let mut input = ZERO_BLOCK;
         overwrite_at_start(&mut input, remainder);
-        let iv = ctr.try_into_iv().map_err(|_| error::Unspecified)?;
+        let iv = ctr.try_into_iv().map_err(SealError::counter_overflow)?;
         let mut output = aes_key.encrypt_iv_xor_block(iv, input);
         output[remainder.len()..].fill(0);
         auth.update_block(output);
@@ -287,6 +290,27 @@ fn seal_finish<A: aes::EncryptBlock, G: gcm::Gmult>(
     Ok(finish(aes_key, auth, tag_iv))
 }
 
+#[non_exhaustive]
+pub(super) enum SealError {
+    #[allow(dead_code)]
+    InputTooLong(gcm::Error),
+    CounterOverflow(CounterOverflowError),
+}
+
+impl SealError {
+    #[cold]
+    #[inline(never)]
+    fn from_gcm_error(error: gcm::Error) -> Self {
+        Self::InputTooLong(error)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn counter_overflow(counter_overflow_error: CounterOverflowError) -> Self {
+        Self::CounterOverflow(counter_overflow_error)
+    }
+}
+
 #[inline(never)]
 pub(super) fn open(
     Key(key): &Key,
@@ -294,10 +318,10 @@ pub(super) fn open(
     aad: Aad<&[u8]>,
     in_out: &mut [u8],
     src: RangeFrom<usize>,
-) -> Result<Tag, error::Unspecified> {
+) -> Result<Tag, OpenError> {
     // Check that `src` is in bounds.
     #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-    let input = in_out.get(src.clone()).ok_or(error::Unspecified)?;
+    let input = in_out.get(src.clone()).ok_or_else(OpenError::invalid_src)?;
 
     let (tag_iv, ctr) = Counter::one_two(nonce);
 
@@ -322,7 +346,8 @@ pub(super) fn open(
                     Xi: &mut gcm::Xi) -> c::size_t;
             }
 
-            let mut auth = gcm::Context::new(gcm_key, aad, input.len())?;
+            let mut auth =
+                gcm::Context::new(gcm_key, aad, input.len()).map_err(OpenError::from_gcm_error)?;
             let (htable, xi) = auth.inner();
             let processed = unsafe {
                 aesni_gcm_decrypt(
@@ -353,7 +378,7 @@ pub(super) fn open(
             let whole_len = if let Some(whole_len) = NonZeroUsize::new(whole.len()) {
                 let iv_block = ctr
                     .increment_by(whole_len)
-                    .map_err(|_: CounterOverflowError| error::Unspecified)?;
+                    .map_err(OpenError::counter_overflow)?;
                 auth.update_blocks(whole);
                 let whole_len = slice::flatten(whole).len();
                 match aes_key.ctr32_encrypt_within(
@@ -381,7 +406,8 @@ pub(super) fn open(
             use crate::bits::BitLength;
 
             let input_len = input.len();
-            let mut auth = gcm::Context::new(gcm_key, aad, input_len)?;
+            let mut auth =
+                gcm::Context::new(gcm_key, aad, input_len).map_err(OpenError::from_gcm_error)?;
 
             let remainder_len = input_len % BLOCK_LEN;
             let whole_len = input_len - remainder_len;
@@ -455,11 +481,11 @@ fn open_strided<A: aes::EncryptBlock + aes::EncryptCtr32, G: gcm::UpdateBlocks +
     src: RangeFrom<usize>,
     mut ctr: Counter,
     tag_iv: aes::Iv,
-) -> Result<Tag, error::Unspecified> {
-    let input = in_out.get(src.clone()).ok_or(error::Unspecified)?;
+) -> Result<Tag, OpenError> {
+    let input = in_out.get(src.clone()).ok_or_else(OpenError::invalid_src)?;
     let input_len = input.len();
 
-    let mut auth = gcm::Context::new(gcm_key, aad, input_len)?;
+    let mut auth = gcm::Context::new(gcm_key, aad, input_len).map_err(OpenError::from_gcm_error)?;
 
     let remainder_len = input_len % BLOCK_LEN;
     let whole_len = input_len - remainder_len;
@@ -483,7 +509,7 @@ fn open_strided<A: aes::EncryptBlock + aes::EncryptCtr32, G: gcm::UpdateBlocks +
             };
             let iv_block = ctr
                 .increment_by(num_blocks)
-                .map_err(|_| error::Unspecified)?;
+                .map_err(OpenError::counter_overflow)?;
 
             auth.update_blocks(ciphertext);
 
@@ -510,8 +536,8 @@ fn open_finish<A: aes::EncryptBlock, G: gcm::Gmult>(
     src: RangeFrom<usize>,
     ctr: Counter,
     tag_iv: aes::Iv,
-) -> Result<Tag, error::Unspecified> {
-    let iv = ctr.try_into_iv().map_err(|_| error::Unspecified)?;
+) -> Result<Tag, OpenError> {
+    let iv = ctr.try_into_iv().map_err(OpenError::counter_overflow)?;
     shift::shift_partial((src.start, remainder), |remainder| {
         let mut input = ZERO_BLOCK;
         overwrite_at_start(&mut input, remainder);
@@ -529,6 +555,34 @@ fn finish<A: aes::EncryptBlock, G: gcm::Gmult>(
 ) -> Tag {
     // Finalize the tag and return it.
     gcm_ctx.pre_finish(|pre_tag| Tag(aes_key.encrypt_iv_xor_block(tag_iv, pre_tag)))
+}
+
+#[non_exhaustive]
+pub(super) enum OpenError {
+    #[allow(dead_code)]
+    InputTooLong(gcm::Error),
+    InvalidSrc,
+    CounterOverflow(CounterOverflowError),
+}
+
+impl OpenError {
+    #[cold]
+    #[inline(never)]
+    fn from_gcm_error(error: gcm::Error) -> Self {
+        Self::InputTooLong(error)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn counter_overflow(counter_overflow_error: CounterOverflowError) -> Self {
+        Self::CounterOverflow(counter_overflow_error)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn invalid_src() -> Self {
+        Self::InvalidSrc
+    }
 }
 
 pub(super) const MAX_IN_OUT_LEN: usize = super::max_input_len(BLOCK_LEN, 2);

--- a/src/aead/algorithm.rs
+++ b/src/aead/algorithm.rs
@@ -193,7 +193,7 @@ fn aes_gcm_seal(
         KeyInner::AesGcm(key) => key,
         _ => unreachable!(),
     };
-    aes_gcm::seal(key, nonce, aad, in_out)
+    aes_gcm::seal(key, nonce, aad, in_out).map_err(|_: aes_gcm::SealError| error::Unspecified)
 }
 
 pub(super) fn aes_gcm_open(
@@ -208,7 +208,7 @@ pub(super) fn aes_gcm_open(
         KeyInner::AesGcm(key) => key,
         _ => unreachable!(),
     };
-    aes_gcm::open(key, nonce, aad, in_out, src)
+    aes_gcm::open(key, nonce, aad, in_out, src).map_err(|_: aes_gcm::OpenError| error::Unspecified)
 }
 
 /// ChaCha20-Poly1305 as described in [RFC 8439].

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -18,10 +18,13 @@
 //! Limbs ordered least-significant-limb to most-significant-limb. The bits
 //! limbs use the native endianness.
 
-use crate::{c, error, polyfill::ArrayFlatMap};
+use crate::{
+    c, error,
+    polyfill::{usize_from_u32, ArrayFlatMap},
+};
 
 #[cfg(any(test, feature = "alloc"))]
-use crate::{bits, constant_time, polyfill::usize_from_u32};
+use crate::{bits, constant_time};
 
 #[cfg(feature = "alloc")]
 use core::num::Wrapping;

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -15,6 +15,8 @@
 //! Polyfills for functionality that will (hopefully) be added to Rust's
 //! standard library soon.
 
+use core::num::{NonZeroU32, NonZeroUsize};
+
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 #[inline(always)]
 pub const fn u64_from_usize(x: usize) -> u64 {
@@ -24,6 +26,12 @@ pub const fn u64_from_usize(x: usize) -> u64 {
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 pub const fn usize_from_u32(x: u32) -> usize {
     x as usize
+}
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+pub const fn nonzerousize_from_nonzerou32(x: NonZeroU32) -> NonZeroUsize {
+    let value = usize_from_u32(x.get());
+    unsafe { NonZeroUsize::new_unchecked(value) }
 }
 
 #[cfg(all(target_arch = "aarch64", target_pointer_width = "64"))]


### PR DESCRIPTION
Create a more robust internal API for counter/nonce/IV management that makes the usage within AES-GCM more clearly correct. The new design is easier to test.