### PR TITLE
arithmetic: Clarify `bn_sqr8x_mont` still needs `cpu::Features`.

### DIFF
--- a/src/arithmetic/ffi.rs
+++ b/src/arithmetic/ffi.rs
@@ -99,7 +99,9 @@ pub(super) fn bn_sqr8x_mont(
     in_out: &mut [Limb],
     n: &[Limb],
     n0: &N0,
+    cpu: crate::cpu::Features,
 ) -> core::ops::ControlFlow<(), ()> {
+    use crate::cpu;
     use core::{ops::ControlFlow, ptr};
 
     prefixed_extern! {
@@ -130,6 +132,7 @@ pub(super) fn bn_sqr8x_mont(
     let unused_bp = ptr::null();
     let np = n.as_ptr();
     let num = n.len();
+    let _: cpu::Features = cpu;
     unsafe { bn_sqr8x_mont(rp, ap, unused_bp, np, n0, num) };
 
     ControlFlow::Break(())

--- a/src/arithmetic/montgomery.rs
+++ b/src/arithmetic/montgomery.rs
@@ -270,7 +270,7 @@ pub(super) fn limbs_square_mont(
         if #[cfg(target_arch = "x86_64")] {
             use super::ffi;
             use core::ops::ControlFlow;
-            match ffi::bn_sqr8x_mont(r, n, n0) {
+            match ffi::bn_sqr8x_mont(r, n, n0, cpu) {
                 ControlFlow::Break(()) => {
                     Ok(())
                 }


### PR DESCRIPTION
Soon `bn_sqr8x_mont` will stop looking at `OPENSSL_ia32cap_P`, but as of this commit it still does. We already held a `cpu::Features` in the caller so it's a non-issue.