### PR TITLE
Separate getrandom features for wasm32-unknown-unknown target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,9 @@ std = ["alloc"]
 unstable-testing-arm-no-hw = []
 unstable-testing-arm-no-neon = []
 test_logging = []
-wasm32_unknown_unknown_js = ["getrandom/js"]
+wasm32_unknown_unknown_custom_or_js = []
+wasm32_unknown_unknown_custom = ["wasm32_unknown_unknown_custom_or_js", "getrandom/custom"]
+wasm32_unknown_unknown_js = ["wasm32_unknown_unknown_custom_or_js", "getrandom/js"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,17 @@
 //! <tr><td><code>std</code>
 //!     <td>Enable features that use libstd, in particular
 //!         <code>std::error::Error</code> integration. Implies `alloc`.
-//! <tr><td><code>wasm32_unknown_unknown_js</code>
+//! <tr><td><code>wasm32_unknown_unknown_custom_or_js</code>
 //!     <td>When this feature is enabled, for the wasm32-unknown-unknown target,
 //!         Web APIs will be used to implement features like `ring::rand` that
 //!         require an operating environment of some kind. This has no effect
-//!         for any other target. This enables the `getrandom` crate's `js`
-//!         feature.
+//!         for any other target.
+//! <tr><td><code>wasm32_unknown_unknown_js</code>
+//!     <td>Enable both `wasm32_unknown_unknown_custom_or_js` and the `getrandom`
+//!         crate's `js` feature.
+//! <tr><td><code>wasm32_unknown_unknown_custom</code>
+//!     <td>Enable both `wasm32_unknown_unknown_custom_or_js` and the `getrandom`
+//!         crate's `custom` feature.
 //! </table>
 
 // When running mk/package.sh, don't actually build any code.

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -154,7 +154,7 @@ impl crate::sealed::Sealed for SystemRandom {}
         target_arch = "wasm32",
         any(
             target_os = "wasi",
-            all(target_os = "unknown", feature = "wasm32_unknown_unknown_js")
+            all(target_os = "unknown", feature = "wasm32_unknown_unknown_custom_or_js")
         )
     ),
 ))]


### PR DESCRIPTION
Instead of just having one `wasm32_unknown_unknown_js` feature that imposes `getrandom/js` upon ring's users, two additional features are added to provide more flexibility.

- `wasm32_unknown_unknown_custom_or_js` implements `SecureRandom` for `SystemRandom`, but does not make a choice between `getrandom/js` or `getrandom/custom`. It instead delegates the choice to the library's user.
- `wasm32_unknown_unknown_js` enables both `wasm32_unknown_unknown_custom_or_js` and `getrandom/js`.
- `wasm32_unknown_unknown_custom` enables both `wasm32_unknown_unknown_custom_or_js` and `getrandom/custom`.

This change is only relevant for the `wasm32-unknown-unknown` target.
