### PR TITLE
digest: Clarify panic safety of `(Block)Digest::finish`

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -76,12 +76,11 @@ impl BlockContext {
     // `block` may be arbitrarily overwritten.
     pub(crate) fn finish(
         mut self,
-        block: &mut [u8],
+        block: &mut [u8; MAX_BLOCK_LEN],
         num_pending: usize,
         cpu_features: cpu::Features,
     ) -> Digest {
         let block_len = self.algorithm.block_len();
-        assert_eq!(block.len(), block_len);
         assert!(num_pending < block.len());
         let block = &mut block[..block_len];
 
@@ -220,13 +219,8 @@ impl Context {
     /// has been called.
     pub fn finish(mut self) -> Digest {
         let cpu_features = cpu::features();
-
-        let block_len = self.block.algorithm.block_len();
-        self.block.finish(
-            &mut self.pending[..block_len],
-            self.num_pending,
-            cpu_features,
-        )
+        self.block
+            .finish(&mut self.pending, self.num_pending, cpu_features)
     }
 
     /// The algorithm that this context is using.

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -315,11 +315,11 @@ impl Context {
         let cpu_features = cpu::features();
 
         let algorithm = self.inner.algorithm();
-        let mut pending = [0u8; digest::MAX_BLOCK_LEN];
-        let pending = &mut pending[..algorithm.block_len()];
+        let mut buffer = [0u8; digest::MAX_BLOCK_LEN];
+        let buffer = &mut buffer[..algorithm.block_len()];
         let num_pending = algorithm.output_len();
-        pending[..num_pending].copy_from_slice(self.inner.finish().as_ref());
-        Tag(self.outer.finish(pending, num_pending, cpu_features))
+        buffer[..num_pending].copy_from_slice(self.inner.finish().as_ref());
+        Tag(self.outer.finish(buffer, num_pending, cpu_features))
     }
 }
 

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -315,8 +315,7 @@ impl Context {
         let cpu_features = cpu::features();
 
         let algorithm = self.inner.algorithm();
-        let mut buffer = [0u8; digest::MAX_BLOCK_LEN];
-        let buffer = &mut buffer[..algorithm.block_len()];
+        let buffer = &mut [0u8; digest::MAX_BLOCK_LEN];
         let num_pending = algorithm.output_len();
         buffer[..num_pending].copy_from_slice(self.inner.finish().as_ref());
         Tag(self.outer.finish(buffer, num_pending, cpu_features))


### PR DESCRIPTION
See the individual commit messages for details. This is a step towards providing a never-panicking variant of the API.