### PR TITLE
limb: Unmerge `usize_from_u32` import from `"alloc"`-guarded `use`

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -20,11 +20,11 @@
 
 use crate::{
     c, constant_time, error,
-    polyfill::{slice, ArrayFlatMap},
+    polyfill::{slice, usize_from_u32, ArrayFlatMap},
 };
 
 #[cfg(any(test, feature = "alloc"))]
-use crate::{bits, polyfill::usize_from_u32};
+use crate::bits;
 
 #[cfg(feature = "alloc")]
 use core::num::Wrapping;


### PR DESCRIPTION
Since commit e88750b87 ("Define native word size as `constant_time::Word`.") `usize_from_u32()` is unconditionally used in and via global `const`s but was (likely accidentally by means of `rust-analyzer`) merged into a `use` statement that's guarded by `feature = "alloc"`.  When compiling this crate without that feature, which happens with `default-features = false`, this fails to compile due to missing the import.

Moving the import to the unguarded `use crate::` group solves this.
