### PR TITLE
arithmetic internals: Clarify evenness check for empty limbs.

### DIFF
--- a/src/arithmetic/bigint/modulusvalue.rs
+++ b/src/arithmetic/bigint/modulusvalue.rs
@@ -49,9 +49,8 @@ impl<M> OwnedModulusValue<M> {
             return Err(error::KeyRejected::unexpected_error());
         }
         // The above implies n >= 3, so we don't need to check it.
-        if limb::limbs_are_even_constant_time(&n).leak() {
-            return Err(error::KeyRejected::invalid_component());
-        }
+        limb::limbs_reject_even_leak_bit(&n)
+            .map_err(|_: error::Unspecified| error::KeyRejected::invalid_component())?;
 
         let len_bits = limb::limbs_minimal_bits(&n);
 

--- a/src/arithmetic/bigint/private_exponent.rs
+++ b/src/arithmetic/bigint/private_exponent.rs
@@ -36,9 +36,7 @@ impl PrivateExponent {
         // `p - 1` and so we know `dP < p - 1`.
         //
         // Further we know `dP != 0` because `dP` is not even.
-        if limb::limbs_are_even_constant_time(&dP).leak() {
-            return Err(error::Unspecified);
-        }
+        limb::limbs_reject_even_leak_bit(&dP)?;
 
         Ok(Self {
             limbs: dP.into_limbs(),


### PR DESCRIPTION
It would be questionable to ask if two empty slices of limbs are even, so `limbs_are_even_constant_time` should return an error in that case. Luckily, we already considered empty limbs even (see the test) and callers always return an error on empty limbs. So, nothing changes, except it is clearer that we handle empty inputs correctly.

This is part of a project to clarify what happens when/if/how we pass empty slices to C.