### PR TITLE
Remove needless as_bytes() call

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -204,7 +204,7 @@ impl TestCase {
         let result = if s.starts_with('\"') {
             // The value is a quoted UTF-8 string.
 
-            let mut bytes = Vec::with_capacity(s.as_bytes().len() - 2);
+            let mut bytes = Vec::with_capacity(s.len() - 2);
             let mut s = s.as_bytes().iter().skip(1);
             loop {
                 let b = match s.next() {


### PR DESCRIPTION
`String::len()` already returns the number of bytes in the string.