### PR TITLE
limbs internals: Move FFI function declarations into their callers.

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -49,6 +49,9 @@ pub fn limbs_equal_limbs_consttime(a: &[Limb], b: &[Limb]) -> LimbMask {
 
 #[inline]
 pub fn limbs_less_than_limbs_consttime(a: &[Limb], b: &[Limb]) -> LimbMask {
+    prefixed_extern! {
+        fn LIMBS_less_than(a: *const Limb, b: *const Limb, num_limbs: c::size_t) -> LimbMask;
+    }
     assert_eq!(a.len(), b.len());
     unsafe { LIMBS_less_than(a.as_ptr(), b.as_ptr(), b.len()) }
 }
@@ -60,18 +63,27 @@ pub fn limbs_less_than_limbs_vartime(a: &[Limb], b: &[Limb]) -> bool {
 
 #[inline]
 pub fn limbs_are_zero_constant_time(limbs: &[Limb]) -> LimbMask {
+    prefixed_extern! {
+        fn LIMBS_are_zero(a: *const Limb, num_limbs: c::size_t) -> LimbMask;
+    }
     unsafe { LIMBS_are_zero(limbs.as_ptr(), limbs.len()) }
 }
 
 #[cfg(any(test, feature = "alloc"))]
 #[inline]
 pub fn limbs_are_even_constant_time(limbs: &[Limb]) -> LimbMask {
+    prefixed_extern! {
+        fn LIMBS_are_even(a: *const Limb, num_limbs: c::size_t) -> LimbMask;
+    }
     unsafe { LIMBS_are_even(limbs.as_ptr(), limbs.len()) }
 }
 
 #[cfg(any(test, feature = "alloc"))]
 #[inline]
 pub fn limbs_equal_limb_constant_time(a: &[Limb], b: Limb) -> LimbMask {
+    prefixed_extern! {
+        fn LIMBS_equal_limb(a: *const Limb, b: Limb, num_limbs: c::size_t) -> LimbMask;
+    }
     unsafe { LIMBS_equal_limb(a.as_ptr(), b, a.len()) }
 }
 
@@ -108,6 +120,9 @@ pub fn limbs_minimal_bits(a: &[Limb]) -> bits::BitLength {
 /// Equivalent to `if (r >= m) { r -= m; }`
 #[inline]
 pub fn limbs_reduce_once_constant_time(r: &mut [Limb], m: &[Limb]) {
+    prefixed_extern! {
+        fn LIMBS_reduce_once(r: *mut Limb, m: *const Limb, num_limbs: c::size_t);
+    }
     assert_eq!(r.len(), m.len());
     unsafe { LIMBS_reduce_once(r.as_mut_ptr(), m.as_ptr(), m.len()) };
 }
@@ -326,17 +341,9 @@ pub(crate) fn limbs_negative_odd(r: &mut [Limb], a: &[Limb]) {
     r[0] |= 1;
 }
 
-prefixed_extern! {
-    fn LIMBS_are_zero(a: *const Limb, num_limbs: c::size_t) -> LimbMask;
-    fn LIMBS_less_than(a: *const Limb, b: *const Limb, num_limbs: c::size_t) -> LimbMask;
-    fn LIMBS_reduce_once(r: *mut Limb, m: *const Limb, num_limbs: c::size_t);
-}
-
 #[cfg(any(test, feature = "alloc"))]
 prefixed_extern! {
     fn LIMB_shr(a: Limb, shift: c::size_t) -> Limb;
-    fn LIMBS_are_even(a: *const Limb, num_limbs: c::size_t) -> LimbMask;
-    fn LIMBS_equal_limb(a: *const Limb, b: Limb, num_limbs: c::size_t) -> LimbMask;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Follow the normal convention.