### PR TITLE
bigint: Move allocations for `Elem` cloning from `clone()` to caller.

### DIFF
--- a/src/arithmetic/bigint/boxed_limbs.rs
+++ b/src/arithmetic/bigint/boxed_limbs.rs
@@ -58,15 +58,6 @@ impl<M> Clone for BoxedLimbs<M> {
 }
 
 impl<M> BoxedLimbs<M> {
-    // The caller must ensure that `limbs.len()` is the same width as the
-    // modulus.
-    pub(super) fn new_unchecked(limbs: Box<[Limb]>) -> Self {
-        Self {
-            limbs,
-            m: PhantomData,
-        }
-    }
-
     pub(super) fn positive_minimal_width_from_be_bytes(
         input: untrusted::Input,
     ) -> Result<Self, error::KeyRejected> {


### PR DESCRIPTION
Make it clearer where cloning an `Elem` causes an allocation to be done, and move those allocations as high up as possible. Replace unnecessary clones.