### PR TITLE
ec/suite_b: Make more LeakyLimb->Limb conversions explicit.

### DIFF
--- a/mk/generate_curves.py
+++ b/mk/generate_curves.py
@@ -33,7 +33,7 @@ rs_template = """
 
 use super::{
     elem::{binary_op, binary_op_assign},
-    elem_sqr_mul, elem_sqr_mul_acc, Modulus, *,
+    elem_sqr_mul, elem_sqr_mul_acc, PublicModulus, *,
 };
 
 pub(super) const NUM_LIMBS: usize = (%(bits)d + LIMB_BITS - 1) / LIMB_BITS;
@@ -42,9 +42,9 @@ pub static COMMON_OPS: CommonOps = CommonOps {
     num_limbs: elem::NumLimbs::P%(bits)s,
     order_bits: %(bits)d,
 
-    q: Modulus {
+    q: PublicModulus {
         p: limbs_from_hex("%(q)x"),
-        rr: limbs_from_hex(%(q_rr)s),
+        rr: PublicElem::from_hex(%(q_rr)s),
     },
     n: PublicElem::from_hex("%(n)x"),
 

--- a/src/ec/suite_b/ecdh.rs
+++ b/src/ec/suite_b/ecdh.rs
@@ -93,6 +93,8 @@ fn ecdh(
     // The "NSA Guide" steps are from section 3.1 of the NSA guide, "Ephemeral
     // Unified Model."
 
+    let q = public_key_ops.common.elem_modulus();
+
     // NSA Guide Step 1 is handled separately.
 
     // NIST SP 800-56Ar2 5.6.2.2.2.
@@ -101,7 +103,7 @@ fn ecdh(
     // `parse_uncompressed_point` verifies that the point is not at infinity
     // and that it is on the curve, using the Partial Public-Key Validation
     // Routine.
-    let peer_public_key = parse_uncompressed_point(public_key_ops, peer_public_key, cpu)?;
+    let peer_public_key = parse_uncompressed_point(public_key_ops, &q, peer_public_key, cpu)?;
 
     // NIST SP 800-56Ar2 Step 1.
     // NSA Guide Step 3 (except point at infinity check).
@@ -123,7 +125,8 @@ fn ecdh(
     // information about their values can be recovered. This doesn't meet the
     // NSA guide's explicit requirement to "zeroize" them though.
     // TODO: this only needs common scalar ops
-    let my_private_key = private_key_as_scalar(private_key_ops, my_private_key);
+    let n = private_key_ops.common.scalar_modulus();
+    let my_private_key = private_key_as_scalar(&n, my_private_key);
     let product = private_key_ops.point_mul(&my_private_key, &peer_public_key, cpu);
 
     // NIST SP 800-56Ar2 Steps 2, 3, 4, and 5.
@@ -134,7 +137,7 @@ fn ecdh(
     // `big_endian_affine_from_jacobian` verifies that the result is not at
     // infinity and also does an extra check to verify that the point is on
     // the curve.
-    big_endian_affine_from_jacobian(private_key_ops, out, None, &product, cpu)
+    big_endian_affine_from_jacobian(private_key_ops, &q, out, None, &product, cpu)
 
     // NSA Guide Step 5 & 6 are deferred to the caller. Again, we have a
     // pretty liberal interpretation of the NIST's spec's "Destroy" that

--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -63,7 +63,8 @@ impl signature::VerificationAlgorithm for EcdsaVerificationAlgorithm {
 
             // NSA Guide Step 3: "Convert the bit string H to an integer e as
             // described in Appendix B.2."
-            digest_scalar(self.ops.scalar_ops, h)
+            let n = self.ops.scalar_ops.scalar_modulus();
+            digest_scalar(&n, h)
         };
 
         self.verify_digest(public_key, e, signature)
@@ -84,6 +85,8 @@ impl EcdsaVerificationAlgorithm {
 
         let public_key_ops = self.ops.public_key_ops;
         let scalar_ops = self.ops.scalar_ops;
+        let q = public_key_ops.common.elem_modulus();
+        let n = scalar_ops.scalar_modulus();
 
         // NSA Guide Prerequisites:
         //
@@ -102,7 +105,7 @@ impl EcdsaVerificationAlgorithm {
         // can do. Prerequisite #2 is handled implicitly as the domain
         // parameters are hard-coded into the source. Prerequisite #3 is
         // handled by `parse_uncompressed_point`.
-        let peer_pub_key = parse_uncompressed_point(public_key_ops, public_key, cpu)?;
+        let peer_pub_key = parse_uncompressed_point(public_key_ops, &q, public_key, cpu)?;
 
         let (r, s) = signature.read_all(error::Unspecified, |input| {
             (self.split_rs)(scalar_ops, input)
@@ -110,8 +113,8 @@ impl EcdsaVerificationAlgorithm {
 
         // NSA Guide Step 1: "If r and s are not both integers in the interval
         // [1, n − 1], output INVALID."
-        let r = scalar_parse_big_endian_variable(public_key_ops.common, limb::AllowZero::No, r)?;
-        let s = scalar_parse_big_endian_variable(public_key_ops.common, limb::AllowZero::No, s)?;
+        let r = scalar_parse_big_endian_variable(&n, limb::AllowZero::No, r)?;
+        let s = scalar_parse_big_endian_variable(&n, limb::AllowZero::No, s)?;
 
         // NSA Guide Step 4: "Compute w = s**−1 mod n, using the routine in
         // Appendix B.1."
@@ -134,7 +137,7 @@ impl EcdsaVerificationAlgorithm {
         // `verify_affine_point_is_on_the_curve_scaled` for details on why).
         // But, we're going to avoid converting to affine for performance
         // reasons, so we do the verification using the Jacobian coordinates.
-        let z2 = verify_jacobian_point_is_on_the_curve(public_key_ops.common, &product)?;
+        let z2 = verify_jacobian_point_is_on_the_curve(public_key_ops.common, &q, &product)?;
 
         // NSA Guide Step 7: "Compute v = xR mod n."
         // NSA Guide Step 8: "Compare v and r0. If v = r0, output VALID;
@@ -158,9 +161,9 @@ impl EcdsaVerificationAlgorithm {
         if sig_r_equals_x(self.ops, &r, &x, &z2) {
             return Ok(());
         }
-        if self.ops.elem_less_than_vartime(&r, &self.ops.q_minus_n) {
+        if q.elem_less_than_vartime(&r, &self.ops.q_minus_n) {
             let n = Elem::from(self.ops.n());
-            self.ops.scalar_ops.common.elem_add(&mut r, &n);
+            q.elem_add(&mut r, &n);
             if sig_r_equals_x(self.ops, &r, &x, &z2) {
                 return Ok(());
             }
@@ -316,11 +319,9 @@ mod tests {
                         panic!("Unsupported curve: {}", curve_name);
                     }
                 };
+                let n = alg.ops.scalar_ops.scalar_modulus();
 
-                let digest = super::super::digest_scalar::digest_bytes_scalar(
-                    alg.ops.scalar_ops,
-                    &digest[..],
-                );
+                let digest = super::super::digest_scalar::digest_bytes_scalar(&n, &digest[..]);
                 let actual_result = alg.verify_digest(
                     untrusted::Input::from(&public_key[..]),
                     digest,

--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -158,7 +158,7 @@ impl EcdsaVerificationAlgorithm {
         if sig_r_equals_x(self.ops, &r, &x, &z2) {
             return Ok(());
         }
-        if self.ops.elem_less_than(&r, &self.ops.q_minus_n) {
+        if self.ops.elem_less_than_vartime(&r, &self.ops.q_minus_n) {
             let n = Elem::from(self.ops.n());
             self.ops.scalar_ops.common.elem_add(&mut r, &n);
             if sig_r_equals_x(self.ops, &r, &x, &z2) {

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -328,7 +328,7 @@ impl PublicScalarOps {
         a.limbs[..num_limbs] == b.limbs[..num_limbs]
     }
 
-    pub fn elem_less_than(&self, a: &Elem<Unencoded>, b: &PublicElem<Unencoded>) -> bool {
+    pub fn elem_less_than_vartime(&self, a: &Elem<Unencoded>, b: &PublicElem<Unencoded>) -> bool {
         let num_limbs = self.public_key_ops.common.num_limbs.into();
         limbs_less_than_limbs_vartime(&a.limbs[..num_limbs], &b.limbs[..num_limbs])
     }

--- a/src/ec/suite_b/ops/elem.rs
+++ b/src/ec/suite_b/ops/elem.rs
@@ -122,11 +122,7 @@ pub fn binary_op<M, EA: Encoding, EB: Encoding, ER: Encoding>(
     a: &Elem<M, EA>,
     b: &Elem<M, EB>,
 ) -> Elem<M, ER> {
-    let mut r = Elem {
-        limbs: [0; NumLimbs::MAX],
-        m: PhantomData,
-        encoding: PhantomData,
-    };
+    let mut r = Elem::zero();
     unsafe { f(r.limbs.as_mut_ptr(), a.limbs.as_ptr(), b.limbs.as_ptr()) }
     r
 }
@@ -147,11 +143,7 @@ pub fn unary_op<M, E: Encoding>(
     f: unsafe extern "C" fn(r: *mut Limb, a: *const Limb),
     a: &Elem<M, E>,
 ) -> Elem<M, E> {
-    let mut r = Elem {
-        limbs: [0; NumLimbs::MAX],
-        m: PhantomData,
-        encoding: PhantomData,
-    };
+    let mut r = Elem::zero();
     unsafe { f(r.limbs.as_mut_ptr(), a.limbs.as_ptr()) }
     r
 }

--- a/src/ec/suite_b/ops/p256.rs
+++ b/src/ec/suite_b/ops/p256.rs
@@ -14,7 +14,7 @@
 
 use super::{
     elem::{binary_op, binary_op_assign},
-    elem_sqr_mul, elem_sqr_mul_acc, Modulus, *,
+    elem_sqr_mul, elem_sqr_mul_acc, PublicModulus, *,
 };
 
 pub(super) const NUM_LIMBS: usize = 256 / LIMB_BITS;
@@ -22,9 +22,9 @@ pub(super) const NUM_LIMBS: usize = 256 / LIMB_BITS;
 pub static COMMON_OPS: CommonOps = CommonOps {
     num_limbs: elem::NumLimbs::P256,
 
-    q: Modulus {
+    q: PublicModulus {
         p: limbs_from_hex("ffffffff00000001000000000000000000000000ffffffffffffffffffffffff"),
-        rr: limbs_from_hex("4fffffffdfffffffffffffffefffffffbffffffff0000000000000003"),
+        rr: PublicElem::from_hex("4fffffffdfffffffffffffffefffffffbffffffff0000000000000003"),
     },
     n: PublicElem::from_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
 
@@ -301,7 +301,7 @@ prefixed_extern! {
     fn p256_scalar_sqr_rep_mont(
         r: *mut Limb,   // [COMMON_OPS.num_limbs]
         a: *const Limb, // [COMMON_OPS.num_limbs]
-        rep: Limb,
+        rep: LeakyWord,
     );
 }
 

--- a/src/ec/suite_b/ops/p384.rs
+++ b/src/ec/suite_b/ops/p384.rs
@@ -14,7 +14,7 @@
 
 use super::{
     elem::{binary_op, binary_op_assign},
-    elem_sqr_mul, elem_sqr_mul_acc, Modulus, *,
+    elem_sqr_mul, elem_sqr_mul_acc, PublicModulus, *,
 };
 
 pub(super) const NUM_LIMBS: usize = 384 / LIMB_BITS;
@@ -22,9 +22,9 @@ pub(super) const NUM_LIMBS: usize = 384 / LIMB_BITS;
 pub static COMMON_OPS: CommonOps = CommonOps {
     num_limbs: elem::NumLimbs::P384,
 
-    q: Modulus {
+    q: PublicModulus {
         p: limbs_from_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff"),
-        rr: limbs_from_hex("10000000200000000fffffffe000000000000000200000000fffffffe00000001"),
+        rr: PublicElem::from_hex("10000000200000000fffffffe000000000000000200000000fffffffe00000001"),
     },
     n: PublicElem::from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973"),
 


### PR DESCRIPTION
Rename `Modulus` to `PublicModulus` and add a new `Modulus`:

    PublicModulus::limbs: [LeakyLimb; _]
    Modulus::limbs: [Limb; _]

Refactor the callers to (approximately) minimize the number of types a `Modulus` is constructed, as it will require a copy if/when `Limb` becomes a type distinct from `LeakyLimb`.