### PR TITLE
ec/suite_b: Move `point_sum()` from `CommonOps` to `PrivateKeyOps`.

### DIFF
--- a/src/ec/suite_b/ops/p256.rs
+++ b/src/ec/suite_b/ops/p256.rs
@@ -33,8 +33,6 @@ pub static COMMON_OPS: CommonOps = CommonOps {
 
     elem_mul_mont: p256_mul_mont,
     elem_sqr_mont: p256_sqr_mont,
-
-    point_add_jacobian_impl: p256_point_add,
 };
 
 #[cfg(test)]
@@ -48,6 +46,7 @@ pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
     elem_inv_squared: p256_elem_inv_squared,
     point_mul_base_impl: p256_point_mul_base_impl,
     point_mul_impl: p256_point_mul,
+    point_add_jacobian_impl: p256_point_add,
 };
 
 fn p256_elem_inv_squared(q: &Modulus<Q>, a: &Elem<R>) -> Elem<R> {
@@ -146,7 +145,7 @@ fn twin_mul_nistz256(
 ) -> Point {
     let scaled_g = point_mul_base_vartime(g_scalar, cpu);
     let scaled_p = PRIVATE_KEY_OPS.point_mul(p_scalar, p_xy, cpu::features());
-    PRIVATE_KEY_OPS.common.point_sum(&scaled_g, &scaled_p, cpu)
+    PRIVATE_KEY_OPS.point_sum(&scaled_g, &scaled_p, cpu)
 }
 
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]

--- a/src/ec/suite_b/ops/p384.rs
+++ b/src/ec/suite_b/ops/p384.rs
@@ -33,8 +33,6 @@ pub static COMMON_OPS: CommonOps = CommonOps {
 
     elem_mul_mont: p384_elem_mul_mont,
     elem_sqr_mont: p384_elem_sqr_mont,
-
-    point_add_jacobian_impl: p384_point_add,
 };
 
 pub(super) static GENERATOR: (PublicElem<R>, PublicElem<R>) = (
@@ -47,6 +45,7 @@ pub static PRIVATE_KEY_OPS: PrivateKeyOps = PrivateKeyOps {
     elem_inv_squared: p384_elem_inv_squared,
     point_mul_base_impl: p384_point_mul_base_impl,
     point_mul_impl: p384_point_mul,
+    point_add_jacobian_impl: p384_point_add,
 };
 
 fn p384_elem_inv_squared(q: &Modulus<Q>, a: &Elem<R>) -> Elem<R> {


### PR DESCRIPTION
Internally, all the operations do use a single point addition function (per curve) but that's an implementation detail of each operation.