### PR TITLE
Derive SecureRandom for SystemRandom on Fuchsia

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -128,6 +128,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "android",
     target_os = "dragonfly",
     target_os = "freebsd",
+    target_os = "fuchsia",
     target_os = "haiku",
     target_os = "hermit",
     target_os = "hurd",


### PR DESCRIPTION
The `getrandom::getrandom` on Fuchsia uses `zx_cprng_draw` to get cryptographically secure random data, which can be seen [here](https://github.com/rust-random/getrandom/blob/master/src/fuchsia.rs).