### PR TITLE
chacha: Use `Overlapping` in the implementation of the fallback impl.

### DIFF
--- a/src/aead/aes/vp.rs
+++ b/src/aead/aes/vp.rs
@@ -64,7 +64,7 @@ impl EncryptCtr32 for Key {
 #[cfg(target_arch = "arm")]
 impl EncryptCtr32 for Key {
     fn ctr32_encrypt_within(&self, in_out: Overlapping<'_>, ctr: &mut Counter) {
-        use super::{super::overlapping::SrcIndexError, bs, BLOCK_LEN};
+        use super::{super::overlapping::IndexError, bs, BLOCK_LEN};
 
         let in_out = {
             let (in_out, src) = in_out.into_slice_src_mut();
@@ -86,7 +86,7 @@ impl EncryptCtr32 for Key {
             let bsaes_in_out_len = bsaes_blocks * BLOCK_LEN;
             let bs_in_out =
                 Overlapping::new(&mut in_out[..(src.start + bsaes_in_out_len)], src.clone())
-                    .unwrap_or_else(|SrcIndexError { .. }| unreachable!());
+                    .unwrap_or_else(|IndexError { .. }| unreachable!());
 
             // SAFETY:
             //  * self.inner was initialized with `vpaes_set_encrypt_key` above,
@@ -96,7 +96,7 @@ impl EncryptCtr32 for Key {
             }
 
             Overlapping::new(&mut in_out[bsaes_in_out_len..], src)
-                .unwrap_or_else(|SrcIndexError { .. }| unreachable!())
+                .unwrap_or_else(|IndexError { .. }| unreachable!())
         };
 
         // SAFETY:

--- a/src/aead/algorithm.rs
+++ b/src/aead/algorithm.rs
@@ -22,7 +22,7 @@ use core::ops::RangeFrom;
 use super::{
     aes, aes_gcm, chacha20_poly1305,
     nonce::{Nonce, NONCE_LEN},
-    overlapping::{Overlapping, SrcIndexError},
+    overlapping::{IndexError, Overlapping},
     Aad, KeyInner, Tag, TAG_LEN,
 };
 
@@ -265,7 +265,7 @@ fn chacha20_poly1305_open(
         KeyInner::ChaCha20Poly1305(key) => key,
         _ => unreachable!(),
     };
-    let in_out = Overlapping::new(in_out, src).map_err(error::erase::<SrcIndexError>)?;
+    let in_out = Overlapping::new(in_out, src).map_err(error::erase::<IndexError>)?;
     chacha20_poly1305::open(key, nonce, aad, in_out, cpu_features)
         .map_err(error::erase::<InputTooLongError>)
 }

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -179,7 +179,7 @@ const BLOCK_LEN: usize = 64;
 mod tests {
     extern crate alloc;
 
-    use super::{super::overlapping::SrcIndexError, *};
+    use super::{super::overlapping::IndexError, *};
     use crate::{error, test};
     use alloc::vec;
 
@@ -286,7 +286,7 @@ mod tests {
                     ctr,
                 );
                 let in_out = Overlapping::new(buf, src)
-                    .map_err(error::erase::<SrcIndexError>)
+                    .map_err(error::erase::<IndexError>)
                     .unwrap();
                 f(key, ctr, in_out);
                 assert_eq!(&buf[..input.len()], expected)

--- a/src/aead/overlapping/array.rs
+++ b/src/aead/overlapping/array.rs
@@ -1,0 +1,72 @@
+// Copyright 2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg_attr(not(test), allow(dead_code))]
+
+use super::Overlapping;
+use core::array::TryFromSliceError;
+
+pub struct Array<'o, T, const N: usize> {
+    // Invariant: N != 0.
+    // Invariant: `self.in_out.len() == N`.
+    in_out: Overlapping<'o, T>,
+}
+
+impl<'o, T, const N: usize> Array<'o, T, N> {
+    pub(super) fn new(in_out: Overlapping<'o, T>) -> Result<Self, LenMismatchError> {
+        if N == 0 || in_out.len() != N {
+            return Err(LenMismatchError::new(N));
+        }
+        Ok(Self { in_out })
+    }
+
+    pub fn into_unwritten_output(self) -> &'o mut [T; N]
+    where
+        &'o mut [T]: TryInto<&'o mut [T; N], Error = TryFromSliceError>,
+    {
+        self.in_out
+            .into_unwritten_output()
+            .try_into()
+            .unwrap_or_else(|TryFromSliceError { .. }| {
+                unreachable!() // Due to invariant
+            })
+    }
+}
+
+impl<T, const N: usize> Array<'_, T, N> {
+    pub fn input<'s>(&'s self) -> &'s [T; N]
+    where
+        &'s [T]: TryInto<&'s [T; N], Error = TryFromSliceError>,
+    {
+        self.in_out
+            .input()
+            .try_into()
+            .unwrap_or_else(|TryFromSliceError { .. }| {
+                unreachable!() // Due to invariant
+            })
+    }
+}
+
+pub struct LenMismatchError {
+    #[allow(dead_code)]
+    len: usize,
+}
+
+impl LenMismatchError {
+    #[cold]
+    #[inline(never)]
+    fn new(len: usize) -> Self {
+        Self { len }
+    }
+}

--- a/src/aead/overlapping/base.rs
+++ b/src/aead/overlapping/base.rs
@@ -25,10 +25,10 @@ impl<'o, T> Overlapping<'o, T> {
         Self { in_out, src: 0.. }
     }
 
-    pub fn new(in_out: &'o mut [T], src: RangeFrom<usize>) -> Result<Self, SrcIndexError> {
+    pub fn new(in_out: &'o mut [T], src: RangeFrom<usize>) -> Result<Self, IndexError> {
         match in_out.get(src.clone()) {
             Some(_) => Ok(Self { in_out, src }),
-            None => Err(SrcIndexError::new(src)),
+            None => Err(IndexError::new(src)),
         }
     }
 
@@ -85,9 +85,9 @@ impl<T> Overlapping<'_, T> {
     }
 }
 
-pub struct SrcIndexError(#[allow(dead_code)] RangeFrom<usize>);
+pub struct IndexError(#[allow(dead_code)] RangeFrom<usize>);
 
-impl SrcIndexError {
+impl IndexError {
     #[cold]
     #[inline(never)]
     fn new(src: RangeFrom<usize>) -> Self {

--- a/src/aead/overlapping/mod.rs
+++ b/src/aead/overlapping/mod.rs
@@ -13,9 +13,13 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 pub use self::{
+    array::Array,
     base::{IndexError, Overlapping},
     partial_block::PartialBlock,
 };
 
+use self::array::LenMismatchError;
+
+mod array;
 mod base;
 mod partial_block;

--- a/src/aead/overlapping/mod.rs
+++ b/src/aead/overlapping/mod.rs
@@ -13,7 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 pub use self::{
-    base::{Overlapping, SrcIndexError},
+    base::{IndexError, Overlapping},
     partial_block::PartialBlock,
 };
 


### PR DESCRIPTION
Eliminate all of the `unsafe` in the fallback implementation.