### PR TITLE
Allow loading ECDSA private key from PKCS8 file missing public key

### DIFF
--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -142,7 +142,7 @@ impl EcdsaKeyPair {
         let key_pair = ec::suite_b::key_pair_from_bytes(
             alg.curve,
             untrusted::Input::from(private_key),
-            untrusted::Input::from(public_key),
+            Some(untrusted::Input::from(public_key)),
             cpu::features(),
         )?;
         Self::new(alg, key_pair, rng)


### PR DESCRIPTION
PKCS8 encoded pem files have an option to have the public key in the same file as the private key.

Not all pem files will have it, and the public key can be derived from the private key anyway.

Fixes #2133

I agree to license my contributions to each file under the terms given at the top of each file I changed.