### PR TITLE
chacha: Reduce API surface for Counter/IV management.

### DIFF
--- a/src/aead/chacha20_poly1305.rs
+++ b/src/aead/chacha20_poly1305.rs
@@ -224,10 +224,8 @@ fn has_integrated(cpu_features: cpu::Features) -> bool {
 
 // Also used by chacha20_poly1305_openssh.
 pub(super) fn begin(key: &chacha::Key, nonce: Nonce) -> (Counter, poly1305::Key) {
-    let mut counter = Counter::zero(nonce);
-    let iv = counter.increment();
     let mut key_bytes = [0u8; poly1305::KEY_LEN];
-    key.encrypt_iv_xor_in_place(iv, &mut key_bytes);
+    let counter = key.encrypt_single_block_with_ctr_0(nonce, &mut key_bytes);
     let poly1305_key = poly1305::Key::new(key_bytes);
     (counter, poly1305_key)
 }

--- a/src/polyfill/slice.rs
+++ b/src/polyfill/slice.rs
@@ -112,3 +112,16 @@ pub fn split_at_checked<T>(slice: &[T], i: usize) -> Option<(&[T], &[T])> {
         None
     }
 }
+
+// TODO(MSRV-1.77): Use `slice::split_first_chunk_mut`.
+#[inline(always)]
+pub fn split_first_chunk_mut<T, const N: usize>(
+    slice: &mut [T],
+) -> Option<(&mut [T; N], &mut [T])> {
+    if slice.len() >= N {
+        let (head, tail) = slice.split_at_mut(N);
+        head.try_into().ok().map(|head| (head, tail))
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
Replace the `pub(super)` IV/Counter API with a simpler, private one.

This makes it clearer that the callers are handling nonces correctly. This will also make it easier to refactor the Counter handling later.