### PR TITLE
arithmetic: Add missing length check to `bn_sqr8x_mont`.

### DIFF
--- a/src/arithmetic/montgomery.rs
+++ b/src/arithmetic/montgomery.rs
@@ -301,9 +301,9 @@ pub(super) fn limbs_square_mont(
         if #[cfg(target_arch = "x86_64")] {
             use core::ops::ControlFlow;
             match super::x86_64_mont::bn_sqr8x_mont(r, n, n0, cpu) {
-                ControlFlow::Break(()) => {
-                    Ok(())
-                }
+                ControlFlow::Break(r) => {
+                    r.map_err(LimbSliceError::len_mismatch)
+                },
                 ControlFlow::Continue(()) => {
                     limbs_mul_mont(r, n, n0, cpu)
                 }


### PR DESCRIPTION
It wasn't checking that `r` has the same length as `n`. Make it do that.