### PR TITLE
aead internals: Move/rename `aead::inout` to `aead::overlapping`.

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -34,7 +34,6 @@ pub use self::{
     sealing_key::SealingKey,
     unbound_key::UnboundKey,
 };
-use inout::InOut;
 
 /// A sequences of unique nonces.
 ///
@@ -176,10 +175,10 @@ mod chacha;
 mod chacha20_poly1305;
 pub mod chacha20_poly1305_openssh;
 mod gcm;
-mod inout;
 mod less_safe_key;
 mod nonce;
 mod opening_key;
+mod overlapping;
 mod poly1305;
 pub mod quic;
 mod sealing_key;

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -32,7 +32,7 @@ pub(super) mod fallback;
 pub(super) mod hw;
 pub(super) mod vp;
 
-pub type Overlapping<'o> = overlapping::Overlapping<'o>;
+pub type Overlapping<'o> = overlapping::Overlapping<'o, u8>;
 
 cfg_if! {
     if #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))] {

--- a/src/aead/aes/bs.rs
+++ b/src/aead/aes/bs.rs
@@ -14,7 +14,7 @@
 
 #![cfg(target_arch = "arm")]
 
-use super::{Counter, InOut, AES_KEY};
+use super::{Counter, Overlapping, AES_KEY};
 
 /// SAFETY:
 ///   * The caller must ensure that if blocks > 0 then either `input` and
@@ -27,7 +27,7 @@ use super::{Counter, InOut, AES_KEY};
 ///   * Upon returning, `blocks` blocks will have been read from `input` and
 ///     written to `output`.
 pub(super) unsafe fn ctr32_encrypt_blocks_with_vpaes_key(
-    in_out: InOut<'_>,
+    in_out: Overlapping<'_>,
     vpaes_key: &AES_KEY,
     ctr: &mut Counter,
 ) {

--- a/src/aead/aes/fallback.rs
+++ b/src/aead/aes/fallback.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{Block, Counter, EncryptBlock, EncryptCtr32, InOut, Iv, KeyBytes, AES_KEY};
+use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, Overlapping, AES_KEY};
 use crate::error;
 
 #[derive(Clone)]
@@ -38,7 +38,7 @@ impl EncryptBlock for Key {
 }
 
 impl EncryptCtr32 for Key {
-    fn ctr32_encrypt_within(&self, in_out: InOut<'_>, ctr: &mut Counter) {
+    fn ctr32_encrypt_within(&self, in_out: Overlapping<'_>, ctr: &mut Counter) {
         unsafe { ctr32_encrypt_blocks!(aes_nohw_ctr32_encrypt_blocks, in_out, &self.inner, ctr) }
     }
 }

--- a/src/aead/aes/ffi.rs
+++ b/src/aead/aes/ffi.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{Block, InOut, KeyBytes, BLOCK_LEN};
+use super::{Block, KeyBytes, Overlapping, BLOCK_LEN};
 use crate::{bits::BitLength, c, error};
 use core::num::{NonZeroU32, NonZeroUsize};
 
@@ -167,7 +167,7 @@ impl AES_KEY {
             key: &AES_KEY,
             ivec: &Counter,
         ),
-        in_out: InOut<'_>,
+        in_out: Overlapping<'_>,
         ctr: &mut Counter,
     ) {
         let (input, output, len) = in_out.into_input_output_len();

--- a/src/aead/aes/hw.rs
+++ b/src/aead/aes/hw.rs
@@ -14,7 +14,7 @@
 
 #![cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 
-use super::{Block, Counter, EncryptBlock, EncryptCtr32, InOut, Iv, KeyBytes, AES_KEY};
+use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, Overlapping, AES_KEY};
 use crate::{cpu, error};
 
 #[cfg(target_arch = "aarch64")]
@@ -55,7 +55,7 @@ impl EncryptBlock for Key {
 }
 
 impl EncryptCtr32 for Key {
-    fn ctr32_encrypt_within(&self, in_out: InOut<'_>, ctr: &mut Counter) {
+    fn ctr32_encrypt_within(&self, in_out: Overlapping<'_>, ctr: &mut Counter) {
         #[cfg(target_arch = "x86_64")]
         let _: cpu::Features = cpu::features();
         unsafe { ctr32_encrypt_blocks!(aes_hw_ctr32_encrypt_blocks, in_out, &self.inner, ctr) }

--- a/src/aead/aes/vp.rs
+++ b/src/aead/aes/vp.rs
@@ -64,7 +64,7 @@ impl EncryptCtr32 for Key {
 #[cfg(target_arch = "arm")]
 impl EncryptCtr32 for Key {
     fn ctr32_encrypt_within(&self, in_out: Overlapping<'_>, ctr: &mut Counter) {
-        use super::{bs, BLOCK_LEN};
+        use super::{super::overlapping::SrcIndexError, bs, BLOCK_LEN};
 
         let in_out = {
             let (in_out, src) = in_out.into_slice_src_mut();
@@ -86,7 +86,7 @@ impl EncryptCtr32 for Key {
             let bsaes_in_out_len = bsaes_blocks * BLOCK_LEN;
             let bs_in_out =
                 Overlapping::new(&mut in_out[..(src.start + bsaes_in_out_len)], src.clone())
-                    .unwrap();
+                    .unwrap_or_else(|SrcIndexError { .. }| unreachable!());
 
             // SAFETY:
             //  * self.inner was initialized with `vpaes_set_encrypt_key` above,
@@ -95,7 +95,8 @@ impl EncryptCtr32 for Key {
                 bs::ctr32_encrypt_blocks_with_vpaes_key(bs_in_out, &self.inner, ctr);
             }
 
-            Overlapping::new(&mut in_out[bsaes_in_out_len..], src).unwrap()
+            Overlapping::new(&mut in_out[bsaes_in_out_len..], src)
+                .unwrap_or_else(|SrcIndexError { .. }| unreachable!())
         };
 
         // SAFETY:

--- a/src/aead/overlapping/base.rs
+++ b/src/aead/overlapping/base.rs
@@ -58,6 +58,7 @@ pub struct SrcIndexError(#[allow(dead_code)] RangeFrom<usize>);
 
 impl SrcIndexError {
     #[cold]
+    #[inline(never)]
     fn new(src: RangeFrom<usize>) -> Self {
         Self(src)
     }

--- a/src/aead/overlapping/base.rs
+++ b/src/aead/overlapping/base.rs
@@ -55,7 +55,6 @@ impl<T> Overlapping<'_, T> {
     }
 }
 
-#[derive(Debug)]
 pub struct SrcIndexError(#[allow(dead_code)] RangeFrom<usize>);
 
 impl SrcIndexError {

--- a/src/aead/overlapping/base.rs
+++ b/src/aead/overlapping/base.rs
@@ -15,17 +15,17 @@
 use crate::error;
 use core::ops::RangeFrom;
 
-pub struct InOut<'i> {
-    in_out: &'i mut [u8],
+pub struct Overlapping<'o> {
+    in_out: &'o mut [u8],
     src: RangeFrom<usize>,
 }
 
-impl<'i> InOut<'i> {
-    pub fn in_place(in_out: &'i mut [u8]) -> Self {
+impl<'o> Overlapping<'o> {
+    pub fn in_place(in_out: &'o mut [u8]) -> Self {
         Self { in_out, src: 0.. }
     }
 
-    pub fn overlapping(in_out: &'i mut [u8], src: RangeFrom<usize>) -> Result<Self, SrcIndexError> {
+    pub fn new(in_out: &'o mut [u8], src: RangeFrom<usize>) -> Result<Self, SrcIndexError> {
         match in_out.get(src.clone()) {
             Some(_) => Ok(Self { in_out, src }),
             None => Err(SrcIndexError::new(src)),
@@ -33,12 +33,12 @@ impl<'i> InOut<'i> {
     }
 
     #[cfg(any(target_arch = "arm", target_arch = "x86"))]
-    pub fn into_slice_src_mut(self) -> (&'i mut [u8], RangeFrom<usize>) {
+    pub fn into_slice_src_mut(self) -> (&'o mut [u8], RangeFrom<usize>) {
         (self.in_out, self.src)
     }
 }
 
-impl InOut<'_> {
+impl Overlapping<'_> {
     pub fn len(&self) -> usize {
         self.in_out[self.src.clone()].len()
     }

--- a/src/aead/overlapping/base.rs
+++ b/src/aead/overlapping/base.rs
@@ -12,7 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use crate::error;
 use core::ops::RangeFrom;
 
 pub struct Overlapping<'o, T> {
@@ -61,11 +60,5 @@ impl SrcIndexError {
     #[cold]
     fn new(src: RangeFrom<usize>) -> Self {
         Self(src)
-    }
-}
-
-impl From<SrcIndexError> for error::Unspecified {
-    fn from(_: SrcIndexError) -> Self {
-        Self
     }
 }

--- a/src/aead/overlapping/mod.rs
+++ b/src/aead/overlapping/mod.rs
@@ -12,7 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#[allow(unused_imports)]
 pub use self::base::{Overlapping, SrcIndexError};
 
 mod base;

--- a/src/aead/overlapping/mod.rs
+++ b/src/aead/overlapping/mod.rs
@@ -12,6 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-pub use self::base::Overlapping;
+#[allow(unused_imports)]
+pub use self::base::{Overlapping, SrcIndexError};
 
 mod base;

--- a/src/aead/overlapping/mod.rs
+++ b/src/aead/overlapping/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+pub use self::base::Overlapping;
+
+mod base;

--- a/src/aead/shift.rs
+++ b/src/aead/shift.rs
@@ -16,7 +16,7 @@ use crate::polyfill::sliceutil::overwrite_at_start;
 
 #[cfg(target_arch = "x86")]
 pub fn shift_full_blocks<const BLOCK_LEN: usize>(
-    in_out: super::InOut<'_>,
+    in_out: super::overlapping::Overlapping<'_>,
     mut transform: impl FnMut(&[u8; BLOCK_LEN]) -> [u8; BLOCK_LEN],
 ) {
     let (in_out, src) = in_out.into_slice_src_mut();

--- a/src/aead/shift.rs
+++ b/src/aead/shift.rs
@@ -16,7 +16,7 @@ use crate::polyfill::sliceutil::overwrite_at_start;
 
 #[cfg(target_arch = "x86")]
 pub fn shift_full_blocks<const BLOCK_LEN: usize>(
-    in_out: super::overlapping::Overlapping<'_>,
+    in_out: super::overlapping::Overlapping<'_, u8>,
     mut transform: impl FnMut(&[u8; BLOCK_LEN]) -> [u8; BLOCK_LEN],
 ) {
     let (in_out, src) = in_out.into_slice_src_mut();


### PR DESCRIPTION
See individual commit messages for details.