### PR TITLE
arithmetic: Clarify memory safety aspects of `AliasingSlices` & rename to `AliasingSlices3`

### DIFF
--- a/src/arithmetic/ffi.rs
+++ b/src/arithmetic/ffi.rs
@@ -53,7 +53,7 @@ macro_rules! bn_mul_mont_ffi {
 
 #[inline]
 pub(super) unsafe fn bn_mul_mont_ffi<Cpu, const LEN_MIN: usize, const LEN_MOD: usize>(
-    mut in_out: impl AliasingSlices<Limb>,
+    in_out: impl AliasingSlices<Limb>,
     n: &[Limb],
     n0: &N0,
     cpu: Cpu,

--- a/src/arithmetic/ffi.rs
+++ b/src/arithmetic/ffi.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{inout::AliasingSlices, n0::N0, LimbSliceError, MAX_LIMBS, MIN_LIMBS};
+use super::{inout::AliasingSlices3, n0::N0, LimbSliceError, MAX_LIMBS, MIN_LIMBS};
 use crate::{c, limb::Limb, polyfill::usize_from_u32};
 use core::mem::size_of;
 
@@ -53,7 +53,7 @@ macro_rules! bn_mul_mont_ffi {
 
 #[inline]
 pub(super) unsafe fn bn_mul_mont_ffi<Cpu, const LEN_MIN: usize, const LEN_MOD: usize>(
-    in_out: impl AliasingSlices<Limb>,
+    in_out: impl AliasingSlices3<Limb>,
     n: &[Limb],
     n0: &N0,
     cpu: Cpu,

--- a/src/arithmetic/ffi.rs
+++ b/src/arithmetic/ffi.rs
@@ -14,7 +14,7 @@
 
 use super::{inout::AliasingSlices3, n0::N0, LimbSliceError, MAX_LIMBS, MIN_LIMBS};
 use crate::{c, limb::Limb, polyfill::usize_from_u32};
-use core::mem::size_of;
+use core::{mem::size_of, num::NonZeroUsize};
 
 const _MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES: () = {
     // BoringSSL's limit: 8 kiloBYTES.
@@ -40,7 +40,7 @@ macro_rules! bn_mul_mont_ffi {
                 b: *const Limb,
                 n: *const Limb,
                 n0: &N0,
-                len: c::size_t,
+                len: c::NonZero_size_t,
             );
         }
         unsafe {
@@ -63,7 +63,7 @@ pub(super) unsafe fn bn_mul_mont_ffi<Cpu, const LEN_MIN: usize, const LEN_MOD: u
         b: *const Limb,
         n: *const Limb,
         n0: &N0,
-        len: c::size_t,
+        len: c::NonZero_size_t,
     ),
 ) -> Result<(), LimbSliceError> {
     assert_eq!(n.len() % LEN_MOD, 0); // The caller should guard against this.
@@ -77,15 +77,18 @@ pub(super) unsafe fn bn_mul_mont_ffi<Cpu, const LEN_MIN: usize, const LEN_MOD: u
     if n.len() < LEN_MIN {
         return Err(LimbSliceError::too_short(n.len()));
     }
+    let len = NonZeroUsize::new(n.len()).unwrap_or_else(|| {
+        // Unreachable because we checked against `LEN_MIN`, and we checked
+        // `LEN_MIN` is nonzero.
+        unreachable!()
+    });
 
     // Avoid stack overflow from the alloca inside.
-    if n.len() > MAX_LIMBS {
+    if len.get() > MAX_LIMBS {
         return Err(LimbSliceError::too_long(n.len()));
     }
-
     in_out
-        .with_pointers(n.len(), |r, a, b| {
-            let len = n.len();
+        .with_non_dangling_non_null_pointers_rab(len, |r, a, b| {
             let n = n.as_ptr();
             let _: Cpu = cpu;
             unsafe { f(r, a, b, n, n0, len) };

--- a/src/arithmetic/inout.rs
+++ b/src/arithmetic/inout.rs
@@ -16,7 +16,7 @@ pub(crate) use crate::error::LenMismatchError;
 
 pub(crate) trait AliasingSlices<T> {
     fn with_pointers<R>(
-        &mut self,
+        self,
         expected_len: usize,
         f: impl FnOnce(*mut T, *const T, *const T) -> R,
     ) -> Result<R, LenMismatchError>;
@@ -24,7 +24,7 @@ pub(crate) trait AliasingSlices<T> {
 
 impl<T> AliasingSlices<T> for &mut [T] {
     fn with_pointers<R>(
-        &mut self,
+        self,
         expected_len: usize,
         f: impl FnOnce(*mut T, *const T, *const T) -> R,
     ) -> Result<R, LenMismatchError> {
@@ -38,7 +38,7 @@ impl<T> AliasingSlices<T> for &mut [T] {
 
 impl<T> AliasingSlices<T> for (&mut [T], &[T]) {
     fn with_pointers<R>(
-        &mut self,
+        self,
         expected_len: usize,
         f: impl FnOnce(*mut T, *const T, *const T) -> R,
     ) -> Result<R, LenMismatchError> {
@@ -55,7 +55,7 @@ impl<T> AliasingSlices<T> for (&mut [T], &[T]) {
 
 impl<T> AliasingSlices<T> for (&mut [T], &[T], &[T]) {
     fn with_pointers<R>(
-        &mut self,
+        self,
         expected_len: usize,
         f: impl FnOnce(*mut T, *const T, *const T) -> R,
     ) -> Result<R, LenMismatchError> {

--- a/src/arithmetic/inout.rs
+++ b/src/arithmetic/inout.rs
@@ -14,7 +14,7 @@
 
 pub(crate) use crate::error::LenMismatchError;
 
-pub(crate) trait AliasingSlices<T> {
+pub(crate) trait AliasingSlices3<T> {
     /// The pointers passed to `f` will all be non-null and properly aligned,
     /// but may be dangling.
     ///
@@ -35,7 +35,7 @@ pub(crate) trait AliasingSlices<T> {
     ) -> Result<R, LenMismatchError>;
 }
 
-impl<T> AliasingSlices<T> for &mut [T] {
+impl<T> AliasingSlices3<T> for &mut [T] {
     fn with_pointers<R>(
         self,
         expected_len: usize,
@@ -49,7 +49,7 @@ impl<T> AliasingSlices<T> for &mut [T] {
     }
 }
 
-impl<T> AliasingSlices<T> for (&mut [T], &[T]) {
+impl<T> AliasingSlices3<T> for (&mut [T], &[T]) {
     fn with_pointers<R>(
         self,
         expected_len: usize,
@@ -66,7 +66,7 @@ impl<T> AliasingSlices<T> for (&mut [T], &[T]) {
     }
 }
 
-impl<T> AliasingSlices<T> for (&mut [T], &[T], &[T]) {
+impl<T> AliasingSlices3<T> for (&mut [T], &[T], &[T]) {
     fn with_pointers<R>(
         self,
         expected_len: usize,

--- a/src/arithmetic/inout.rs
+++ b/src/arithmetic/inout.rs
@@ -15,6 +15,19 @@
 pub(crate) use crate::error::LenMismatchError;
 
 pub(crate) trait AliasingSlices<T> {
+    /// The pointers passed to `f` will all be non-null and properly aligned,
+    /// but may be dangling.
+    ///
+    /// The first pointer, `r` points to potentially-uninitialized writable
+    /// space for `expected_len` elements of type `T`. Accordingly, `f` must
+    /// not read from `r` before writing to it.
+    ///
+    /// The second & third pointers, `a` and `b`, point to `expected_len`
+    /// initialized values of type `T`.
+    ///
+    /// `r`, `a`, and/or `b` may alias each other, but only in the following
+    /// ways: `ptr::eq(r, a)`, `ptr::eq(r, b)`, and/or `ptr::eq(a, b)`; they
+    /// will not be "overlapping."
     fn with_pointers<R>(
         self,
         expected_len: usize,

--- a/src/arithmetic/montgomery.rs
+++ b/src/arithmetic/montgomery.rs
@@ -13,7 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 pub use super::n0::N0;
-use super::{inout::AliasingSlices, LimbSliceError, MIN_LIMBS};
+use super::{inout::AliasingSlices3, LimbSliceError, MIN_LIMBS};
 use crate::cpu;
 use cfg_if::cfg_if;
 
@@ -116,7 +116,7 @@ use crate::{bssl, c, limb::Limb};
 
 #[inline(always)]
 pub(super) fn limbs_mul_mont(
-    in_out: impl AliasingSlices<Limb>,
+    in_out: impl AliasingSlices3<Limb>,
     n: &[Limb],
     n0: &N0,
     cpu: cpu::Features,


### PR DESCRIPTION
See each individual commit for details.