### PR TITLE
arithmetic: Avoid heap & simplify alignment logic in `elem_exp_consttime`.

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -26,6 +26,7 @@ mod constant;
 pub mod bigint;
 
 pub(crate) mod inout;
+mod limbs512;
 pub mod montgomery;
 
 mod n0;

--- a/src/arithmetic/limbs512/mod.rs
+++ b/src/arithmetic/limbs512/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2025 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+mod storage;
+
+pub(super) use self::storage::{AlignedStorage, LIMBS_PER_CHUNK};

--- a/src/arithmetic/limbs512/storage.rs
+++ b/src/arithmetic/limbs512/storage.rs
@@ -1,0 +1,60 @@
+// Copyright 2025 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use crate::{
+    error::LenMismatchError,
+    limb::{Limb, LIMB_BITS},
+    polyfill::slice::{self, AsChunksMut},
+};
+use core::mem::{align_of, size_of};
+
+// Some x86_64 assembly is written under the assumption that some of its
+// input data and/or temporary storage is aligned to `MOD_EXP_CTIME_ALIGN`
+// bytes, which was/is 64 in OpenSSL.
+//
+// We use this in the non-X86-64 implementation of exponentiation as well,
+// with the hope of converging th two implementations into one.
+
+#[repr(C, align(64))]
+pub struct AlignedStorage<const N: usize>([Limb; N]);
+
+const _LIMB_SIZE_DIVIDES_ALIGNMENT: () =
+    assert!(align_of::<AlignedStorage<1>>() % size_of::<Limb>() == 0);
+
+pub const LIMBS_PER_CHUNK: usize = 512 / LIMB_BITS;
+
+impl<const N: usize> AlignedStorage<N> {
+    pub fn zeroed() -> Self {
+        assert_eq!(N % LIMBS_PER_CHUNK, 0); // TODO: const.
+        Self([0; N])
+    }
+
+    // The result will have every chunk aligned on a 64 byte boundary.
+    pub fn aligned_chunks_mut(
+        &mut self,
+        num_entries: usize,
+        chunks_per_entry: usize,
+    ) -> Result<AsChunksMut<Limb, LIMBS_PER_CHUNK>, LenMismatchError> {
+        let total_limbs = num_entries * chunks_per_entry * LIMBS_PER_CHUNK;
+        let len = self.0.len();
+        let flattened = self
+            .0
+            .get_mut(..total_limbs)
+            .ok_or_else(|| LenMismatchError::new(len))?;
+        match slice::as_chunks_mut(flattened) {
+            (chunks, []) => Ok(chunks),
+            (_, r) => Err(LenMismatchError::new(r.len())),
+        }
+    }
+}

--- a/src/polyfill/slice/as_chunks_mut.rs
+++ b/src/polyfill/slice/as_chunks_mut.rs
@@ -40,6 +40,11 @@ impl<T, const N: usize> AsChunksMut<'_, T, N> {
         self.0.as_ptr().cast()
     }
 
+    #[cfg(target_arch = "x86_64")]
+    pub fn as_ptr(&self) -> *const [T; N] {
+        self.0.as_ptr().cast()
+    }
+
     #[cfg(target_arch = "aarch64")]
     pub fn as_mut_ptr(&mut self) -> *mut [T; N] {
         self.0.as_mut_ptr().cast()
@@ -61,6 +66,13 @@ impl<T, const N: usize> AsChunksMut<'_, T, N> {
     #[inline(always)]
     pub fn chunks_mut<const CHUNK_LEN: usize>(&mut self) -> AsChunksMutChunksMutIter<T, N> {
         AsChunksMutChunksMutIter(self.0.chunks_mut(CHUNK_LEN * N))
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[inline(always)]
+    pub fn split_at_mut(&mut self, mid: usize) -> (AsChunksMut<T, N>, AsChunksMut<T, N>) {
+        let (before, after) = self.0.split_at_mut(mid * N);
+        (AsChunksMut(before), AsChunksMut(after))
     }
 }
 


### PR DESCRIPTION
Avoid allocating on the heap. Let the compiler do the alignment instead of manually aligning the start of the table.