### PR TITLE
arithmetic: Clarify memory safety of `elem_exp_consttime`.

### DIFF
--- a/src/arithmetic/x86_64_mont.rs
+++ b/src/arithmetic/x86_64_mont.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Brian Smith.
+// Copyright 2015-2025 Brian Smith.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -14,7 +14,7 @@
 
 #![cfg(target_arch = "x86_64")]
 
-use super::{inout::AliasingSlices2, n0::N0, MAX_LIMBS};
+use super::{inout::AliasingSlices2, n0::N0, LimbSliceError, MAX_LIMBS};
 use crate::{
     c,
     cpu::{
@@ -23,9 +23,9 @@ use crate::{
         GetFeature as _,
     },
     error::LenMismatchError,
-    limb::Limb,
+    limb::{LeakyWindow, Limb, Window},
 };
-use core::ops::ControlFlow;
+use core::{num::NonZeroUsize, ops::ControlFlow};
 
 #[inline]
 pub(super) fn bn_sqr8x_mont(
@@ -74,4 +74,172 @@ pub(super) fn bn_sqr8x_mont(
         unsafe { bn_sqr8x_mont(r, a, mulx_adx_capable, n, n0, num_limbs) };
     });
     ControlFlow::Break(r)
+}
+
+#[inline(always)]
+pub(super) fn scatter5(
+    a: &[Limb],
+    table: &mut [Limb],
+    power: LeakyWindow,
+) -> Result<(), LimbSliceError> {
+    prefixed_extern! {
+        // Upstream uses `num: c::size_t` too, and `power: c::size_t`; see
+        // `_MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES`.
+        fn bn_scatter5(
+            inp: *const Limb,
+            num: c::NonZero_size_t,
+            table: *mut Limb,
+            power: LeakyWindow,
+        );
+    }
+    let num_limbs = check_common(a, table)?;
+    assert!(power < 32);
+    unsafe { bn_scatter5(a.as_ptr(), num_limbs, table.as_mut_ptr(), power) };
+    Ok(())
+}
+
+// SAFETY: `power` must be less than 32.
+#[inline(always)]
+pub(super) unsafe fn gather5(
+    r: &mut [Limb],
+    table: &[Limb],
+    power: Window,
+) -> Result<(), LimbSliceError> {
+    prefixed_extern! {
+        // Upstream uses `num: c::size_t` too, and `power: c::size_t`; see
+        // `_MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES`.
+        pub(super) fn bn_gather5(
+            out: *mut Limb,
+            num: c::NonZero_size_t,
+            table: *const Limb,
+            power: Window);
+    }
+    let num_limbs = check_common(r, table)?;
+    // SAFETY: We cannot assert that `power` is in range because it is secret.
+    // TODO: Create a `Window5` type that is guaranteed to be in range.
+    unsafe { bn_gather5(r.as_mut_ptr(), num_limbs, table.as_ptr(), power) };
+    Ok(())
+}
+
+// SAFETY: `power` must be less than 32.
+#[inline(always)]
+pub(super) unsafe fn mul_mont_gather5_amm(
+    r: &mut [Limb],
+    a: &[Limb],
+    table: &[Limb],
+    n: &[Limb],
+    n0: &N0,
+    power: Window,
+    _maybe_adx_bmi1_bmi2: cpu::Features, // TODO: Option<(Adx, Bmi1, Bmi2)>,
+) -> Result<(), LimbSliceError> {
+    prefixed_extern! {
+        // Upstream has `num: c::int` and `power: c::int`; see
+        // `_MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES`.
+        pub(super) fn bn_mul_mont_gather5(
+            rp: *mut Limb,
+            ap: *const Limb,
+            table: *const Limb,
+            np: *const Limb,
+            n0: &N0,
+            num: c::NonZero_size_t,
+            power: Window,
+        );
+    }
+    let num_limbs = check_common_with_n(r, table, n)?;
+    if a.len() != num_limbs.get() {
+        return Err(LimbSliceError::len_mismatch(LenMismatchError::new(a.len())));
+    }
+    // SAFETY: We cannot assert that `power` is in range because it is secret.
+    // TODO: Create a `Window5` type that is guaranteed to be in range.
+    unsafe {
+        bn_mul_mont_gather5(
+            r.as_mut_ptr(),
+            a.as_ptr(),
+            table.as_ptr(),
+            n.as_ptr(),
+            n0,
+            num_limbs,
+            power,
+        )
+    };
+    Ok(())
+}
+
+// SAFETY: `power` must be less than 32.
+#[inline(always)]
+pub(super) unsafe fn power5_amm(
+    in_out: &mut [Limb],
+    table: &[Limb],
+    n: &[Limb],
+    n0: &N0,
+    power: Window,
+    _maybe_adx_bmi1_bmi2: cpu::Features, // TODO: Option<(Adx, Bmi1, Bmi2)>,
+) -> Result<(), LimbSliceError> {
+    prefixed_extern! {
+        // Upstream has `num: c::int` and `power: c::int`; see
+        // `_MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES`.
+        fn bn_power5(
+            rp: *mut Limb,
+            ap: *const Limb,
+            table: *const Limb,
+            np: *const Limb,
+            n0: &N0,
+            num: c::NonZero_size_t,
+            power: Window,
+        );
+    }
+    let num_limbs = check_common_with_n(in_out, table, n)?;
+    // SAFETY: We cannot assert that `power` is in range because it is secret.
+    // TODO: Create a `Window5` type that is guaranteed to be in range.
+    unsafe {
+        bn_power5(
+            in_out.as_mut_ptr(),
+            in_out.as_ptr(),
+            table.as_ptr(),
+            n.as_ptr(),
+            n0,
+            num_limbs,
+            power,
+        );
+    }
+    Ok(())
+}
+
+// Helps the compiler will be able to hoist all of these checks out of the
+// loops in the caller. Try to help the compiler by doing the checks
+// consistently in each function and also by inlining this function and all the
+// callers.
+#[inline(always)]
+fn check_common(a: &[Limb], table: &[Limb]) -> Result<NonZeroUsize, LimbSliceError> {
+    assert_eq!((table.as_ptr() as usize) % 16, 0); // According to BoringSSL.
+    let num_limbs = NonZeroUsize::new(a.len()).ok_or_else(|| LimbSliceError::too_short(a.len()))?;
+    if num_limbs.get() % 8 != 0 {
+        // TODO: Use a different error.
+        return Err(LimbSliceError::len_mismatch(LenMismatchError::new(a.len())));
+    }
+    if num_limbs.get() > MAX_LIMBS {
+        return Err(LimbSliceError::too_long(a.len()));
+    }
+    if num_limbs.get() * 32 != table.len() {
+        return Err(LimbSliceError::len_mismatch(LenMismatchError::new(
+            table.len(),
+        )));
+    };
+    Ok(num_limbs)
+}
+
+#[inline(always)]
+fn check_common_with_n(
+    a: &[Limb],
+    table: &[Limb],
+    n: &[Limb],
+) -> Result<NonZeroUsize, LimbSliceError> {
+    // Choose `a` instead of `n` so that every function starts with
+    // `check_common` passing the exact same arguments, so that the compiler
+    // can easily de-dupe the checks.
+    let num_limbs = check_common(a, table)?;
+    if n.len() != num_limbs.get() {
+        return Err(LimbSliceError::len_mismatch(LenMismatchError::new(n.len())));
+    }
+    Ok(num_limbs)
 }

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -174,6 +174,7 @@ cfg_if! {
         impl_get_feature!{ MOVBE => Movbe }
         impl_get_feature!{ AVX => Avx }
         impl_get_feature!{ AVX2 => Avx2 }
+        impl_get_feature!{ BMI1 => Bmi1 }
         impl_get_feature!{ BMI2 => Bmi2 }
         impl_get_feature!{ ADX => Adx }
         impl_get_feature!{ SHA => Sha }

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -242,9 +242,11 @@ pub fn unstripped_be_bytes(limbs: &[Limb]) -> impl ExactSizeIterator<Item = u8> 
     ArrayFlatMap::new(limbs.iter().rev().copied(), Limb::to_be_bytes).unwrap()
 }
 
+// Used in FFI
 #[cfg(feature = "alloc")]
 pub type Window = constant_time::Word;
 
+// Used in FFI
 #[cfg(feature = "alloc")]
 pub type LeakyWindow = constant_time::LeakyWord;
 

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -21,6 +21,7 @@ use crate::{
     arithmetic::{
         bigint,
         montgomery::{R, RR, RRR},
+        LimbSliceError,
     },
     bits::BitLength,
     cpu, digest,
@@ -491,7 +492,7 @@ fn elem_exp_consttime<M>(
     let m = &p.modulus.modulus(cpu_features);
     let c_mod_m = bigint::elem_reduced(c, m, other_prime_len_bits);
     let c_mod_m = bigint::elem_mul(p.oneRRR.as_ref(), c_mod_m, m);
-    bigint::elem_exp_consttime(c_mod_m, &p.exponent, m)
+    bigint::elem_exp_consttime(c_mod_m, &p.exponent, m).map_err(error::erase::<LimbSliceError>)
 }
 
 // Type-level representations of the different moduli used in RSA signing, in


### PR DESCRIPTION
`elem_exp_consttime` was written weirdly in that it had a bunch of wrappers functions around assembly functions, `bn_gather5`, etc., where the wrapper functions were not marked `unsafe` but also they didn't themselves enforce safety properties. It kind of made sense but technically they should have been `unsafe`. And, there were just a lot of confusing details in how they were written.

Start over with the wrapper functions, and put the new versions of them in the `x86_64_mont` submodule.

We intentionally avoid adding any masking to `power` arguments, which would make them completely safe.

To review this properly, one needs to compare how these functions are documented and used in `crypto/fipsmodule/bn/internal.h` and `crypto/fipsmodule/bn/exponentiation.c` (note this file was renamed in recent versions of BoringSSL; use the version that corresponds to the most recently-merged BoringSSL in *ring*.)

```
git difftool HEAD^1:src/arithmetic/bigint.rs \
                    src/arithmetic/x86_64_mont.rs
```