### PR TITLE
bigint: Remove redundant ">= 3" check for Modulus.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -855,7 +855,6 @@ fn prefix_all_symbols(pp: char, prefix_prefix: &str, prefix: &str) -> String {
         "LIMBS_equal",
         "LIMBS_equal_limb",
         "LIMBS_less_than",
-        "LIMBS_less_than_limb",
         "LIMBS_reduce_once",
         "LIMBS_select_512_32",
         "LIMBS_shl_mod",

--- a/crypto/limbs/limbs.c
+++ b/crypto/limbs/limbs.c
@@ -80,15 +80,6 @@ Limb LIMBS_less_than(const Limb a[], const Limb b[], size_t num_limbs) {
   return constant_time_is_nonzero_w(borrow);
 }
 
-Limb LIMBS_less_than_limb(const Limb a[], Limb b, size_t num_limbs) {
-  debug_assert_nonsecret(num_limbs >= 1);
-
-  Limb dummy;
-  Limb lo = constant_time_is_nonzero_w(limb_sub(&dummy, a[0], b));
-  Limb hi = LIMBS_are_zero(&a[1], num_limbs - 1);
-  return constant_time_select_w(lo, hi, lo);
-}
-
 /* if (r >= m) { r -= m; } */
 void LIMBS_reduce_once(Limb r[], const Limb m[], size_t num_limbs) {
   debug_assert_nonsecret(num_limbs >= 1);

--- a/src/arithmetic/bigint/modulusvalue.rs
+++ b/src/arithmetic/bigint/modulusvalue.rs
@@ -44,14 +44,13 @@ impl<M> OwnedModulusValue<M> {
         if n.len() > MODULUS_MAX_LIMBS {
             return Err(error::KeyRejected::too_large());
         }
+        const _MODULUS_MIN_LIMBS_AT_LEAST_2: () = assert!(MODULUS_MIN_LIMBS >= 2);
         if n.len() < MODULUS_MIN_LIMBS {
             return Err(error::KeyRejected::unexpected_error());
         }
+        // The above implies n >= 3, so we don't need to check it.
         if limb::limbs_are_even_constant_time(&n).leak() {
             return Err(error::KeyRejected::invalid_component());
-        }
-        if limb::limbs_less_than_limb_constant_time(&n, 3).leak() {
-            return Err(error::KeyRejected::unexpected_error());
         }
 
         let len_bits = limb::limbs_minimal_bits(&n);

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -59,12 +59,6 @@ pub fn limbs_less_than_limbs_vartime(a: &[Limb], b: &[Limb]) -> bool {
 }
 
 #[inline]
-#[cfg(feature = "alloc")]
-pub fn limbs_less_than_limb_constant_time(a: &[Limb], b: Limb) -> LimbMask {
-    unsafe { LIMBS_less_than_limb(a.as_ptr(), b, a.len()) }
-}
-
-#[inline]
 pub fn limbs_are_zero_constant_time(limbs: &[Limb]) -> LimbMask {
     unsafe { LIMBS_are_zero(limbs.as_ptr(), limbs.len()) }
 }
@@ -345,11 +339,6 @@ prefixed_extern! {
     fn LIMBS_equal_limb(a: *const Limb, b: Limb, num_limbs: c::size_t) -> LimbMask;
 }
 
-#[cfg(feature = "alloc")]
-prefixed_extern! {
-    fn LIMBS_less_than_limb(a: *const Limb, b: Limb, num_limbs: c::size_t) -> LimbMask;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -475,46 +464,6 @@ mod tests {
         for &(a, b) in UNEQUAL {
             let a = &Vec::from_iter(a.iter().copied().map(Limb::from));
             assert!(!leak_in_test(limbs_equal_limb_constant_time(a, b)));
-        }
-    }
-
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn test_limbs_less_than_limb_constant_time() {
-        static LESSER: &[(&[LeakyLimb], LeakyLimb)] = &[
-            (&[0], 1),
-            (&[0, 0], 1),
-            (&[1, 0], 2),
-            (&[2, 0], 3),
-            (&[2, 0], 3),
-            (&[MAX - 1], MAX),
-            (&[MAX - 1, 0], MAX),
-        ];
-        for &(a, b) in LESSER {
-            let a = &Vec::from_iter(a.iter().copied().map(Limb::from));
-            let b = Limb::from(b);
-            assert!(leak_in_test(limbs_less_than_limb_constant_time(a, b)));
-        }
-        static EQUAL: &[(&[LeakyLimb], LeakyLimb)] = &[
-            (&[0], 0),
-            (&[0, 0, 0, 0], 0),
-            (&[1], 1),
-            (&[1, 0, 0, 0, 0, 0, 0], 1),
-            (&[MAX], MAX),
-        ];
-        static GREATER: &[(&[LeakyLimb], LeakyLimb)] = &[
-            (&[1], 0),
-            (&[2, 0], 1),
-            (&[3, 0, 0, 0], 1),
-            (&[0, 1, 0, 0], 1),
-            (&[0, 0, 1, 0], 1),
-            (&[0, 0, 1, 1], 1),
-            (&[MAX], MAX - 1),
-        ];
-        for &(a, b) in EQUAL.iter().chain(GREATER.iter()) {
-            let a = &Vec::from_iter(a.iter().copied().map(Limb::from));
-            let b = Limb::from(b);
-            assert!(!leak_in_test(limbs_less_than_limb_constant_time(a, b)));
         }
     }
 


### PR DESCRIPTION
As we require the modulus to be multiple limbs long, its value cannot be less than 3.