### PR TITLE
error handling: Refactor how "Input too long" errors are handled.

### DIFF
--- a/src/error/input_too_long.rs
+++ b/src/error/input_too_long.rs
@@ -1,0 +1,39 @@
+// Copyright 2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+pub struct InputTooLongError<T = usize> {
+    /// Note that this might not actually be the (exact) length of the input,
+    /// and its units might be lost. For example, it could be any of the
+    /// following:
+    ///
+    ///    * The length in bytes of the entire input.
+    ///    * The length in bytes of some *part* of the input.
+    ///    * A bit length.
+    ///    * A length in terms of "blocks" or other grouping of input values.
+    ///    * Some intermediate quantity that was used when checking the input
+    ///      length.
+    ///    * Some arbitrary value.
+    #[allow(dead_code)]
+    imprecise_input_length: T,
+}
+
+impl<T> InputTooLongError<T> {
+    #[cold]
+    #[inline(never)]
+    pub(crate) fn new(imprecise_input_length: T) -> Self {
+        Self {
+            imprecise_input_length,
+        }
+    }
+}

--- a/src/error/into_unspecified.rs
+++ b/src/error/into_unspecified.rs
@@ -15,19 +15,19 @@
 use crate::error::{KeyRejected, Unspecified};
 
 impl From<untrusted::EndOfInput> for Unspecified {
-    fn from(_: untrusted::EndOfInput) -> Self {
-        Self
+    fn from(source: untrusted::EndOfInput) -> Self {
+        super::erase(source)
     }
 }
 
 impl From<core::array::TryFromSliceError> for Unspecified {
-    fn from(_: core::array::TryFromSliceError) -> Self {
-        Self
+    fn from(source: core::array::TryFromSliceError) -> Self {
+        super::erase(source)
     }
 }
 
 impl From<KeyRejected> for Unspecified {
-    fn from(_: KeyRejected) -> Self {
-        Self
+    fn from(source: KeyRejected) -> Self {
+        super::erase(source)
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -16,6 +16,15 @@
 
 pub use self::{key_rejected::KeyRejected, unspecified::Unspecified};
 
+pub(crate) use self::input_too_long::InputTooLongError;
+
+mod input_too_long;
 mod into_unspecified;
 mod key_rejected;
 mod unspecified;
+
+#[cold]
+#[inline(never)]
+pub(crate) fn erase<T>(_: T) -> Unspecified {
+    Unspecified
+}

--- a/src/rsa/public_modulus.rs
+++ b/src/rsa/public_modulus.rs
@@ -1,7 +1,8 @@
 use crate::{
     arithmetic::{bigint, montgomery::RR},
     bits::{self, FromByteLen as _},
-    cpu, error,
+    cpu,
+    error::{self, InputTooLongError},
     rsa::N,
 };
 use core::ops::RangeInclusive;
@@ -45,8 +46,9 @@ impl PublicModulus {
         // the public modulus to be exactly 2048 or 3072 bits, but we are more
         // flexible to be compatible with other commonly-used crypto libraries.
         assert!(min_bits >= MIN_BITS);
-        let bits_rounded_up =
-            bits::BitLength::from_byte_len(bits.as_usize_bytes_rounded_up()).unwrap(); // TODO: safe?
+        let bits_rounded_up = bits::BitLength::from_byte_len(bits.as_usize_bytes_rounded_up())
+            .map_err(error::erase::<InputTooLongError>)
+            .unwrap(); // TODO: safe?
         if bits_rounded_up < min_bits {
             return Err(error::KeyRejected::too_small());
         }

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -19,7 +19,9 @@ use super::{
 };
 use crate::{
     bits::{self, FromByteLen as _},
-    cpu, digest, error, sealed, signature,
+    cpu, digest,
+    error::{self, InputTooLongError},
+    sealed, signature,
 };
 
 impl signature::VerificationAlgorithm for RsaParameters {
@@ -201,7 +203,8 @@ pub(crate) fn verify_rsa_(
     cpu_features: cpu::Features,
 ) -> Result<(), error::Unspecified> {
     let max_bits: bits::BitLength =
-        bits::BitLength::from_byte_len(PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN)?;
+        bits::BitLength::from_byte_len(PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN)
+            .map_err(error::erase::<InputTooLongError>)?;
 
     // XXX: FIPS 186-4 seems to indicate that the minimum
     // exponent value is 2**16 + 1, but it isn't clear if this is just for

--- a/src/tests/bits_tests.rs
+++ b/src/tests/bits_tests.rs
@@ -13,11 +13,8 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{
+    bits::{BitLength, FromByteLen as _},
     polyfill::u64_from_usize,
-    {
-        bits::{BitLength, FromByteLen as _},
-        error,
-    },
 };
 
 #[test]
@@ -25,43 +22,43 @@ fn test_from_byte_len_overflow() {
     const USIZE_MAX_VALID_BYTES: usize = usize::MAX / 8;
 
     // Maximum valid input for BitLength<usize>.
-    {
-        let bits = BitLength::<usize>::from_byte_len(USIZE_MAX_VALID_BYTES).unwrap();
-        assert_eq!(bits.as_usize_bytes_rounded_up(), USIZE_MAX_VALID_BYTES);
-        assert_eq!(bits.as_bits(), usize::MAX & !0b111);
+    match BitLength::<usize>::from_byte_len(USIZE_MAX_VALID_BYTES) {
+        Ok(bits) => {
+            assert_eq!(bits.as_usize_bytes_rounded_up(), USIZE_MAX_VALID_BYTES);
+            assert_eq!(bits.as_bits(), usize::MAX & !0b111);
+        }
+        Err(_) => unreachable!(),
     }
 
     // Minimum invalid usize input for BitLength<usize>.
-    assert_eq!(
-        BitLength::<usize>::from_byte_len(USIZE_MAX_VALID_BYTES + 1),
-        Err(error::Unspecified)
-    );
+    assert!(BitLength::<usize>::from_byte_len(USIZE_MAX_VALID_BYTES + 1).is_err());
 
     // Minimum invalid usize input for BitLength<u64> on 64-bit targets.
     {
-        let bits = BitLength::<u64>::from_byte_len(USIZE_MAX_VALID_BYTES + 1);
+        let r = BitLength::<u64>::from_byte_len(USIZE_MAX_VALID_BYTES + 1);
         if cfg!(target_pointer_width = "64") {
-            assert_eq!(bits, Err(error::Unspecified));
+            assert!(r.is_err());
         } else {
-            let bits = bits.unwrap();
-            assert_eq!(
-                bits.as_bits(),
-                (u64_from_usize(USIZE_MAX_VALID_BYTES) + 1) * 8
-            );
+            match r {
+                Ok(bits) => {
+                    assert_eq!(
+                        bits.as_bits(),
+                        (u64_from_usize(USIZE_MAX_VALID_BYTES) + 1) * 8
+                    );
+                }
+                Err(_) => unreachable!(),
+            }
         }
     }
 
     const U64_MAX_VALID_BYTES: u64 = u64::MAX / 8;
 
     // Maximum valid u64 input for BitLength<u64>.
-    {
-        let bits = BitLength::<u64>::from_byte_len(U64_MAX_VALID_BYTES).unwrap();
-        assert_eq!(bits.as_bits(), u64::MAX & !0b111);
-    }
+    match BitLength::<u64>::from_byte_len(U64_MAX_VALID_BYTES) {
+        Ok(bits) => assert_eq!(bits.as_bits(), u64::MAX & !0b111),
+        Err(_) => unreachable!(),
+    };
 
     // Minimum invalid usize input for BitLength<u64> on 64-bit targets.
-    {
-        let bits = BitLength::<u64>::from_byte_len(U64_MAX_VALID_BYTES + 1);
-        assert_eq!(bits, Err(error::Unspecified));
-    }
+    assert!(BitLength::<u64>::from_byte_len(U64_MAX_VALID_BYTES + 1).is_err());
 }


### PR DESCRIPTION
Handle "input too long" errors consistently across the `digest` and `bits` modules. This is a step towards more modules doing the same.