### PR TITLE
chacha: Remove optimized code path for Silvermont-like CPUs.

### DIFF
--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -135,19 +135,10 @@ impl Key {
                             self, counter, in_out, cpu);
                     }
                     if let Some(cpu) = <cpu::Features as GetFeature<Ssse3>>::get_feature(&cpu) {
-                        if in_out.len() >= 192 || !cpu.perf_is_like_silvermont() {
-                            return chacha20_ctr32_ffi!(
-                                unsafe {
-                                    (SSE_MIN_LEN, Ssse3, Overlapping<'_>) =>
-                                    ChaCha20_ctr32_ssse3_4x
-                                },
-                                self, counter, in_out, cpu)
-                        }
                         return chacha20_ctr32_ffi!(
-                            unsafe {
-                                (SSE_MIN_LEN, Ssse3, Overlapping<'_>) => ChaCha20_ctr32_ssse3
-                            },
-                            self, counter, in_out, cpu)
+                            unsafe { (SSE_MIN_LEN, Ssse3, Overlapping<'_>) =>
+                                ChaCha20_ctr32_ssse3_4x },
+                            self, counter, in_out, cpu);
                     }
                 }
                 if in_out.len() >= 1 {

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -106,10 +106,6 @@ impl_get_feature_cpuid! { ("x86", "x86_64") => (1, 9) => SSSE3 => Ssse3 }
 impl_get_feature_cpuid! { ("x86", "x86_64") => (1, 19) => SSE41 => Sse41 }
 impl_get_feature_cpuid! { ("x86_64") => (1, 22) => MOVBE => Movbe }
 impl_get_feature_cpuid! { ("x86", "x86_64") => (1, 25) => AES => Aes }
-
-// Synthesized
-impl_get_feature_cpuid! { ("x86_64") => (1, 26) => XSAVE_BUT_NOT_REALLY => XSaveButNotReally }
-
 impl_get_feature_cpuid! { ("x86", "x86_64") => (1, 28) => AVX => Avx }
 impl_get_feature_cpuid! { ("x86_64") => (2, 3) => BMI1 => Bmi1 }
 impl_get_feature_cpuid! { ("x86_64") => (2, 5) => AVX2 => Avx2 }
@@ -123,34 +119,6 @@ impl_get_feature_cpuid! { ("x86_64") => (2, 29) => SHA => Sha }
 cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
 
-        impl Ssse3 {
-            /// BoringSSL's counterpart is `CRYPTO_cpu_perf_is_like_silvermont`.
-            ///
-            /// Returns true if, based on a heuristic, the
-            /// CPU has Silvermont-like performance characteristics. It is often faster to
-            /// run different codepaths on these CPUs than the available instructions would
-            /// otherwise select. See chacha-x86_64.pl.
-            ///
-            /// Bonnell, Silvermont's predecessor in the Atom lineup, will also be matched by
-            /// this. Goldmont (Silvermont's successor in the Atom lineup) added XSAVE so it
-            /// isn't matched by this. Various sources indicate AMD first implemented MOVBE
-            /// and XSAVE at the same time in Jaguar, so it seems like AMD chips will not be
-            /// matched by this. That seems to be the case for other x86(-64) CPUs.
-            ///
-            /// WARNING: This MUST NOT be used to guard the execution of the XSAVE
-            /// instruction. This is the "hardware supports XSAVE" bit, not the OSXSAVE bit
-            /// that indicates whether we can safely execute XSAVE. This bit may be set
-            /// even when XSAVE is disabled (by the operating system). See how the users of
-            /// this bit use it.
-            ///
-            /// Historically, the XSAVE bit was artificially cleared on Knights Landing
-            /// and Knights Mill chips, but as Intel has removed all support from GCC,
-            /// LLVM, and SDE, we assume they are no longer worth special-casing.
-            pub fn perf_is_like_silvermont(self) -> bool {
-                use super::GetFeature as _;
-                matches!(self.0.get_feature(), Some((XSaveButNotReally { .. }, Movbe { .. })))
-            }
-        }
 
         #[derive(Clone, Copy)]
         pub(crate) struct NotPreZenAmd(super::Features);


### PR DESCRIPTION
This makes CPU feature detection simpler and helps the code coverage testing effort.