### PR TITLE
Split out wasm32_unknown_unknown_js feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,8 @@ std = ["alloc"]
 unstable-testing-arm-no-hw = []
 unstable-testing-arm-no-neon = []
 test_logging = []
-wasm32_unknown_unknown_js = ["getrandom/js"]
+wasm32_unknown_unknown_js = ["getrandom/js", "wasm32_unknown_unknown"]
+wasm32_unknown_unknown = []
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,10 @@
 //!         require an operating environment of some kind. This has no effect
 //!         for any other target. This enables the `getrandom` crate's `js`
 //!         feature.
+//! <tr><td><code>wasm32_unknown_unknown</code>
+//!     <td>When this feature is enabled, for the wasm32-unknown-unknown target,
+//!         `getrandom` is used and assumed to be preconfigured in a WASM
+//!         environment. This has no effect for any other target.
 //! </table>
 
 // When running mk/package.sh, don't actually build any code.

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -153,7 +153,7 @@ impl crate::sealed::Sealed for SystemRandom {}
         target_arch = "wasm32",
         any(
             target_os = "wasi",
-            all(target_os = "unknown", feature = "wasm32_unknown_unknown_js")
+            all(target_os = "unknown", feature = "wasm32_unknown_unknown")
         )
     ),
 ))]


### PR DESCRIPTION
This PR:
* Adds a feature `wasm32_unknown_unknown`, which is identical to `wasm32_unknown_unknown_js`, except it doesn't enable the `getrandom` crate features.
* This allows WASM-only environments to implement their own context-specific rand functionality and register it with `getrandom`.