### PR TITLE
arithmetic/limbs: Rewrite limbs_equal_limbs_consttime in Rust.

### DIFF
--- a/src/ec/suite_b/ecdsa/verification.rs
+++ b/src/ec/suite_b/ecdsa/verification.rs
@@ -150,7 +150,7 @@ impl EcdsaVerificationAlgorithm {
         fn sig_r_equals_x(q: &Modulus<Q>, r: &Elem<Unencoded>, x: &Elem<R>, z2: &Elem<R>) -> bool {
             let r_jacobian = q.elem_product(z2, r);
             let x = q.elem_unencoded(x);
-            q.elem_equals_vartime(&r_jacobian, &x)
+            q.elems_are_equal(&r_jacobian, &x).leak()
         }
         let mut r = self.ops.scalar_as_elem(&r);
         if sig_r_equals_x(q, &r, &x, &z2) {

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -143,9 +143,10 @@ impl<M> Modulus<M> {
 
 impl Modulus<Q> {
     #[inline]
-    pub fn elems_are_equal(&self, a: &Elem<R>, b: &Elem<R>) -> LimbMask {
+    pub fn elems_are_equal<E: Encoding>(&self, a: &Elem<E>, b: &Elem<E>) -> LimbMask {
         let num_limbs = self.num_limbs.into();
         limbs_equal_limbs_consttime(&a.limbs[..num_limbs], &b.limbs[..num_limbs])
+            .unwrap_or_else(unwrap_impossible_len_mismatch_error)
     }
 
     #[inline]
@@ -434,11 +435,6 @@ impl PublicScalarOps {
 }
 
 impl Modulus<Q> {
-    pub fn elem_equals_vartime(&self, a: &Elem<Unencoded>, b: &Elem<Unencoded>) -> bool {
-        let num_limbs = self.num_limbs.into();
-        limbs_equal_limbs_consttime(&a.limbs[..num_limbs], &b.limbs[..num_limbs]).leak()
-    }
-
     pub fn elem_less_than_vartime(&self, a: &Elem<Unencoded>, b: &PublicElem<Unencoded>) -> bool {
         let num_limbs = self.num_limbs.into();
         limbs_less_than_limbs_vartime(&a.limbs[..num_limbs], &b.limbs[..num_limbs])
@@ -602,6 +598,12 @@ fn parse_big_endian_fixed_consttime<M>(
         &mut r.limbs[..num_limbs],
     )?;
     Ok(r)
+}
+
+#[cold]
+#[inline(never)]
+fn unwrap_impossible_len_mismatch_error<T>(LenMismatchError { .. }: LenMismatchError) -> T {
+    unreachable!()
 }
 
 #[cfg(test)]

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -40,12 +40,12 @@ pub const LIMB_BYTES: usize = (LIMB_BITS + 7) / 8;
 pub type LimbMask = constant_time::BoolMask;
 
 #[inline]
-pub fn limbs_equal_limbs_consttime(a: &[Limb], b: &[Limb]) -> LimbMask {
-    prefixed_extern! {
-        fn LIMBS_equal(a: *const Limb, b: *const Limb, num_limbs: c::size_t) -> LimbMask;
+pub fn limbs_equal_limbs_consttime(a: &[Limb], b: &[Limb]) -> Result<LimbMask, LenMismatchError> {
+    if a.len() != b.len() {
+        return Err(LenMismatchError::new(a.len()));
     }
-    assert_eq!(a.len(), b.len());
-    unsafe { LIMBS_equal(a.as_ptr(), b.as_ptr(), a.len()) }
+    let all = a.iter().zip(b).fold(0, |running, (a, b)| running | (a ^ b));
+    Ok(limb_is_zero_constant_time(all))
 }
 
 #[inline]


### PR DESCRIPTION
The C variant is still used by the P-384 C code, so leave it.

In ec, combine the `Elem` equality functions into a single implementation that abstracts over the encoding.

This eliminates another call from Rust to a pointer-taking function written in C.