### PR TITLE
CI: Add more CPUs to QEMU-based testing of x86 and run "slow" tests in CPU-model coverage jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,7 +633,7 @@ jobs:
 
           - features: --features=unstable-testing-arm-no-hw,std
             target: aarch64-unknown-linux-gnu
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
@@ -645,7 +645,7 @@ jobs:
 
           - features: --features=unstable-testing-arm-no-neon,std
             target: armv7-unknown-linux-gnueabihf
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
@@ -677,84 +677,84 @@ jobs:
           - target: i686-unknown-linux-gnu
             cpu_model: Conroe-v1
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
             cpu_model: Conroe-v1
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: i686-unknown-linux-gnu
             cpu_model: Denverton-v2
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
             cpu_model: Denverton-v2
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: i686-unknown-linux-gnu
             cpu_model: Haswell
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
             cpu_model: Haswell
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: i686-unknown-linux-gnu
             cpu_model: Nehalem
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
             cpu_model: Nehalem
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: i686-unknown-linux-gnu
             cpu_model: SandyBridge
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
             cpu_model: SandyBridge
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: i686-unknown-linux-gnu
             cpu_model: Westmere
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
             cpu_model: Westmere
             features: --features=std
-            mode: # debug
+            mode: --release
             rust_channel: nightly
             host_os: ubuntu-22.04
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,6 +617,11 @@ jobs:
 
         # TODO: targets
         include:
+          # First because it is slowest; we hope being first will nudge it to
+          # start sooner.
+          - target: s390x-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
           - target: aarch64-apple-darwin
             host_os: macos-14
 
@@ -671,9 +676,6 @@ jobs:
             host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu
-            host_os: ubuntu-22.04
-
-          - target: s390x-unknown-linux-gnu
             host_os: ubuntu-22.04
 
           - target: x86_64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,13 +659,6 @@ jobs:
             rust_channel: nightly
             host_os: ubuntu-22.04
 
-          - target: i686-unknown-linux-gnu
-            cpu_model: Conroe-v1
-            features: --features=std
-            mode: # debug
-            rust_channel: nightly
-            host_os: ubuntu-22.04
-
           - target: powerpc-unknown-linux-gnu
             host_os: ubuntu-22.04
 
@@ -681,8 +674,22 @@ jobs:
           - target: x86_64-apple-darwin
             host_os: macos-13
 
+          - target: i686-unknown-linux-gnu
+            cpu_model: Conroe-v1
+            features: --features=std
+            mode: # debug
+            rust_channel: nightly
+            host_os: ubuntu-22.04
+
           - target: x86_64-unknown-linux-gnu
             cpu_model: Conroe-v1
+            features: --features=std
+            mode: # debug
+            rust_channel: nightly
+            host_os: ubuntu-22.04
+
+          - target: i686-unknown-linux-gnu
+            cpu_model: Denverton-v2
             features: --features=std
             mode: # debug
             rust_channel: nightly
@@ -695,8 +702,22 @@ jobs:
             rust_channel: nightly
             host_os: ubuntu-22.04
 
+          - target: i686-unknown-linux-gnu
+            cpu_model: Haswell
+            features: --features=std
+            mode: # debug
+            rust_channel: nightly
+            host_os: ubuntu-22.04
+
           - target: x86_64-unknown-linux-gnu
             cpu_model: Haswell
+            features: --features=std
+            mode: # debug
+            rust_channel: nightly
+            host_os: ubuntu-22.04
+
+          - target: i686-unknown-linux-gnu
+            cpu_model: Nehalem
             features: --features=std
             mode: # debug
             rust_channel: nightly
@@ -709,8 +730,22 @@ jobs:
             rust_channel: nightly
             host_os: ubuntu-22.04
 
+          - target: i686-unknown-linux-gnu
+            cpu_model: SandyBridge
+            features: --features=std
+            mode: # debug
+            rust_channel: nightly
+            host_os: ubuntu-22.04
+
           - target: x86_64-unknown-linux-gnu
             cpu_model: SandyBridge
+            features: --features=std
+            mode: # debug
+            rust_channel: nightly
+            host_os: ubuntu-22.04
+
+          - target: i686-unknown-linux-gnu
+            cpu_model: Westmere
             features: --features=std
             mode: # debug
             rust_channel: nightly


### PR DESCRIPTION
See individual commits for details.