### PR TITLE
ec/suite_b: Consistently use `let {q,n} = &` for moduli.

### DIFF
--- a/src/ec/suite_b/ecdh.rs
+++ b/src/ec/suite_b/ecdh.rs
@@ -93,7 +93,7 @@ fn ecdh(
     // The "NSA Guide" steps are from section 3.1 of the NSA guide, "Ephemeral
     // Unified Model."
 
-    let q = public_key_ops.common.elem_modulus();
+    let q = &public_key_ops.common.elem_modulus();
 
     // NSA Guide Step 1 is handled separately.
 
@@ -103,7 +103,7 @@ fn ecdh(
     // `parse_uncompressed_point` verifies that the point is not at infinity
     // and that it is on the curve, using the Partial Public-Key Validation
     // Routine.
-    let peer_public_key = parse_uncompressed_point(public_key_ops, &q, peer_public_key, cpu)?;
+    let peer_public_key = parse_uncompressed_point(public_key_ops, q, peer_public_key, cpu)?;
 
     // NIST SP 800-56Ar2 Step 1.
     // NSA Guide Step 3 (except point at infinity check).
@@ -125,8 +125,8 @@ fn ecdh(
     // information about their values can be recovered. This doesn't meet the
     // NSA guide's explicit requirement to "zeroize" them though.
     // TODO: this only needs common scalar ops
-    let n = private_key_ops.common.scalar_modulus();
-    let my_private_key = private_key_as_scalar(&n, my_private_key);
+    let n = &private_key_ops.common.scalar_modulus();
+    let my_private_key = private_key_as_scalar(n, my_private_key);
     let product = private_key_ops.point_mul(&my_private_key, &peer_public_key, cpu);
 
     // NIST SP 800-56Ar2 Steps 2, 3, 4, and 5.
@@ -137,7 +137,7 @@ fn ecdh(
     // `big_endian_affine_from_jacobian` verifies that the result is not at
     // infinity and also does an extra check to verify that the point is on
     // the curve.
-    big_endian_affine_from_jacobian(private_key_ops, &q, out, None, &product, cpu)
+    big_endian_affine_from_jacobian(private_key_ops, q, out, None, &product, cpu)
 
     // NSA Guide Step 5 & 6 are deferred to the caller. Again, we have a
     // pretty liberal interpretation of the NIST's spec's "Destroy" that

--- a/src/ec/suite_b/ecdsa/digest_scalar.rs
+++ b/src/ec/suite_b/ecdsa/digest_scalar.rs
@@ -91,20 +91,20 @@ mod tests {
                         panic!("Unsupported curve+digest: {}+{}", curve_name, digest_name);
                     }
                 };
-                let n = ops.scalar_ops.scalar_modulus();
+                let n = &ops.scalar_ops.scalar_modulus();
 
                 assert_eq!(input.len(), digest_alg.output_len());
                 assert_eq!(output.len(), ops.scalar_ops.scalar_bytes_len());
                 assert_eq!(output.len(), n.bytes_len());
 
                 let expected = scalar_parse_big_endian_variable(
-                    &n,
+                    n,
                     limb::AllowZero::Yes,
                     untrusted::Input::from(&output),
                 )
                 .unwrap();
 
-                let actual = digest_bytes_scalar(&n, &input);
+                let actual = digest_bytes_scalar(n, &input);
                 assert_eq!(
                     ops.scalar_ops.leak_limbs(&actual),
                     ops.scalar_ops.leak_limbs(&expected)

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -156,8 +156,8 @@ impl EcdsaKeyPair {
         let cpu = cpu::features();
 
         let (seed, public_key) = key_pair.split();
-        let n = alg.private_scalar_ops.scalar_ops.scalar_modulus();
-        let d = private_key::private_key_as_scalar(&n, &seed);
+        let n = &alg.private_scalar_ops.scalar_ops.scalar_modulus();
+        let d = private_key::private_key_as_scalar(n, &seed);
         let d = alg.private_scalar_ops.to_mont(&d, cpu);
 
         let nonce_key = NonceRandomKey::new(alg, &seed, rng)?;
@@ -240,13 +240,13 @@ impl EcdsaKeyPair {
         let scalar_ops = ops.scalar_ops;
         let cops = scalar_ops.common;
         let private_key_ops = self.alg.private_key_ops;
-        let q = cops.elem_modulus();
-        let n = scalar_ops.scalar_modulus();
+        let q = &cops.elem_modulus();
+        let n = &scalar_ops.scalar_modulus();
 
         for _ in 0..100 {
             // XXX: iteration conut?
             // Step 1.
-            let k = private_key::random_scalar(self.alg.private_key_ops, &n, rng)?;
+            let k = private_key::random_scalar(self.alg.private_key_ops, n, rng)?;
             let k_inv = ops.scalar_inv_to_mont(&k, cpu);
 
             // Step 2.
@@ -254,7 +254,7 @@ impl EcdsaKeyPair {
 
             // Step 3.
             let r = {
-                let (x, _) = private_key::affine_from_jacobian(private_key_ops, &q, &r, cpu)?;
+                let (x, _) = private_key::affine_from_jacobian(private_key_ops, q, &r, cpu)?;
                 let x = cops.elem_unencoded(&x);
                 n.elem_reduced_to_scalar(&x)
             };
@@ -265,7 +265,7 @@ impl EcdsaKeyPair {
             // Step 4 is done by the caller.
 
             // Step 5.
-            let e = digest_scalar(&n, h);
+            let e = digest_scalar(n, h);
 
             // Step 6.
             let s = {

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -557,7 +557,7 @@ mod tests {
 
     fn q_minus_n_plus_n_equals_0_test(ops: &PublicScalarOps) {
         let cops = ops.scalar_ops.common;
-        let q = cops.elem_modulus();
+        let q = &cops.elem_modulus();
         let mut x = Elem::from(&ops.q_minus_n);
         q.elem_add(&mut x, &Elem::from(&cops.n));
         assert!(cops.is_zero(&x));
@@ -804,12 +804,12 @@ mod tests {
     fn scalar_mul_test(ops: &ScalarOps, test_file: test::File) {
         let cpu = cpu::features();
         let cops = ops.common;
-        let n = cops.scalar_modulus();
+        let n = &cops.scalar_modulus();
         test::run(test_file, |section, test_case| {
             assert_eq!(section, "");
-            let a = consume_scalar(&n, test_case, "a");
-            let b = consume_scalar_mont(&n, test_case, "b");
-            let expected_result = consume_scalar(&n, test_case, "r");
+            let a = consume_scalar(n, test_case, "a");
+            let b = consume_scalar_mont(n, test_case, "b");
+            let expected_result = consume_scalar(n, test_case, "r");
             let actual_result = ops.scalar_product(&a, &b, cpu);
             assert_limbs_are_equal(cops, &actual_result.limbs, &expected_result.limbs);
 
@@ -838,12 +838,12 @@ mod tests {
         test_file: test::File,
     ) {
         let cops = ops.common;
-        let n = cops.scalar_modulus();
+        let n = &cops.scalar_modulus();
         test::run(test_file, |section, test_case| {
             assert_eq!(section, "");
             let cpu = cpu::features();
-            let a = consume_scalar(&n, test_case, "a");
-            let expected_result = consume_scalar(&n, test_case, "r");
+            let a = consume_scalar(n, test_case, "a");
+            let expected_result = consume_scalar(n, test_case, "r");
 
             {
                 let mut actual_result: Scalar<R> = Scalar {
@@ -1056,16 +1056,16 @@ mod tests {
     ) {
         let cpu = cpu::features();
         let cops = pub_ops.common;
-        let q = cops.elem_modulus();
-        let n = cops.scalar_modulus();
+        let q = &cops.elem_modulus();
+        let n = &cops.scalar_modulus();
         test::run(test_file, |section, test_case| {
             assert_eq!(section, "");
-            let p_scalar = consume_scalar(&n, test_case, "p_scalar");
+            let p_scalar = consume_scalar(n, test_case, "p_scalar");
 
             let p = test_case.consume_bytes("p");
             let p = super::super::public_key::parse_uncompressed_point(
                 pub_ops,
-                &q,
+                q,
                 untrusted::Input::from(&p),
                 cpu,
             )
@@ -1080,7 +1080,7 @@ mod tests {
                 let (x, y) = actual_result[1..].split_at_mut(cops.len());
                 super::super::private_key::big_endian_affine_from_jacobian(
                     priv_ops,
-                    &q,
+                    q,
                     x,
                     Some(y),
                     &product,
@@ -1119,10 +1119,10 @@ mod tests {
         test_file: test::File,
     ) {
         let cpu = cpu::features();
-        let n = ops.common.scalar_modulus();
+        let n = &ops.common.scalar_modulus();
         test::run(test_file, |section, test_case| {
             assert_eq!(section, "");
-            let g_scalar = consume_scalar(&n, test_case, "g_scalar");
+            let g_scalar = consume_scalar(n, test_case, "g_scalar");
             let expected_result: TestPoint<Unencoded> = consume_point(ops, test_case, "r");
             let actual_result = f(&g_scalar, cpu);
             assert_point_actual_equals_expected(ops, &actual_result, &expected_result);

--- a/src/ec/suite_b/private_key.rs
+++ b/src/ec/suite_b/private_key.rs
@@ -95,8 +95,8 @@ pub(super) fn check_scalar_big_endian_bytes(
     bytes: &[u8],
 ) -> Result<(), error::Unspecified> {
     debug_assert_eq!(bytes.len(), ops.common.len());
-    let n = ops.common.scalar_modulus();
-    scalar_from_big_endian_bytes(&n, bytes).map(|_| ())
+    let n = &ops.common.scalar_modulus();
+    scalar_from_big_endian_bytes(n, bytes).map(|_| ())
 }
 
 // Parses a fixed-length (zero-padded) big-endian-encoded scalar in the range
@@ -132,18 +132,18 @@ pub(super) fn public_from_private(
     my_private_key: &ec::Seed,
     cpu: cpu::Features,
 ) -> Result<(), error::Unspecified> {
-    let q = ops.common.elem_modulus();
+    let q = &ops.common.elem_modulus();
     let elem_and_scalar_bytes = ops.common.len();
     debug_assert_eq!(public_out.len(), 1 + (2 * elem_and_scalar_bytes));
-    let n = ops.common.scalar_modulus();
-    let my_private_key = private_key_as_scalar(&n, my_private_key);
+    let n = &ops.common.scalar_modulus();
+    let my_private_key = private_key_as_scalar(n, my_private_key);
     let my_public_key = ops.point_mul_base(&my_private_key, cpu);
     public_out[0] = 4; // Uncompressed encoding.
     let (x_out, y_out) = public_out[1..].split_at_mut(elem_and_scalar_bytes);
 
     // `big_endian_affine_from_jacobian` verifies that the point is not at
     // infinity and is on the curve.
-    big_endian_affine_from_jacobian(ops, &q, x_out, Some(y_out), &my_public_key, cpu)
+    big_endian_affine_from_jacobian(ops, q, x_out, Some(y_out), &my_public_key, cpu)
 }
 
 pub(super) fn affine_from_jacobian(

--- a/src/ec/suite_b/public_key.rs
+++ b/src/ec/suite_b/public_key.rs
@@ -86,9 +86,9 @@ mod tests {
                 let is_valid = test_case.consume_string("Result") == "P";
 
                 let curve_ops = public_key_ops_from_curve_name(&curve_name);
-                let q = curve_ops.common.elem_modulus();
+                let q = &curve_ops.common.elem_modulus();
 
-                let result = parse_uncompressed_point(curve_ops, &q, public_key, cpu);
+                let result = parse_uncompressed_point(curve_ops, q, public_key, cpu);
                 assert_eq!(is_valid, result.is_ok());
 
                 // TODO: Verify that we when we re-serialize the parsed (x, y), the


### PR DESCRIPTION
`Modulus<M>` is always passed by reference, so when it is constructed, just reference it immediately. This avoids a lot of noise, replacing `&q` with `q` and `&n` with `n`. This reduces the noise of future refactorings where `q` and/or `n` are constructed in a different place.