### PR TITLE
chacha20_poly1305_openssh: Rename confusing variable (NFC).

### DIFF
--- a/src/aead/chacha20_poly1305_openssh.rs
+++ b/src/aead/chacha20_poly1305_openssh.rs
@@ -143,13 +143,11 @@ impl OpeningKey {
         verify(poly_key, ciphertext_in_plaintext_out, tag)?;
 
         // Won't panic because the length was checked above.
-        let plaintext_in_ciphertext_out = &mut ciphertext_in_plaintext_out[PACKET_LENGTH_LEN..];
+        let after_packet_length = &mut ciphertext_in_plaintext_out[PACKET_LENGTH_LEN..];
 
-        self.key
-            .k_2
-            .encrypt_in_place(counter, plaintext_in_ciphertext_out);
+        self.key.k_2.encrypt_in_place(counter, after_packet_length);
 
-        Ok(plaintext_in_ciphertext_out)
+        Ok(after_packet_length)
     }
 }
 


### PR DESCRIPTION
`open_in_place` takes ciphertext in and outputs plaintext, and it already has a local variable with a name to that effect. It is very confusing to then have a variable named `plaintext_in_ciphertext_out` in this function. Probably it was copy-pasta from `seal_in_place`.