### PR TITLE
ec: Use `LeakyLimb` for public values.

### DIFF
--- a/mk/generate_curves.py
+++ b/mk/generate_curves.py
@@ -44,10 +44,10 @@ pub static COMMON_OPS: CommonOps = CommonOps {
         p: limbs_from_hex("%(q)x"),
         rr: limbs_from_hex(%(q_rr)s),
     },
-    n: Elem::from_hex("%(n)x"),
+    n: PublicElem::from_hex("%(n)x"),
 
-    a: Elem::from_hex(%(a)s),
-    b: Elem::from_hex(%(b)s),
+    a: PublicElem::from_hex(%(a)s),
+    b: PublicElem::from_hex(%(b)s),
 
     elem_mul_mont: p%(bits)s_elem_mul_mont,
     elem_sqr_mont: p%(bits)s_elem_sqr_mont,
@@ -56,8 +56,8 @@ pub static COMMON_OPS: CommonOps = CommonOps {
 };
 
 pub(super) static GENERATOR: (Elem<R>, Elem<R>) = (
-    Elem::from_hex(%(Gx)s),
-    Elem::from_hex(%(Gy)s),
+    PublicElem::from_hex(%(Gx)s),
+    PublicElem::from_hex(%(Gy)s),
 );
 
 pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
@@ -93,7 +93,8 @@ fn p%(bits)d_elem_inv_squared(a: &Elem<R>) -> Elem<R> {
 
 fn p%(bits)s_point_mul_base_impl(a: &Scalar) -> Point {
     // XXX: Not efficient. TODO: Precompute multiples of the generator.
-    PRIVATE_KEY_OPS.point_mul(a, &GENERATOR)
+    let generator = (Elem::from(&GENERATOR.0), Elem::from(&GENERATOR.1));
+    PRIVATE_KEY_OPS.point_mul(a, &generator)
 }
 
 pub static PUBLIC_KEY_OPS: PublicKeyOps = PublicKeyOps {
@@ -112,7 +113,7 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
         twin_mul_inefficient(&PRIVATE_KEY_OPS, g_scalar, p_scalar, p_xy, cpu)
     },
 
-    q_minus_n: Elem::from_hex("%(q_minus_n)x"),
+    q_minus_n: PublicElem::from_hex("%(q_minus_n)x"),
 
     // TODO: Use an optimized variable-time implementation.
     scalar_inv_to_mont_vartime: |s| PRIVATE_SCALAR_OPS.scalar_inv_to_mont(s),
@@ -121,7 +122,7 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
 pub static PRIVATE_SCALAR_OPS: PrivateScalarOps = PrivateScalarOps {
     scalar_ops: &SCALAR_OPS,
 
-    oneRR_mod_n: Scalar::from_hex(%(oneRR_mod_n)s),
+    oneRR_mod_n: PublicScalar::from_hex(%(oneRR_mod_n)s),
     scalar_inv_to_mont: p%(bits)s_scalar_inv_to_mont,
 };
 

--- a/src/arithmetic/constant.rs
+++ b/src/arithmetic/constant.rs
@@ -1,4 +1,4 @@
-use crate::limb::Limb;
+use crate::limb::LeakyLimb;
 use core::mem::size_of;
 
 const fn parse_digit(d: u8) -> u8 {
@@ -10,16 +10,16 @@ const fn parse_digit(d: u8) -> u8 {
 }
 
 // TODO: this would be nicer as a trait, but currently traits don't support const functions
-pub const fn limbs_from_hex<const LIMBS: usize>(hex: &str) -> [Limb; LIMBS] {
+pub const fn limbs_from_hex<const LIMBS: usize>(hex: &str) -> [LeakyLimb; LIMBS] {
     let hex = hex.as_bytes();
     let mut limbs = [0; LIMBS];
-    let limb_nibbles = size_of::<Limb>() * 2;
+    let limb_nibbles = size_of::<LeakyLimb>() * 2;
     let mut i = 0;
 
     while i < hex.len() {
         let char = hex[hex.len() - 1 - i];
         let val = parse_digit(char);
-        limbs[i / limb_nibbles] |= (val as Limb) << ((i % limb_nibbles) * 4);
+        limbs[i / limb_nibbles] |= (val as LeakyLimb) << ((i % limb_nibbles) * 4);
         i += 1;
     }
 

--- a/src/ec/curve25519/scalar.rs
+++ b/src/ec/curve25519/scalar.rs
@@ -25,6 +25,7 @@ impl Scalar {
     pub fn from_bytes_checked(bytes: [u8; SCALAR_LEN]) -> Result<Self, error::Unspecified> {
         const ORDER: [limb::Limb; SCALAR_LEN / limb::LIMB_BYTES] =
             limbs_from_hex("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed");
+        let order = ORDER.map(limb::Limb::from);
 
         // `bytes` is in little-endian order.
         let mut reversed = bytes;
@@ -34,7 +35,7 @@ impl Scalar {
         limb::parse_big_endian_in_range_and_pad_consttime(
             untrusted::Input::from(&reversed),
             limb::AllowZero::Yes,
-            &ORDER,
+            &order,
             &mut limbs,
         )?;
 

--- a/src/ec/suite_b.rs
+++ b/src/ec/suite_b.rs
@@ -33,7 +33,12 @@ fn verify_affine_point_is_on_the_curve(
     ops: &CommonOps,
     (x, y): (&Elem<R>, &Elem<R>),
 ) -> Result<(), error::Unspecified> {
-    verify_affine_point_is_on_the_curve_scaled(ops, (x, y), &ops.a, &ops.b)
+    verify_affine_point_is_on_the_curve_scaled(
+        ops,
+        (x, y),
+        &Elem::from(&ops.a),
+        &Elem::from(&ops.b),
+    )
 }
 
 // Use `verify_affine_point_is_on_the_curve` instead of this function whenever
@@ -101,9 +106,9 @@ fn verify_jacobian_point_is_on_the_curve(
     //
     let z2 = ops.elem_squared(&z);
     let z4 = ops.elem_squared(&z2);
-    let z4_a = ops.elem_product(&z4, &ops.a);
+    let z4_a = ops.elem_product(&z4, &Elem::from(&ops.a));
     let z6 = ops.elem_product(&z4, &z2);
-    let z6_b = ops.elem_product(&z6, &ops.b);
+    let z6_b = ops.elem_product(&z6, &Elem::from(&ops.b));
     verify_affine_point_is_on_the_curve_scaled(ops, (&x, &y), &z4_a, &z6_b)?;
     Ok(z2)
 }

--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -159,7 +159,8 @@ impl EcdsaVerificationAlgorithm {
             return Ok(());
         }
         if self.ops.elem_less_than(&r, &self.ops.q_minus_n) {
-            self.ops.scalar_ops.common.elem_add(&mut r, self.ops.n());
+            let n = Elem::from(self.ops.n());
+            self.ops.scalar_ops.common.elem_add(&mut r, &n);
             if sig_r_equals_x(self.ops, &r, &x, &z2) {
                 return Ok(());
             }

--- a/src/ec/suite_b/ops/p256.rs
+++ b/src/ec/suite_b/ops/p256.rs
@@ -24,10 +24,10 @@ pub static COMMON_OPS: CommonOps = CommonOps {
         p: limbs_from_hex("ffffffff00000001000000000000000000000000ffffffffffffffffffffffff"),
         rr: limbs_from_hex("4fffffffdfffffffffffffffefffffffbffffffff0000000000000003"),
     },
-    n: Elem::from_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
+    n: PublicElem::from_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
 
-    a: Elem::from_hex("fffffffc00000004000000000000000000000003fffffffffffffffffffffffc"),
-    b: Elem::from_hex("dc30061d04874834e5a220abf7212ed6acf005cd78843090d89cdf6229c4bddf"),
+    a: PublicElem::from_hex("fffffffc00000004000000000000000000000003fffffffffffffffffffffffc"),
+    b: PublicElem::from_hex("dc30061d04874834e5a220abf7212ed6acf005cd78843090d89cdf6229c4bddf"),
 
     elem_mul_mont: p256_mul_mont,
     elem_sqr_mont: p256_sqr_mont,
@@ -36,9 +36,9 @@ pub static COMMON_OPS: CommonOps = CommonOps {
 };
 
 #[cfg(test)]
-pub(super) static GENERATOR: (Elem<R>, Elem<R>) = (
-    Elem::from_hex("18905f76a53755c679fb732b7762251075ba95fc5fedb60179e730d418a9143c"),
-    Elem::from_hex("8571ff1825885d85d2e88688dd21f3258b4ab8e4ba19e45cddf25357ce95560a"),
+pub(super) static GENERATOR: (PublicElem<R>, PublicElem<R>) = (
+    PublicElem::from_hex("18905f76a53755c679fb732b7762251075ba95fc5fedb60179e730d418a9143c"),
+    PublicElem::from_hex("8571ff1825885d85d2e88688dd21f3258b4ab8e4ba19e45cddf25357ce95560a"),
 );
 
 pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
@@ -129,7 +129,7 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
         twin_mul_inefficient(&PRIVATE_KEY_OPS, g_scalar, p_scalar, p_xy, cpu)
     },
 
-    q_minus_n: Elem::from_hex("4319055358e8617b0c46353d039cdaae"),
+    q_minus_n: PublicElem::from_hex("4319055358e8617b0c46353d039cdaae"),
 
     // TODO: Use an optimized variable-time implementation.
     scalar_inv_to_mont_vartime: |s, cpu| PRIVATE_SCALAR_OPS.scalar_inv_to_mont(s, cpu),
@@ -164,7 +164,7 @@ fn point_mul_base_vartime(g_scalar: &Scalar, _cpu: cpu::Features) -> Point {
 pub static PRIVATE_SCALAR_OPS: PrivateScalarOps = PrivateScalarOps {
     scalar_ops: &SCALAR_OPS,
 
-    oneRR_mod_n: Scalar::from_hex(
+    oneRR_mod_n: PublicScalar::from_hex(
         "66e12d94f3d956202845b2392b6bec594699799c49bd6fa683244c95be79eea2",
     ),
     scalar_inv_to_mont: p256_scalar_inv_to_mont,

--- a/src/ec/suite_b/ops/p384.rs
+++ b/src/ec/suite_b/ops/p384.rs
@@ -24,10 +24,10 @@ pub static COMMON_OPS: CommonOps = CommonOps {
         p: limbs_from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff"),
         rr: limbs_from_hex("10000000200000000fffffffe000000000000000200000000fffffffe00000001"),
     },
-    n: Elem::from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973"),
+    n: PublicElem::from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973"),
 
-    a: Elem::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbfffffffc0000000000000003fffffffc"),
-    b: Elem::from_hex("cd08114b604fbff9b62b21f41f022094e3374bee94938ae277f2209b1920022ef729add87a4c32ec081188719d412dcc"),
+    a: PublicElem::from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbfffffffc0000000000000003fffffffc"),
+    b: PublicElem::from_hex("cd08114b604fbff9b62b21f41f022094e3374bee94938ae277f2209b1920022ef729add87a4c32ec081188719d412dcc"),
 
     elem_mul_mont: p384_elem_mul_mont,
     elem_sqr_mont: p384_elem_sqr_mont,
@@ -35,9 +35,9 @@ pub static COMMON_OPS: CommonOps = CommonOps {
     point_add_jacobian_impl: p384_point_add,
 };
 
-pub(super) static GENERATOR: (Elem<R>, Elem<R>) = (
-    Elem::from_hex("4d3aadc2299e1513812ff723614ede2b6454868459a30eff879c3afc541b4d6e20e378e2a0d6ce383dd0756649c0b528"),
-    Elem::from_hex("2b78abc25a15c5e9dd8002263969a840c6c3521968f4ffd98bade7562e83b050a1bfa8bf7bb4a9ac23043dad4b03a4fe"),
+pub(super) static GENERATOR: (PublicElem<R>, PublicElem<R>) = (
+    PublicElem::from_hex("4d3aadc2299e1513812ff723614ede2b6454868459a30eff879c3afc541b4d6e20e378e2a0d6ce383dd0756649c0b528"),
+    PublicElem::from_hex("2b78abc25a15c5e9dd8002263969a840c6c3521968f4ffd98bade7562e83b050a1bfa8bf7bb4a9ac23043dad4b03a4fe"),
 );
 
 pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
@@ -105,7 +105,8 @@ fn p384_elem_inv_squared(a: &Elem<R>, _cpu: cpu::Features) -> Elem<R> {
 
 fn p384_point_mul_base_impl(a: &Scalar, cpu: cpu::Features) -> Point {
     // XXX: Not efficient. TODO: Precompute multiples of the generator.
-    PRIVATE_KEY_OPS.point_mul(a, &GENERATOR, cpu)
+    let generator = (Elem::from(&GENERATOR.0), Elem::from(&GENERATOR.1));
+    PRIVATE_KEY_OPS.point_mul(a, &generator, cpu)
 }
 
 pub static PUBLIC_KEY_OPS: PublicKeyOps = PublicKeyOps {
@@ -124,7 +125,7 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
         twin_mul_inefficient(&PRIVATE_KEY_OPS, g_scalar, p_scalar, p_xy, cpu)
     },
 
-    q_minus_n: Elem::from_hex("389cb27e0bc8d21fa7e5f24cb74f58851313e696333ad68c"),
+    q_minus_n: PublicElem::from_hex("389cb27e0bc8d21fa7e5f24cb74f58851313e696333ad68c"),
 
     // TODO: Use an optimized variable-time implementation.
     scalar_inv_to_mont_vartime: |s, cpu| PRIVATE_SCALAR_OPS.scalar_inv_to_mont(s, cpu),
@@ -133,7 +134,7 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
 pub static PRIVATE_SCALAR_OPS: PrivateScalarOps = PrivateScalarOps {
     scalar_ops: &SCALAR_OPS,
 
-    oneRR_mod_n: Scalar::from_hex("c84ee012b39bf213fb05b7a28266895d40d49174aab1cc5bc3e483afcb82947ff3d81e5df1aa4192d319b2419b409a9"),
+    oneRR_mod_n: PublicScalar::from_hex("c84ee012b39bf213fb05b7a28266895d40d49174aab1cc5bc3e483afcb82947ff3d81e5df1aa4192d319b2419b409a9"),
     scalar_inv_to_mont: p384_scalar_inv_to_mont,
 };
 

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -28,6 +28,7 @@ use core::num::Wrapping;
 
 // XXX: Not correct for x32 ABIs.
 pub type Limb = constant_time::Word;
+pub type LeakyLimb = constant_time::LeakyWord;
 pub const LIMB_BITS: usize = usize_from_u32(Limb::BITS);
 pub const LIMB_BYTES: usize = (LIMB_BITS + 7) / 8;
 


### PR DESCRIPTION
Take a step toward making `Word` (and `Limb`) opaque types.

This adds some unnecessary copies but the overhead is negligible as those copies are outside of loops.