### PR TITLE
aes_gcm: Change `InOut` semantics.

### DIFF
--- a/src/aead/aes/ffi.rs
+++ b/src/aead/aes/ffi.rs
@@ -167,10 +167,10 @@ impl AES_KEY {
             key: &AES_KEY,
             ivec: &Counter,
         ),
-        mut in_out: InOut<'_>,
+        in_out: InOut<'_>,
         ctr: &mut Counter,
     ) {
-        let (input, output, len) = in_out.input_output_len();
+        let (input, output, len) = in_out.into_input_output_len();
         debug_assert_eq!(len % BLOCK_LEN, 0);
 
         let blocks = match NonZeroUsize::new(len / BLOCK_LEN) {

--- a/src/aead/inout.rs
+++ b/src/aead/inout.rs
@@ -42,7 +42,7 @@ impl InOut<'_> {
     pub fn len(&self) -> usize {
         self.in_out[self.src.clone()].len()
     }
-    pub fn input_output_len(&mut self) -> (*const u8, *mut u8, usize) {
+    pub fn into_input_output_len(self) -> (*const u8, *mut u8, usize) {
         let len = self.len();
         let output = self.in_out.as_mut_ptr();
         // TODO: MSRV(1.65): use `output.cast_const()`


### PR DESCRIPTION
We convert an `InOut` to pointers only immediately prior to calling a function that will immediately invalidate the input. Therefore, it makes more sense for the conversion to consume the `InOut`.