### PR TITLE
arm: Minimize the Rust<->C feature detection interface.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -64,7 +64,7 @@ const RING_SRCS: &[(&[&str], &str)] = &[
     (&[], "crypto/mem.c"),
     (&[], "crypto/poly1305/poly1305.c"),
 
-    (&[AARCH64, ARM, X86_64, X86], "crypto/crypto.c"),
+    (&[ARM, X86_64, X86], "crypto/crypto.c"),
 
     (&[X86_64, X86], "crypto/cpu_intel.c"),
 
@@ -876,7 +876,6 @@ fn prefix_all_symbols(pp: char, prefix_prefix: &str, prefix: &str) -> String {
         "LIMBS_window5_split_window",
         "LIMBS_window5_unsplit_window",
         "LIMB_shr",
-        "OPENSSL_armcap_P",
         "OPENSSL_cpuid_setup",
         "OPENSSL_ia32cap_P",
         "aes_hw_ctr32_encrypt_blocks",
@@ -950,6 +949,7 @@ fn prefix_all_symbols(pp: char, prefix_prefix: &str, prefix: &str) -> String {
         "ecp_nistz256_neg",
         "ecp_nistz256_select_w5",
         "ecp_nistz256_select_w7",
+        "neon_available",
         "p256_mul_mont",
         "p256_point_add",
         "p256_point_add_affine",

--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -34,6 +34,6 @@
 // initialising it to zero, it becomes a "data symbol", which isn't so
 // affected.
 HIDDEN uint32_t OPENSSL_ia32cap_P[4] = {0};
-#elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
-HIDDEN uint32_t OPENSSL_armcap_P = 0;
+#elif defined(OPENSSL_ARM)
+HIDDEN uint32_t neon_available = 0;
 #endif

--- a/crypto/fipsmodule/bn/internal.h
+++ b/crypto/fipsmodule/bn/internal.h
@@ -229,8 +229,8 @@ static inline void bn_mul_mont_small(
     // Approximate what `bn_mul_mont` did so that the NEON version for P-256
     // when practical.
     if (num == 8) {
-        // XXX: This should not be accessing `OPENSSL_armcap_P` directly.
-        if ((OPENSSL_armcap_P & ARMV7_NEON) != 0) {
+        // XXX: This should not be accessing `neon_available` directly.
+        if (neon_available) {
             bn_mul8x_mont_neon(rp, ap, bp, np, n0, num);
             return;
         }

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -572,8 +572,7 @@ static inline int CRYPTO_is_ADX_capable(void) {
 
 
 #if defined(OPENSSL_ARM)
-// OPENSSL_armcap_P contains ARM CPU capabilities.
-extern uint32_t OPENSSL_armcap_P;
+extern uint32_t neon_available;
 #endif  // OPENSSL_ARM
 
 #endif  // OPENSSL_HEADER_CRYPTO_INTERNAL_H


### PR DESCRIPTION
Remove `OPENSSL_armcap_P` from Aarch64.
Replace `OPENSSL_armcap_P` with a boolean `neon_available` flag on ARM.