### PR TITLE
digest: Enable AVX SHA-{384,512/256,512} on Zen+ AMD CPUs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,6 +689,29 @@ jobs:
             host_os: ubuntu-24.04
 
           - target: x86_64-unknown-linux-gnu
+            cpu_model: Opteron_G4-v1
+            features: --features=std
+            mode: --release
+            rust_channel: nightly
+            host_os: ubuntu-24.04
+
+          # Excavator is pre-Zen but with AVX2.
+          - target: x86_64-unknown-linux-gnu
+            cpu_model: Opteron_G5-v1
+            features: --features=std
+            mode: --release
+            rust_channel: nightly
+            host_os: ubuntu-24.04
+
+          # Excavator is pre-Zen but with AVX2.
+          - target: x86_64-unknown-linux-gnu
+            cpu_model: EPYC-v1
+            features: --features=std
+            mode: --release
+            rust_channel: nightly
+            host_os: ubuntu-24.04
+
+          - target: x86_64-unknown-linux-gnu
             cpu_model: Conroe-v1
             features: --features=std
             mode: --release

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -206,6 +206,28 @@ cfg_if! {
                 XSAVE_BUT_NOT_REALLY.available(self.0) && MOVBE.available(self.0)
             }
         }
+
+        #[derive(Clone, Copy)]
+        pub(crate) struct NotPreZenAmd(super::Features);
+
+        impl super::GetFeature<NotPreZenAmd> for super::Features {
+            fn get_feature(&self) -> Option<NotPreZenAmd> {
+                let sha2: Option<Avx2> = self.get_feature();
+                // Pre-Zen AMD CPUs didn't implement SHA. (One Pre-Zen AMD CPU
+                // did support AVX2.) If we're building for a CPU that requires
+                // SHA instructions then we want to avoid the runtime check for
+                // an Intel/AND CPU.
+                if sha2.is_some() {
+                    return Some(NotPreZenAmd(*self));
+                }
+                // Perhaps we should do !AMD instead of Intel.
+                let intel: Option<IntelCpu> = self.get_feature();
+                if intel.is_some() {
+                    return Some(NotPreZenAmd(*self))
+                }
+                None
+            }
+        }
     }
 }
 


### PR DESCRIPTION
See BoringSSL fcef13a49852397a0d39c00be8d7bc2ba1ab6fb9.