### PR TITLE
aead: Support stacked borrows model using a new `InOut` type.

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 Brian Smith.
+// Copyright 2015-2024 Brian Smith.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -34,6 +34,7 @@ pub use self::{
     sealing_key::SealingKey,
     unbound_key::UnboundKey,
 };
+use inout::InOut;
 
 /// A sequences of unique nonces.
 ///
@@ -175,6 +176,7 @@ mod chacha;
 mod chacha20_poly1305;
 pub mod chacha20_poly1305_openssh;
 mod gcm;
+mod inout;
 mod less_safe_key;
 mod nonce;
 mod opening_key;

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -12,14 +12,13 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{nonce::Nonce, quic::Sample, NONCE_LEN};
+use super::{nonce::Nonce, quic::Sample, InOut, NONCE_LEN};
 use crate::{
     constant_time,
     cpu::{self, GetFeature as _},
     error,
 };
 use cfg_if::cfg_if;
-use core::ops::RangeFrom;
 
 pub(super) use ffi::Counter;
 
@@ -158,7 +157,7 @@ pub(super) trait EncryptBlock {
 }
 
 pub(super) trait EncryptCtr32 {
-    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter);
+    fn ctr32_encrypt_within(&self, in_out: InOut<'_>, ctr: &mut Counter);
 }
 
 #[allow(dead_code)]
@@ -178,7 +177,7 @@ fn encrypt_iv_xor_block_using_encrypt_block(
 #[allow(dead_code)]
 fn encrypt_iv_xor_block_using_ctr32(key: &impl EncryptCtr32, iv: Iv, mut block: Block) -> Block {
     let mut ctr = Counter(iv.0); // This is OK because we're only encrypting one block.
-    key.ctr32_encrypt_within(&mut block, 0.., &mut ctr);
+    key.ctr32_encrypt_within(InOut::in_place(&mut block), &mut ctr);
     block
 }
 

--- a/src/aead/aes/bs.rs
+++ b/src/aead/aes/bs.rs
@@ -14,8 +14,7 @@
 
 #![cfg(target_arch = "arm")]
 
-use super::{Counter, AES_KEY};
-use core::ops::RangeFrom;
+use super::{Counter, InOut, AES_KEY};
 
 /// SAFETY:
 ///   * The caller must ensure that if blocks > 0 then either `input` and
@@ -28,8 +27,7 @@ use core::ops::RangeFrom;
 ///   * Upon returning, `blocks` blocks will have been read from `input` and
 ///     written to `output`.
 pub(super) unsafe fn ctr32_encrypt_blocks_with_vpaes_key(
-    in_out: &mut [u8],
-    src: RangeFrom<usize>,
+    in_out: InOut<'_>,
     vpaes_key: &AES_KEY,
     ctr: &mut Counter,
 ) {
@@ -57,6 +55,6 @@ pub(super) unsafe fn ctr32_encrypt_blocks_with_vpaes_key(
     //  * `bsaes_ctr32_encrypt_blocks` satisfies the contract for
     //    `ctr32_encrypt_blocks`.
     unsafe {
-        ctr32_encrypt_blocks!(bsaes_ctr32_encrypt_blocks, in_out, src, &bsaes_key, ctr);
+        ctr32_encrypt_blocks!(bsaes_ctr32_encrypt_blocks, in_out, &bsaes_key, ctr);
     }
 }

--- a/src/aead/aes/fallback.rs
+++ b/src/aead/aes/fallback.rs
@@ -12,9 +12,8 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, AES_KEY};
+use super::{Block, Counter, EncryptBlock, EncryptCtr32, InOut, Iv, KeyBytes, AES_KEY};
 use crate::error;
-use core::ops::RangeFrom;
 
 #[derive(Clone)]
 pub struct Key {
@@ -39,9 +38,7 @@ impl EncryptBlock for Key {
 }
 
 impl EncryptCtr32 for Key {
-    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
-        unsafe {
-            ctr32_encrypt_blocks!(aes_nohw_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr)
-        }
+    fn ctr32_encrypt_within(&self, in_out: InOut<'_>, ctr: &mut Counter) {
+        unsafe { ctr32_encrypt_blocks!(aes_nohw_ctr32_encrypt_blocks, in_out, &self.inner, ctr) }
     }
 }

--- a/src/aead/aes/hw.rs
+++ b/src/aead/aes/hw.rs
@@ -14,9 +14,8 @@
 
 #![cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 
-use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, AES_KEY};
+use super::{Block, Counter, EncryptBlock, EncryptCtr32, InOut, Iv, KeyBytes, AES_KEY};
 use crate::{cpu, error};
-use core::ops::RangeFrom;
 
 #[cfg(target_arch = "aarch64")]
 pub(in super::super) type RequiredCpuFeatures = cpu::arm::Aes;
@@ -56,9 +55,9 @@ impl EncryptBlock for Key {
 }
 
 impl EncryptCtr32 for Key {
-    fn ctr32_encrypt_within(&self, in_out: &mut [u8], src: RangeFrom<usize>, ctr: &mut Counter) {
+    fn ctr32_encrypt_within(&self, in_out: InOut<'_>, ctr: &mut Counter) {
         #[cfg(target_arch = "x86_64")]
         let _: cpu::Features = cpu::features();
-        unsafe { ctr32_encrypt_blocks!(aes_hw_ctr32_encrypt_blocks, in_out, src, &self.inner, ctr) }
+        unsafe { ctr32_encrypt_blocks!(aes_hw_ctr32_encrypt_blocks, in_out, &self.inner, ctr) }
     }
 }

--- a/src/aead/inout.rs
+++ b/src/aead/inout.rs
@@ -1,0 +1,72 @@
+// Copyright 2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use crate::error;
+use core::ops::RangeFrom;
+
+pub struct InOut<'i> {
+    in_out: &'i mut [u8],
+    src: RangeFrom<usize>,
+}
+
+impl<'i> InOut<'i> {
+    pub fn in_place(in_out: &'i mut [u8]) -> Self {
+        Self { in_out, src: 0.. }
+    }
+
+    pub fn overlapping(in_out: &'i mut [u8], src: RangeFrom<usize>) -> Result<Self, SrcIndexError> {
+        match in_out.get(src.clone()) {
+            Some(_) => Ok(Self { in_out, src }),
+            None => Err(SrcIndexError::new(src)),
+        }
+    }
+
+    #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+    pub fn into_slice_src_mut(self) -> (&'i mut [u8], RangeFrom<usize>) {
+        (self.in_out, self.src)
+    }
+}
+
+impl InOut<'_> {
+    pub fn len(&self) -> usize {
+        self.in_out[self.src.clone()].len()
+    }
+    pub fn input_output_len(&mut self) -> (*const u8, *mut u8, usize) {
+        let len = self.len();
+        let output = self.in_out.as_mut_ptr();
+        // TODO: MSRV(1.65): use `output.cast_const()`
+        let output_const: *const u8 = output;
+        // SAFETY: The constructor ensures that `src` is a valid range.
+        // Equivalent to `self.in_out[src.clone()].as_ptr()` but without
+        // worries about compatibility with the stacked borrows model.
+        let input = unsafe { output_const.add(self.src.start) };
+        (input, output, len)
+    }
+}
+
+#[derive(Debug)]
+pub struct SrcIndexError(#[allow(dead_code)] RangeFrom<usize>);
+
+impl SrcIndexError {
+    #[cold]
+    fn new(src: RangeFrom<usize>) -> Self {
+        Self(src)
+    }
+}
+
+impl From<SrcIndexError> for error::Unspecified {
+    fn from(_: SrcIndexError) -> Self {
+        Self
+    }
+}

--- a/src/aead/shift.rs
+++ b/src/aead/shift.rs
@@ -16,10 +16,10 @@ use crate::polyfill::sliceutil::overwrite_at_start;
 
 #[cfg(target_arch = "x86")]
 pub fn shift_full_blocks<const BLOCK_LEN: usize>(
-    in_out: &mut [u8],
-    src: core::ops::RangeFrom<usize>,
+    in_out: super::InOut<'_>,
     mut transform: impl FnMut(&[u8; BLOCK_LEN]) -> [u8; BLOCK_LEN],
 ) {
+    let (in_out, src) = in_out.into_slice_src_mut();
     let in_out_len = in_out[src.clone()].len();
 
     for i in (0..in_out_len).step_by(BLOCK_LEN) {


### PR DESCRIPTION
Notably, `InOut::input_output_len` constructs the `input` pointer from the `output` pointer in a way that safely avoids any concerns about the order of borrowing the (now implicit) input slice and output slice, and in particular whether any such borrowing invalidates any pointers derived from those slices.

Practically, this helps people who are using Miri in its default stacked borrows mode (as opposed to the tree borrows mode) verify the memory safety of our code.