### PR TITLE
Restrict usage of assembly code to little endian for ARM & AAarch64.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,16 +157,16 @@ cfg-if = { version = "1.0.0", default-features = false }
 getrandom = { version = "0.2.10" }
 untrusted = { version = "0.9" }
 
-[target.'cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86",target_arch = "x86_64"))'.dependencies]
+[target.'cfg(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little"), target_arch = "x86",target_arch = "x86_64"))'.dependencies]
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
 
-[target.'cfg(all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "linux")))'.dependencies]
+[target.'cfg(all(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little")), any(target_os = "android", target_os = "linux")))'.dependencies]
 libc = { version = "0.2.148", default-features = false }
 
-[target.'cfg(all(target_arch = "aarch64", target_vendor = "apple", any(target_os = "ios", target_os = "macos", target_os = "tvos", target_os = "visionos", target_os = "watchos")))'.dependencies]
+[target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_vendor = "apple", any(target_os = "ios", target_os = "macos", target_os = "tvos", target_os = "visionos", target_os = "watchos")))'.dependencies]
 libc = { version = "0.2.155", default-features = false }
 
-[target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
+[target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_os = "windows"))'.dependencies]
 windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -301,6 +301,8 @@ fn ring_build_rs_main(c_root_dir: &Path, core_name_and_version: &str) {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+    let endian = env::var("CARGO_CFG_TARGET_ENDIAN").unwrap();
+    let is_little_endian = endian == "little";
 
     let is_git = fs::metadata(c_root_dir.join(".git")).is_ok();
 
@@ -321,9 +323,13 @@ fn ring_build_rs_main(c_root_dir: &Path, core_name_and_version: &str) {
         force_warnings_into_errors,
     };
 
-    let asm_target = ASM_TARGETS.iter().find(|asm_target| {
-        asm_target.arch == target.arch && asm_target.oss.contains(&target.os.as_ref())
-    });
+    let asm_target = if is_little_endian {
+        ASM_TARGETS.iter().find(|asm_target| {
+            asm_target.arch == target.arch && asm_target.oss.contains(&target.os.as_ref())
+        })
+    } else {
+        None
+    };
 
     // If `.git` exists then assume this is the "local hacking" case where
     // we want to make it easy to build *ring* using `cargo build`/`cargo test`

--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -36,7 +36,7 @@ pub type Overlapping<'o> = overlapping::Overlapping<'o, u8>;
 pub type OverlappingPartialBlock<'o> = overlapping::PartialBlock<'o, u8, BLOCK_LEN>;
 
 cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))] {
+    if #[cfg(any(all(target_arch = "aarch64", target_endian = "little"), target_arch = "x86_64"))] {
         pub(super) use ffi::AES_KEY;
     } else {
         use ffi::AES_KEY;
@@ -45,12 +45,16 @@ cfg_if! {
 
 #[derive(Clone)]
 pub(super) enum Key {
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64",
+        target_arch = "x86"
+    ))]
     Hw(hw::Key),
 
     #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "arm", target_endian = "little"),
         target_arch = "x86",
         target_arch = "x86_64"
     ))]
@@ -65,14 +69,18 @@ impl Key {
         bytes: KeyBytes<'_>,
         cpu_features: cpu::Features,
     ) -> Result<Self, error::Unspecified> {
-        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(any(
+            all(target_arch = "aarch64", target_endian = "little"),
+            target_arch = "x86",
+            target_arch = "x86_64"
+        ))]
         if let Some(hw_features) = cpu_features.get_feature() {
             return Ok(Self::Hw(hw::Key::new(bytes, hw_features)?));
         }
 
         #[cfg(any(
-            target_arch = "aarch64",
-            target_arch = "arm",
+            all(target_arch = "aarch64", target_endian = "little"),
+            all(target_arch = "arm", target_endian = "little"),
             target_arch = "x86_64",
             target_arch = "x86"
         ))]
@@ -88,12 +96,16 @@ impl Key {
     #[inline]
     fn encrypt_block(&self, a: Block) -> Block {
         match self {
-            #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))]
+            #[cfg(any(
+                all(target_arch = "aarch64", target_endian = "little"),
+                target_arch = "x86_64",
+                target_arch = "x86"
+            ))]
             Key::Hw(inner) => inner.encrypt_block(a),
 
             #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "arm",
+                all(target_arch = "aarch64", target_endian = "little"),
+                all(target_arch = "arm", target_endian = "little"),
                 target_arch = "x86",
                 target_arch = "x86_64"
             ))]

--- a/src/aead/aes/bs.rs
+++ b/src/aead/aes/bs.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(target_arch = "arm")]
+#![cfg(all(target_arch = "arm", target_endian = "little"))]
 
 use super::{Counter, Overlapping, AES_KEY};
 

--- a/src/aead/aes/ffi.rs
+++ b/src/aead/aes/ffi.rs
@@ -57,7 +57,7 @@ impl AES_KEY {
     }
 }
 
-#[cfg(target_arch = "arm")]
+#[cfg(all(target_arch = "arm", target_endian = "little"))]
 impl AES_KEY {
     pub(super) unsafe fn derive(
         f: for<'a> unsafe extern "C" fn(*mut AES_KEY, &'a AES_KEY),

--- a/src/aead/aes/hw.rs
+++ b/src/aead/aes/hw.rs
@@ -12,12 +12,16 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
+#![cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
 
 use super::{Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, Overlapping, AES_KEY};
 use crate::{cpu, error};
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 pub(in super::super) type RequiredCpuFeatures = cpu::arm::Aes;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -37,7 +41,10 @@ impl Key {
         Ok(Self { inner })
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     #[must_use]
     pub(in super::super) fn inner_less_safe(&self) -> &AES_KEY {
         &self.inner

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -18,8 +18,8 @@ use super::{overlapping, quic::Sample, Nonce};
 #[cfg(any(
     test,
     not(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "arm", target_endian = "little"),
         target_arch = "x86",
         target_arch = "x86_64"
     ))
@@ -71,8 +71,8 @@ impl Key {
     #[inline(always)]
     pub fn encrypt_within(&self, counter: Counter, in_out: Overlapping<'_>) {
         #[cfg(any(
-            target_arch = "aarch64",
-            target_arch = "arm",
+            all(target_arch = "aarch64", target_endian = "little"),
+            all(target_arch = "arm", target_endian = "little"),
             target_arch = "x86",
             target_arch = "x86_64"
         ))]
@@ -84,7 +84,10 @@ impl Key {
             // has this limitation and come up with a better solution.
             //
             // https://rt.openssl.org/Ticket/Display.html?id=4362
-            #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+            #[cfg(not(any(
+                all(target_arch = "aarch64", target_endian = "little"),
+                target_arch = "x86_64"
+            )))]
             let in_out = Overlapping::in_place(in_out.copy_within());
 
             let (input, output, len) = in_out.into_input_output_len();
@@ -104,8 +107,8 @@ impl Key {
         }
 
         #[cfg(not(any(
-            target_arch = "aarch64",
-            target_arch = "arm",
+            all(target_arch = "aarch64", target_endian = "little"),
+            all(target_arch = "arm", target_endian = "little"),
             target_arch = "x86",
             target_arch = "x86_64"
         )))]
@@ -145,8 +148,8 @@ impl Counter {
     #[cfg(any(
         test,
         not(any(
-            target_arch = "aarch64",
-            target_arch = "arm",
+            all(target_arch = "aarch64", target_endian = "little"),
+            all(target_arch = "arm", target_endian = "little"),
             target_arch = "x86",
             target_arch = "x86_64"
         ))
@@ -195,8 +198,8 @@ mod tests {
     fn chacha20_test_default() {
         // Always use `MAX_OFFSET` if we hav assembly code.
         let max_offset = if cfg!(any(
-            target_arch = "aarch64",
-            target_arch = "arm",
+            all(target_arch = "aarch64", target_endian = "little"),
+            all(target_arch = "arm", target_endian = "little"),
             target_arch = "x86",
             target_arch = "x86_64"
         )) {

--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -55,7 +55,10 @@ pub(super) fn seal(
     /// check.
     const _USIZE_BOUNDED_BY_U64: u64 = u64_from_usize(usize::MAX);
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     if has_integrated(cpu_features) {
         // XXX: BoringSSL uses `alignas(16)` on `key` instead of on the
         // structure, but Rust can't do that yet; see
@@ -139,7 +142,10 @@ pub(super) fn open(
     // check.
     const _USIZE_BOUNDED_BY_U64: u64 = u64_from_usize(usize::MAX);
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     if has_integrated(cpu_features) {
         // XXX: BoringSSL uses `alignas(16)` on `key` instead of on the
         // structure, but Rust can't do that yet; see
@@ -204,11 +210,14 @@ pub(super) fn open(
     Ok(finish(auth, aad.as_ref().len(), in_out_len))
 }
 
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86_64"
+))]
 #[allow(clippy::needless_return)]
 #[inline(always)]
 fn has_integrated(cpu_features: cpu::Features) -> bool {
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     {
         return cpu::arm::NEON.available(cpu_features);
     }
@@ -228,14 +237,20 @@ fn finish(mut auth: poly1305::Context, aad_len: usize, in_out_len: usize) -> Tag
     auth.finish()
 }
 
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86_64"
+))]
 mod integrated {
     use super::super::TAG_LEN;
 
     // Keep in sync with BoringSSL's `chacha20_poly1305_open_data` and
     // `chacha20_poly1305_seal_data`.
     #[repr(C)]
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     pub(super) union InOut<T>
     where
         T: Copy,
@@ -248,7 +263,10 @@ mod integrated {
     // 16-byte aligned. In practice it will always be 16-byte aligned because it
     // is embedded in a union where the other member of the union is 16-byte
     // aligned.
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     #[derive(Clone, Copy)]
     #[repr(align(16), C)]
     pub(super) struct Out {

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -24,7 +24,7 @@ use cfg_if::cfg_if;
 pub(super) use ffi::KeyValue;
 
 cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))] {
+    if #[cfg(any(all(target_arch = "aarch64", target_endian = "little"), target_arch = "x86_64"))] {
         pub(super) use self::ffi::{HTable, Xi};
     } else {
         use self::ffi::{HTable, Xi};
@@ -84,7 +84,11 @@ impl<'key, K: Gmult> Context<'key, K> {
     }
 }
 
-#[cfg(all(target_arch = "aarch64", target_pointer_width = "64"))]
+#[cfg(all(
+    target_arch = "aarch64",
+    target_endian = "little",
+    target_pointer_width = "64"
+))]
 impl<K> Context<'_, K> {
     pub(super) fn in_out_whole_block_bits(&self) -> BitLength<usize> {
         use crate::polyfill::usize_from_u64;
@@ -96,7 +100,7 @@ impl<K> Context<'_, K> {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 /// Access to `inner` for the integrated AES-GCM implementations only.
 impl Context<'_, clmul::Key> {
     #[inline]

--- a/src/aead/gcm/clmul.rs
+++ b/src/aead/gcm/clmul.rs
@@ -12,12 +12,16 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
+#![cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
 
 use super::{ffi::KeyValue, Gmult, HTable, Xi};
 use crate::cpu;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 pub(in super::super) type RequiredCpuFeatures = cpu::arm::PMull;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -45,7 +49,10 @@ impl Key {
         }
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     pub(super) fn inner(&self) -> &HTable {
         &self.h_table
     }

--- a/src/aead/gcm/ffi.rs
+++ b/src/aead/gcm/ffi.rs
@@ -19,8 +19,8 @@ pub(in super::super) type Block = [u8; BLOCK_LEN];
 pub(super) const ZERO_BLOCK: Block = [0u8; BLOCK_LEN];
 
 #[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86",
     target_arch = "x86_64"
 ))]
@@ -35,8 +35,8 @@ macro_rules! htable_new {
 }
 
 #[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86",
     target_arch = "x86_64"
 ))]
@@ -54,8 +54,8 @@ macro_rules! gmult {
 ///  * The function `$name` must meet the contract of the `f` paramweter of
 ///    `ghash()`.
 #[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86",
     target_arch = "x86_64"
 ))]
@@ -91,8 +91,8 @@ impl KeyValue {
 ///     that `len` is a (non-zero) multiple of `BLOCK_LEN`.
 ///   * `f` may inspect CPU features.
 #[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86",
     target_arch = "x86_64"
 ))]

--- a/src/aead/gcm/neon.rs
+++ b/src/aead/gcm/neon.rs
@@ -12,7 +12,10 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+#![cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little")
+))]
 
 use super::{Gmult, HTable, KeyValue, UpdateBlocks, Xi, BLOCK_LEN};
 use crate::cpu;

--- a/src/aead/overlapping/base.rs
+++ b/src/aead/overlapping/base.rs
@@ -34,7 +34,10 @@ impl<'o, T> Overlapping<'o, T> {
         }
     }
 
-    #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+    #[cfg(any(
+        all(target_arch = "arm", target_endian = "little"),
+        target_arch = "x86"
+    ))]
     pub fn copy_within(self) -> &'o mut [T]
     where
         T: Copy,
@@ -48,7 +51,10 @@ impl<'o, T> Overlapping<'o, T> {
         }
     }
 
-    #[cfg(any(target_arch = "arm", target_arch = "x86"))]
+    #[cfg(any(
+        all(target_arch = "arm", target_endian = "little"),
+        target_arch = "x86"
+    ))]
     pub fn into_slice_src_mut(self) -> (&'o mut [T], RangeFrom<usize>) {
         (self.in_out, self.src)
     }

--- a/src/aead/poly1305.rs
+++ b/src/aead/poly1305.rs
@@ -56,7 +56,7 @@ macro_rules! dispatch {
       ( $( $a:expr ),+ ) ) => {
         match () {
             // BoringSSL uses `!defined(OPENSSL_APPLE)`.
-            #[cfg(all(target_arch = "arm", any(target_os = "android", target_os = "linux")))]
+            #[cfg(all(all(target_arch = "arm", target_endian = "little"), any(target_os = "android", target_os = "linux")))]
             () if cpu::arm::NEON.available($features) => {
                 prefixed_extern! {
                     fn $neon_f( $( $p : $t ),+ );

--- a/src/arithmetic/montgomery.rs
+++ b/src/arithmetic/montgomery.rs
@@ -126,8 +126,8 @@ unsafe fn mul_mont(
 }
 
 #[cfg(not(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86",
     target_arch = "x86_64"
 )))]
@@ -165,8 +165,8 @@ prefixed_export! {
 #[cfg(any(
     feature = "alloc",
     not(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "arm", target_endian = "little"),
         target_arch = "x86",
         target_arch = "x86_64"
     ))
@@ -198,8 +198,8 @@ pub(super) fn limbs_from_mont_in_place(r: &mut [Limb], tmp: &mut [Limb], m: &[Li
 }
 
 #[cfg(not(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86",
     target_arch = "x86_64"
 )))]
@@ -219,8 +219,8 @@ fn limbs_mul(r: &mut [Limb], a: &[Limb], b: &[Limb]) {
 #[cfg(any(
     test,
     not(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "arm", target_endian = "little"),
         target_arch = "x86_64",
         target_arch = "x86"
     ))
@@ -232,8 +232,8 @@ prefixed_extern! {
 }
 
 #[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86_64",
     target_arch = "x86"
 ))]

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -87,7 +87,10 @@ impl BitLength<usize> {
     }
 
     /// The bit length, rounded up to a whole number of bytes.
-    #[cfg(any(target_arch = "aarch64", feature = "alloc"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        feature = "alloc"
+    ))]
     #[inline]
     pub fn as_usize_bytes_rounded_up(&self) -> usize {
         // Equivalent to (self.0 + 7) / 8, except with no potential for

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -78,7 +78,7 @@ mod features {
     pub(crate) struct Features(NotSend);
 
     cfg_if::cfg_if! {
-        if #[cfg(any(target_arch = "aarch64", target_arch = "arm",
+        if #[cfg(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little"),
                      target_arch = "x86", target_arch = "x86_64"))] {
             impl Features {
                 // SAFETY: This must only be called after CPU features have been written
@@ -100,7 +100,7 @@ mod features {
 const _: () = assert!(size_of::<Features>() == 0);
 
 cfg_if::cfg_if! {
-    if #[cfg(any(target_arch = "aarch64", target_arch = "arm"))] {
+    if #[cfg(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little")))] {
         pub mod arm;
         use arm::featureflags::get_or_init as get_or_init_feature_flags;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {

--- a/src/cpu/arm/linux.rs
+++ b/src/cpu/arm/linux.rs
@@ -42,7 +42,10 @@ pub fn detect_features() -> u32 {
     0
 }
 
-#[cfg(all(not(target_env = "uclibc"), target_arch = "aarch64"))]
+#[cfg(all(
+    not(target_env = "uclibc"),
+    all(target_arch = "aarch64", target_endian = "little")
+))]
 pub fn detect_features() -> u32 {
     use super::{AES, ARMCAP_STATIC, PMULL, SHA256, SHA512};
     use libc::{getauxval, AT_HWCAP, HWCAP_AES, HWCAP_PMULL, HWCAP_SHA2, HWCAP_SHA512};
@@ -70,7 +73,10 @@ pub fn detect_features() -> u32 {
     features
 }
 
-#[cfg(all(not(target_env = "uclibc"), target_arch = "arm"))]
+#[cfg(all(
+    not(target_env = "uclibc"),
+    all(target_arch = "arm", target_endian = "little")
+))]
 pub fn detect_features() -> u32 {
     use super::ARMCAP_STATIC;
 

--- a/src/digest/sha2.rs
+++ b/src/digest/sha2.rs
@@ -29,7 +29,7 @@ pub(super) fn block_data_order_32(
     cpu_features: cpu::Features,
 ) {
     cfg_if! {
-        if #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64"))] {
+        if #[cfg(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little"), target_arch = "x86_64"))] {
             if let Some(num) = core::num::NonZeroUsize::new(data.len()) {
                 // Assembly require CPU feature detection tohave been done.
                 let _cpu_features = cpu_features;
@@ -51,7 +51,7 @@ pub(super) fn block_data_order_64(
     cpu_features: cpu::Features,
 ) {
     cfg_if! {
-        if #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64"))] {
+        if #[cfg(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little"), target_arch = "x86_64"))] {
             if let Some(num) = core::num::NonZeroUsize::new(data.len()) {
                 // Assembly require CPU feature detection tohave been done.
                 let _cpu_features = cpu_features;
@@ -68,7 +68,11 @@ pub(super) fn block_data_order_64(
 }
 
 #[cfg_attr(
-    any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64"),
+    any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "arm", target_endian = "little"),
+        target_arch = "x86_64"
+    ),
     allow(dead_code)
 )]
 #[inline]
@@ -404,7 +408,11 @@ impl Sha2 for Wrapping<u64> {
     ];
 }
 
-#[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86_64"))]
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
+    target_arch = "x86_64"
+))]
 prefixed_extern! {
     fn sha256_block_data_order(
         state: &mut [Wrapping<u32>; CHAINING_WORDS],

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -66,7 +66,10 @@ fn x25519_public_from_private(
     let private_key: &[u8; SCALAR_LEN] = private_key.bytes_less_safe().try_into()?;
     let private_key = ops::MaskedScalar::from_bytes_masked(*private_key);
 
-    #[cfg(all(target_arch = "arm", any(target_os = "android", target_os = "linux")))]
+    #[cfg(all(
+        all(target_arch = "arm", target_endian = "little"),
+        any(target_os = "android", target_os = "linux")
+    ))]
     {
         if cpu::arm::NEON.available(cpu_features) {
             static MONTGOMERY_BASE_POINT: [u8; 32] = [
@@ -112,7 +115,10 @@ fn x25519_ecdh(
         point: &ops::EncodedPoint,
         #[allow(unused_variables)] cpu_features: cpu::Features,
     ) {
-        #[cfg(all(target_arch = "arm", any(target_os = "android", target_os = "linux")))]
+        #[cfg(all(
+            all(target_arch = "arm", target_endian = "little"),
+            any(target_os = "android", target_os = "linux")
+        ))]
         {
             if cpu::arm::NEON.available(cpu_features) {
                 return x25519_neon(out, scalar, point);
@@ -162,7 +168,10 @@ fn x25519_ecdh(
 }
 
 // BoringSSL uses `!defined(OPENSSL_APPLE)`.
-#[cfg(all(target_arch = "arm", any(target_os = "android", target_os = "linux")))]
+#[cfg(all(
+    all(target_arch = "arm", target_endian = "little"),
+    any(target_os = "android", target_os = "linux")
+))]
 fn x25519_neon(out: &mut ops::EncodedPoint, scalar: &ops::MaskedScalar, point: &ops::EncodedPoint) {
     prefixed_extern! {
         fn x25519_NEON(

--- a/src/ec/suite_b/ops/p256.rs
+++ b/src/ec/suite_b/ops/p256.rs
@@ -122,10 +122,16 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
     scalar_ops: &SCALAR_OPS,
     public_key_ops: &PUBLIC_KEY_OPS,
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     twin_mul: twin_mul_nistz256,
 
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    )))]
     twin_mul: |g_scalar, p_scalar, p_xy, cpu| {
         twin_mul_inefficient(&PRIVATE_KEY_OPS, g_scalar, p_scalar, p_xy, cpu)
     },
@@ -136,7 +142,10 @@ pub static PUBLIC_SCALAR_OPS: PublicScalarOps = PublicScalarOps {
     scalar_inv_to_mont_vartime: |s, cpu| PRIVATE_SCALAR_OPS.scalar_inv_to_mont(s, cpu),
 };
 
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86_64"
+))]
 fn twin_mul_nistz256(
     g_scalar: &Scalar,
     p_scalar: &Scalar,
@@ -148,7 +157,10 @@ fn twin_mul_nistz256(
     PRIVATE_KEY_OPS.point_sum(&scaled_g, &scaled_p, cpu)
 }
 
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86_64"
+))]
 fn point_mul_base_vartime(g_scalar: &Scalar, _cpu: cpu::Features) -> Point {
     prefixed_extern! {
         fn p256_point_mul_base_vartime(r: *mut Limb,          // [3][COMMON_OPS.num_limbs]
@@ -306,7 +318,10 @@ prefixed_extern! {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     #[test]
     fn p256_point_mul_base_vartime_test() {
         use super::{super::tests::point_mul_base_tests, *};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@
 )]
 #![cfg_attr(
     not(any(
-        target_arch = "aarch64",
-        target_arch = "arm",
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "arm", target_endian = "little"),
         target_arch = "x86",
         target_arch = "x86_64"
     )),

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -26,7 +26,11 @@ pub const fn usize_from_u32(x: u32) -> usize {
     x as usize
 }
 
-#[cfg(all(target_arch = "aarch64", target_pointer_width = "64"))]
+#[cfg(all(
+    target_arch = "aarch64",
+    target_endian = "little",
+    target_pointer_width = "64"
+))]
 #[allow(clippy::cast_possible_truncation)]
 pub fn usize_from_u64(x: u64) -> usize {
     x as usize

--- a/src/polyfill/cstr.rs
+++ b/src/polyfill/cstr.rs
@@ -26,7 +26,10 @@
 //! Work around lack of `core::ffi::CStr` prior to Rust 1.64, and the lack of
 //! `const fn` support for `CStr` in later versions.
 
-#![cfg(all(target_arch = "aarch64", target_vendor = "apple"))]
+#![cfg(all(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_vendor = "apple"
+))]
 
 use core::mem::{align_of, size_of};
 

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -66,8 +66,8 @@ macro_rules! prefixed_extern {
 
 #[deprecated = "`#[export_name]` creates problems and we will stop doing it."]
 #[cfg(not(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86",
     target_arch = "x86_64"
 )))]


### PR DESCRIPTION
We have this in cpu/arm.rs to force the build to fail for big-endian ARM/AArch64 targets:

```
const _ASSUMED_ENDIANNESS: () = assert!(cfg!(target_endian = "little"));
```

As a step towards removing that restriction, change the `cfg` logic for ARM and Aarch64 to take the endianness into consideration.

Also, don't try to assembly any assembly language sources if the target isn't little endian.