### PR TITLE
Add support for armv6k-nintendo-3ds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -190,6 +190,11 @@ const ASM_TARGETS: &[AsmTarget] = &[
         perlasm_format: "elf",
     },
     AsmTarget {
+        oss: &["horizon"],
+        arch: ARM,
+        perlasm_format: "linux32",
+    },
+    AsmTarget {
         oss: APPLE_ABI,
         arch: AARCH64,
         perlasm_format: "ios64",

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -132,6 +132,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "haiku",
     target_os = "hermit",
     target_os = "hurd",
+    target_os = "horizon",
     target_os = "illumos",
     target_os = "linux",
     target_os = "netbsd",


### PR DESCRIPTION
with this change, the Nintendo 3DS (`target_os = "horizon"`) can do https (so long as the relevant modifications to the rust standard library are also made to allow TCP to work again)