### PR TITLE
arithmetic/limbs internals: Clarify limbs < limbs checks.

### DIFF
--- a/src/arithmetic/bigint/boxed_limbs.rs
+++ b/src/arithmetic/bigint/boxed_limbs.rs
@@ -88,9 +88,7 @@ impl<M> BoxedLimbs<M> {
     ) -> Result<Self, error::Unspecified> {
         let mut r = Self::zero(m.limbs().len());
         limb::parse_big_endian_and_pad_consttime(input, &mut r)?;
-        if !limb::limbs_less_than_limbs_consttime(&r, m.limbs()).leak() {
-            return Err(error::Unspecified);
-        }
+        limb::verify_limbs_less_than_limbs_leak_bit(&r, m.limbs())?;
         Ok(r)
     }
 

--- a/src/arithmetic/bigint/modulusvalue.rs
+++ b/src/arithmetic/bigint/modulusvalue.rs
@@ -59,11 +59,11 @@ impl<M> OwnedModulusValue<M> {
     }
 
     pub fn verify_less_than<L>(&self, l: &Modulus<L>) -> Result<(), error::Unspecified> {
-        if self.len_bits() > l.len_bits()
-            || (self.limbs.len() == l.limbs().len()
-                && !limb::limbs_less_than_limbs_consttime(&self.limbs, l.limbs()).leak())
-        {
+        if self.len_bits() > l.len_bits() {
             return Err(error::Unspecified);
+        }
+        if self.limbs.len() == l.limbs().len() {
+            limb::verify_limbs_less_than_limbs_leak_bit(&self.limbs, l.limbs())?;
         }
         Ok(())
     }

--- a/src/ec/curve25519/scalar.rs
+++ b/src/ec/curve25519/scalar.rs
@@ -32,9 +32,7 @@ impl Scalar {
         debug_assert!(_empty.is_empty());
         let limbs: [limb::Limb; SCALAR_LEN / limb::LIMB_BYTES] =
             array::from_fn(|i| limb::Limb::from_le_bytes(limbs_as_bytes[i]));
-        if !limb::limbs_less_than_limbs_consttime(&limbs, &order).leak() {
-            return Err(error::Unspecified);
-        }
+        limb::verify_limbs_less_than_limbs_leak_bit(&limbs, &order)?;
 
         Ok(Self(bytes))
     }

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -13,7 +13,11 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{
-    arithmetic::limbs_from_hex, arithmetic::montgomery::*, constant_time::LeakyWord, cpu, error,
+    arithmetic::limbs_from_hex,
+    arithmetic::montgomery::*,
+    constant_time::LeakyWord,
+    cpu,
+    error::{self, LenMismatchError},
     limb::*,
 };
 use core::marker::PhantomData;
@@ -437,8 +441,8 @@ impl Modulus<Q> {
 
     pub fn elem_less_than_vartime(&self, a: &Elem<Unencoded>, b: &PublicElem<Unencoded>) -> bool {
         let num_limbs = self.num_limbs.into();
-        // TODO: let b = Elem::from(b);
         limbs_less_than_limbs_vartime(&a.limbs[..num_limbs], &b.limbs[..num_limbs])
+            .unwrap_or_else(|LenMismatchError { .. }| unreachable!())
     }
 }
 


### PR DESCRIPTION
Reject empty or non-matching-length inputs. Refactor the internal API so that it is clearer that we're nearly always using this function to reject too-large inputs. This makes it easier to see that it is OK to return an error when previously we didn't.

This isn't intended to have any effect other than making the code easier to audit.