### PR TITLE
arithmetic: Remove `PartialEq` & `Debug` for  `LimbMask`.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -46,7 +46,7 @@ use crate::{
     arithmetic::montgomery::*,
     bits::BitLength,
     c, error,
-    limb::{self, Limb, LimbMask, LIMB_BITS},
+    limb::{self, Limb, LIMB_BITS},
 };
 use alloc::vec;
 use core::{marker::PhantomData, num::NonZeroU64};
@@ -85,7 +85,7 @@ impl<M, E> Clone for Elem<M, E> {
 impl<M, E> Elem<M, E> {
     #[inline]
     pub fn is_zero(&self) -> bool {
-        limb::limbs_are_zero_constant_time(&self.limbs) == LimbMask::True
+        limb::limbs_are_zero_constant_time(&self.limbs).leak()
     }
 }
 
@@ -132,7 +132,7 @@ impl<M> Elem<M, Unencoded> {
     }
 
     fn is_one(&self) -> bool {
-        limb::limbs_equal_limb_constant_time(&self.limbs, 1) == LimbMask::True
+        limb::limbs_equal_limb_constant_time(&self.limbs, 1).leak()
     }
 }
 
@@ -696,7 +696,7 @@ pub fn elem_verify_equal_consttime<M, E>(
     a: &Elem<M, E>,
     b: &Elem<M, E>,
 ) -> Result<(), error::Unspecified> {
-    if limb::limbs_equal_limbs_consttime(&a.limbs, &b.limbs) == LimbMask::True {
+    if limb::limbs_equal_limbs_consttime(&a.limbs, &b.limbs).leak() {
         Ok(())
     } else {
         Err(error::Unspecified)

--- a/src/arithmetic/bigint/boxed_limbs.rs
+++ b/src/arithmetic/bigint/boxed_limbs.rs
@@ -15,7 +15,7 @@
 use super::Modulus;
 use crate::{
     error,
-    limb::{self, Limb, LimbMask, LIMB_BYTES},
+    limb::{self, Limb, LIMB_BYTES},
 };
 use alloc::{boxed::Box, vec};
 use core::{
@@ -88,7 +88,7 @@ impl<M> BoxedLimbs<M> {
     ) -> Result<Self, error::Unspecified> {
         let mut r = Self::zero(m.limbs().len());
         limb::parse_big_endian_and_pad_consttime(input, &mut r)?;
-        if limb::limbs_less_than_limbs_consttime(&r, m.limbs()) != LimbMask::True {
+        if !limb::limbs_less_than_limbs_consttime(&r, m.limbs()).leak() {
             return Err(error::Unspecified);
         }
         Ok(r)

--- a/src/arithmetic/bigint/modulusvalue.rs
+++ b/src/arithmetic/bigint/modulusvalue.rs
@@ -19,7 +19,7 @@ use super::{
 use crate::{
     bits::BitLength,
     error,
-    limb::{self, Limb, LimbMask},
+    limb::{self, Limb},
 };
 
 /// `OwnedModulus`, without the overhead of Montgomery multiplication support.
@@ -47,10 +47,10 @@ impl<M> OwnedModulusValue<M> {
         if n.len() < MODULUS_MIN_LIMBS {
             return Err(error::KeyRejected::unexpected_error());
         }
-        if limb::limbs_are_even_constant_time(&n) != LimbMask::False {
+        if limb::limbs_are_even_constant_time(&n).leak() {
             return Err(error::KeyRejected::invalid_component());
         }
-        if limb::limbs_less_than_limb_constant_time(&n, 3) != LimbMask::False {
+        if limb::limbs_less_than_limb_constant_time(&n, 3).leak() {
             return Err(error::KeyRejected::unexpected_error());
         }
 
@@ -62,7 +62,7 @@ impl<M> OwnedModulusValue<M> {
     pub fn verify_less_than<L>(&self, l: &Modulus<L>) -> Result<(), error::Unspecified> {
         if self.len_bits() > l.len_bits()
             || (self.limbs.len() == l.limbs().len()
-                && limb::limbs_less_than_limbs_consttime(&self.limbs, l.limbs()) != LimbMask::True)
+                && !limb::limbs_less_than_limbs_consttime(&self.limbs, l.limbs()).leak())
         {
             return Err(error::Unspecified);
         }

--- a/src/arithmetic/bigint/private_exponent.rs
+++ b/src/arithmetic/bigint/private_exponent.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{limb, BoxedLimbs, Limb, LimbMask, Modulus};
+use super::{limb, BoxedLimbs, Limb, Modulus};
 use crate::error;
 use alloc::boxed::Box;
 
@@ -36,7 +36,7 @@ impl PrivateExponent {
         // `p - 1` and so we know `dP < p - 1`.
         //
         // Further we know `dP != 0` because `dP` is not even.
-        if limb::limbs_are_even_constant_time(&dP) != LimbMask::False {
+        if limb::limbs_are_even_constant_time(&dP).leak() {
             return Err(error::Unspecified);
         }
 

--- a/src/ec/suite_b.rs
+++ b/src/ec/suite_b.rs
@@ -15,7 +15,7 @@
 //! Elliptic curve operations on P-256 & P-384.
 
 use self::ops::*;
-use crate::{arithmetic::montgomery::*, cpu, ec, error, io::der, limb::LimbMask, pkcs8};
+use crate::{arithmetic::montgomery::*, cpu, ec, error, io::der, pkcs8};
 
 // NIST SP 800-56A Step 3: "If q is an odd prime p, verify that
 // yQ**2 = xQ**3 + axQ + b in GF(p), where the arithmetic is performed modulo
@@ -146,7 +146,7 @@ fn verify_affine_point_is_on_the_curve_scaled(
     ops.elem_mul(&mut rhs, x);
     ops.elem_add(&mut rhs, b_scaled);
 
-    if ops.elems_are_equal(&lhs, &rhs) != LimbMask::True {
+    if !ops.elems_are_equal(&lhs, &rhs).leak() {
         return Err(error::Unspecified);
     }
 

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -128,7 +128,7 @@ impl CommonOps {
 
     #[inline]
     pub fn is_zero<M, E: Encoding>(&self, a: &elem::Elem<M, E>) -> bool {
-        limbs_are_zero_constant_time(&a.limbs[..self.num_limbs]) == LimbMask::True
+        limbs_are_zero_constant_time(&a.limbs[..self.num_limbs]).leak()
     }
 
     pub fn elem_verify_is_not_zero(&self, a: &Elem<R>) -> Result<(), error::Unspecified> {


### PR DESCRIPTION
Add `LimbMask::leak()` and change all callers to use it. This proactively prevents accidental leakage of the `LimbMask` value and makes it easier to audit the code for places where we intentionally leak the value of a `LimbMask`.

Within the tests, use a `#[cfg(test)]-only wrapper `leak_in_test` to make it easier to see that those leaks are uninteresting.