### PR TITLE
Use only non-panicking digest API internally.

### DIFF
--- a/src/ec/curve25519/ed25519.rs
+++ b/src/ec/curve25519/ed25519.rs
@@ -15,7 +15,7 @@
 //! EdDSA Signatures.
 
 use super::ops::ELEM_LEN;
-use crate::digest;
+use crate::{cpu, digest};
 
 pub mod signing;
 pub mod verification;
@@ -23,10 +23,15 @@ pub mod verification;
 /// The length of an Ed25519 public key.
 pub const ED25519_PUBLIC_KEY_LEN: usize = ELEM_LEN;
 
-pub fn eddsa_digest(signature_r: &[u8], public_key: &[u8], msg: &[u8]) -> digest::Digest {
+fn eddsa_digest(
+    signature_r: &[u8],
+    public_key: &[u8],
+    msg: &[u8],
+    cpu: cpu::Features,
+) -> Result<digest::Digest, digest::FinishError> {
     let mut ctx = digest::Context::new(&digest::SHA512);
     ctx.update(signature_r);
     ctx.update(public_key);
     ctx.update(msg);
-    ctx.finish()
+    ctx.try_finish(cpu)
 }

--- a/src/ec/curve25519/ed25519/verification.rs
+++ b/src/ec/curve25519/ed25519/verification.rs
@@ -60,7 +60,12 @@ impl signature::VerificationAlgorithm for EdDSAParameters {
         let mut a = ExtPoint::from_encoded_point_vartime(public_key)?;
         a.invert_vartime();
 
-        let h_digest = eddsa_digest(signature_r, public_key, msg.as_slice_less_safe());
+        let h_digest = eddsa_digest(
+            signature_r,
+            public_key,
+            msg.as_slice_less_safe(),
+            cpu_features,
+        )?;
         let h = Scalar::from_sha512_digest_reduced(h_digest);
 
         let mut r = Point::new_at_infinity();

--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -60,7 +60,7 @@ impl signature::VerificationAlgorithm for EcdsaVerificationAlgorithm {
         let e = {
             // NSA Guide Step 2: "Use the selected hash function to compute H =
             // Hash(M)."
-            let h = digest::digest(self.digest_alg, msg.as_slice_less_safe());
+            let h = digest::Digest::compute_from(self.digest_alg, msg.as_slice_less_safe(), cpu)?;
 
             // NSA Guide Step 3: "Convert the bit string H to an integer e as
             // described in Appendix B.2."

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -109,7 +109,11 @@
 //! [code for `ring::hkdf`]:
 //!     https://github.com/briansmith/ring/blob/main/src/hkdf.rs
 
-use crate::{constant_time, cpu, digest, error, hkdf, rand};
+use crate::{
+    constant_time, cpu,
+    digest::{self, Digest},
+    error, hkdf, rand,
+};
 
 /// An HMAC algorithm.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -139,7 +143,7 @@ pub static HMAC_SHA512: Algorithm = Algorithm(&digest::SHA512);
 ///
 /// For a given tag `t`, use `t.as_ref()` to get the tag value as a byte slice.
 #[derive(Clone, Copy, Debug)]
-pub struct Tag(digest::Digest);
+pub struct Tag(Digest);
 
 impl AsRef<[u8]> for Tag {
     #[inline]
@@ -175,17 +179,21 @@ impl Key {
         algorithm: Algorithm,
         rng: &dyn rand::SecureRandom,
     ) -> Result<Self, error::Unspecified> {
-        Self::construct(algorithm, |buf| rng.fill(buf))
+        Self::construct(algorithm, |buf| rng.fill(buf), cpu::features())
     }
 
-    fn construct<F>(algorithm: Algorithm, fill: F) -> Result<Self, error::Unspecified>
+    fn construct<F>(
+        algorithm: Algorithm,
+        fill: F,
+        cpu: cpu::Features,
+    ) -> Result<Self, error::Unspecified>
     where
         F: FnOnce(&mut [u8]) -> Result<(), error::Unspecified>,
     {
         let mut key_bytes = [0; digest::MAX_OUTPUT_LEN];
         let key_bytes = &mut key_bytes[..algorithm.0.output_len()];
         fill(key_bytes)?;
-        Ok(Self::new(algorithm, key_bytes))
+        Self::try_new(algorithm, key_bytes, cpu).map_err(error::Unspecified::from)
     }
 
     /// Construct an HMAC signing key using the given digest algorithm and key
@@ -208,8 +216,16 @@ impl Key {
     /// `digest_alg.output_len * 8` bits. Support for such keys is likely to be
     /// removed in a future version of *ring*.
     pub fn new(algorithm: Algorithm, key_value: &[u8]) -> Self {
-        let cpu_features = cpu::features();
+        Self::try_new(algorithm, key_value, cpu::features())
+            .map_err(error::Unspecified::from)
+            .unwrap()
+    }
 
+    fn try_new(
+        algorithm: Algorithm,
+        key_value: &[u8],
+        cpu_features: cpu::Features,
+    ) -> Result<Self, digest::FinishError> {
         let digest_alg = algorithm.0;
         let mut key = Self {
             inner: digest::BlockContext::new(digest_alg),
@@ -222,7 +238,7 @@ impl Key {
         let key_value = if key_value.len() <= block_len {
             key_value
         } else {
-            key_hash = digest::digest(digest_alg, key_value);
+            key_hash = Digest::compute_from(digest_alg, key_value, cpu_features)?;
             key_hash.as_ref()
         };
 
@@ -249,13 +265,19 @@ impl Key {
         let leftover = key.outer.update(padded_key, cpu_features);
         debug_assert_eq!(leftover.len(), 0);
 
-        key
+        Ok(key)
     }
 
     /// The digest algorithm for the key.
     #[inline]
     pub fn algorithm(&self) -> Algorithm {
         Algorithm(self.inner.algorithm)
+    }
+
+    fn try_sign(&self, data: &[u8], cpu: cpu::Features) -> Result<Tag, digest::FinishError> {
+        let mut ctx = Context::with_key(self);
+        ctx.update(data);
+        ctx.try_sign(cpu)
     }
 }
 
@@ -267,7 +289,7 @@ impl hkdf::KeyType for Algorithm {
 
 impl From<hkdf::Okm<'_, Algorithm>> for Key {
     fn from(okm: hkdf::Okm<Algorithm>) -> Self {
-        Self::construct(*okm.len(), |buf| okm.fill(buf)).unwrap()
+        Self::construct(*okm.len(), |buf| okm.fill(buf), cpu::features()).unwrap()
     }
 }
 
@@ -312,11 +334,12 @@ impl Context {
     /// the return value of `sign` to a tag. Use `verify` for verification
     /// instead.
     pub fn sign(self) -> Tag {
-        self.try_sign().map_err(error::Unspecified::from).unwrap()
+        self.try_sign(cpu::features())
+            .map_err(error::Unspecified::from)
+            .unwrap()
     }
 
-    fn try_sign(self) -> Result<Tag, digest::FinishError> {
-        let cpu_features = cpu::features();
+    fn try_sign(self, cpu_features: cpu::Features) -> Result<Tag, digest::FinishError> {
         let inner = self.inner.try_finish(cpu_features)?;
         let inner = inner.as_ref();
         let num_pending = inner.len();
@@ -337,9 +360,9 @@ impl Context {
 /// It is generally not safe to implement HMAC verification by comparing the
 /// return value of `sign` to a tag. Use `verify` for verification instead.
 pub fn sign(key: &Key, data: &[u8]) -> Tag {
-    let mut ctx = Context::with_key(key);
-    ctx.update(data);
-    ctx.sign()
+    key.try_sign(data, cpu::features())
+        .map_err(error::Unspecified::from)
+        .unwrap()
 }
 
 /// Calculates the HMAC of `data` using the signing key `key`, and verifies
@@ -350,7 +373,9 @@ pub fn sign(key: &Key, data: &[u8]) -> Tag {
 ///
 /// The verification will be done in constant time to prevent timing attacks.
 pub fn verify(key: &Key, data: &[u8], tag: &[u8]) -> Result<(), error::Unspecified> {
-    constant_time::verify_slices_are_equal(sign(key, data).as_ref(), tag)
+    let cpu = cpu::features();
+    let computed = key.try_sign(data, cpu)?;
+    constant_time::verify_slices_are_equal(computed.as_ref(), tag)
 }
 
 #[cfg(test)]

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -221,7 +221,7 @@ impl Key {
             .unwrap()
     }
 
-    fn try_new(
+    pub(crate) fn try_new(
         algorithm: Algorithm,
         key_value: &[u8],
         cpu_features: cpu::Features,
@@ -274,7 +274,11 @@ impl Key {
         Algorithm(self.inner.algorithm)
     }
 
-    fn try_sign(&self, data: &[u8], cpu: cpu::Features) -> Result<Tag, digest::FinishError> {
+    pub(crate) fn try_sign(
+        &self,
+        data: &[u8],
+        cpu: cpu::Features,
+    ) -> Result<Tag, digest::FinishError> {
         let mut ctx = Context::with_key(self);
         ctx.update(data);
         ctx.try_sign(cpu)
@@ -339,7 +343,7 @@ impl Context {
             .unwrap()
     }
 
-    fn try_sign(self, cpu_features: cpu::Features) -> Result<Tag, digest::FinishError> {
+    pub(crate) fn try_sign(self, cpu_features: cpu::Features) -> Result<Tag, digest::FinishError> {
         let inner = self.inner.try_finish(cpu_features)?;
         let inner = inner.as_ref();
         let num_pending = inner.len();

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -307,16 +307,15 @@ pub struct Signature {
 
 impl Signature {
     // Panics if `value` is too long.
-    pub(crate) fn new<F>(fill: F) -> Self
-    where
-        F: FnOnce(&mut [u8; MAX_LEN]) -> usize,
-    {
+    pub(crate) fn new<E>(
+        fill: impl FnOnce(&mut [u8; MAX_LEN]) -> Result<usize, E>,
+    ) -> Result<Self, E> {
         let mut r = Self {
             value: [0; MAX_LEN],
             len: 0,
         };
-        r.len = fill(&mut r.value);
-        r
+        r.len = fill(&mut r.value)?;
+        Ok(r)
     }
 }
 


### PR DESCRIPTION
Expose `digest::try_finish` to the rest of the crate. Use it everywhere digests are computed internally, avoiding `digest::finish` completely, including transitive uses. This requires adding new non-panicking variants of several APIs. For now, make those variants non-public, until tests and documentation are updated.

This is a bit too extreme because we know some of these cases will never fail as the input is known to be short. We will need to choose to either just accept this, or introduce another new (internal?) infallible API.