### PR TITLE
ec/suite_b: Optimize away slice bounds checks.

### DIFF
--- a/mk/generate_curves.py
+++ b/mk/generate_curves.py
@@ -36,8 +36,10 @@ use super::{
     elem_sqr_mul, elem_sqr_mul_acc, Modulus, *,
 };
 
+pub(super) const NUM_LIMBS: usize = (%(bits)d + LIMB_BITS - 1) / LIMB_BITS;
+
 pub static COMMON_OPS: CommonOps = CommonOps {
-    num_limbs: (%(bits)d + LIMB_BITS - 1) / LIMB_BITS,
+    num_limbs: elem::NumLimbs::P%(bits)s,
     order_bits: %(bits)d,
 
     q: Modulus {

--- a/src/ec/suite_b/ops/p256.rs
+++ b/src/ec/suite_b/ops/p256.rs
@@ -17,8 +17,10 @@ use super::{
     elem_sqr_mul, elem_sqr_mul_acc, Modulus, *,
 };
 
+pub(super) const NUM_LIMBS: usize = 256 / LIMB_BITS;
+
 pub static COMMON_OPS: CommonOps = CommonOps {
-    num_limbs: 256 / LIMB_BITS,
+    num_limbs: elem::NumLimbs::P256,
 
     q: Modulus {
         p: limbs_from_hex("ffffffff00000001000000000000000000000000ffffffffffffffffffffffff"),

--- a/src/ec/suite_b/ops/p384.rs
+++ b/src/ec/suite_b/ops/p384.rs
@@ -17,8 +17,10 @@ use super::{
     elem_sqr_mul, elem_sqr_mul_acc, Modulus, *,
 };
 
+pub(super) const NUM_LIMBS: usize = 384 / LIMB_BITS;
+
 pub static COMMON_OPS: CommonOps = CommonOps {
-    num_limbs: 384 / LIMB_BITS,
+    num_limbs: elem::NumLimbs::P384,
 
     q: Modulus {
         p: limbs_from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff"),


### PR DESCRIPTION
Help the compiler see that COMMON_OPS.num_limbs, which is used in all the slicing, is always less than the size of the array, so no bounds checks need to be emitted.