### PR TITLE
build.rs: Disable LTO if enabled implictly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -597,6 +597,8 @@ fn configure_cc(c: &mut cc::Build, target: &Target, c_root_dir: &Path, include_d
     if target.force_warnings_into_errors {
         c.warnings_into_errors(true);
     }
+
+    c.flag_if_supported("-fno-lto");
 }
 
 fn nasm(file: &Path, arch: &str, include_dir: &Path, out_dir: &Path, c_root_dir: &Path) {


### PR DESCRIPTION
LTO between Rust and C is complicated. It requires clang and specific invocations configurations for both Rust and C compilations. If the CFLAGS from the environment enable LTO, for example from distribution build tools this can lead to errors.
Instead always disable LTO for the C compilation. There is not much to optimize away anyways.

Closes #1444