### PR TITLE
Remove spin dependency on x86 and x86_64 targets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ cfg-if = { version = "1.0.0", default-features = false }
 getrandom = { version = "0.2.10" }
 untrusted = { version = "0.9" }
 
-[target.'cfg(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little"), target_arch = "x86",target_arch = "x86_64"))'.dependencies]
+[target.'cfg(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little")))'.dependencies]
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
 
 [target.'cfg(all(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little")), any(target_os = "android", target_os = "linux")))'.dependencies]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -61,6 +61,12 @@ macro_rules! impl_get_feature {
 
             #[cfg(target_arch = "x86_64")]
             IntelCpu,
+
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            // Synthesized to ensure the dynamic flag set is always non-zero.
+            //
+            // Keep this at the end as it is never checked except during init.
+            Initialized,
         }
     }
 }

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -61,6 +61,11 @@ pub mod sliceutil;
 #[cfg(feature = "alloc")]
 mod leading_zeros_skipped;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub mod once_cell {
+    pub mod race;
+}
+
 mod notsend;
 pub mod ptr;
 

--- a/src/polyfill/once_cell/LICENSE-APACHE
+++ b/src/polyfill/once_cell/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/polyfill/once_cell/LICENSE-MIT
+++ b/src/polyfill/once_cell/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/src/polyfill/once_cell/README.txt
+++ b/src/polyfill/once_cell/README.txt
@@ -1,0 +1,2 @@
+Vendored from matklad/once_cell d119eeade59cd7e47b7abf979488b0be1d5b2d79.
+Originally unmodified except for deleting everything after `OnceNonZeroUsize`.

--- a/src/polyfill/once_cell/race.rs
+++ b/src/polyfill/once_cell/race.rs
@@ -33,7 +33,9 @@ impl OnceNonZeroUsize {
     /// Creates a new empty cell.
     #[inline]
     pub const fn new() -> OnceNonZeroUsize {
-        OnceNonZeroUsize { inner: AtomicUsize::new(0) }
+        OnceNonZeroUsize {
+            inner: AtomicUsize::new(0),
+        }
     }
 
     /// Gets the underlying value.
@@ -82,7 +84,9 @@ impl OnceNonZeroUsize {
     #[inline(never)]
     fn init<E>(&self, f: impl FnOnce() -> Result<NonZeroUsize, E>) -> Result<NonZeroUsize, E> {
         let mut val = f()?.get();
-        let exchange = self.inner.compare_exchange(0, val, Ordering::AcqRel, Ordering::Acquire);
+        let exchange = self
+            .inner
+            .compare_exchange(0, val, Ordering::AcqRel, Ordering::Acquire);
         if let Err(old) = exchange {
             val = old;
         }

--- a/src/polyfill/once_cell/race.rs
+++ b/src/polyfill/once_cell/race.rs
@@ -1,0 +1,112 @@
+//! Thread-safe, non-blocking, "first one wins" flavor of `OnceCell`.
+//!
+//! If two threads race to initialize a type from the `race` module, they
+//! don't block, execute initialization function together, but only one of
+//! them stores the result.
+//!
+//! This module does not require `std` feature.
+//!
+//! # Atomic orderings
+//!
+//! All types in this module use `Acquire` and `Release`
+//! [atomic orderings](Ordering) for all their operations. While this is not
+//! strictly necessary for types other than `OnceBox`, it is useful for users as
+//! it allows them to be certain that after `get` or `get_or_init` returns on
+//! one thread, any side-effects caused by the setter thread prior to them
+//! calling `set` or `get_or_init` will be made visible to that thread; without
+//! it, it's possible for it to appear as if they haven't happened yet from the
+//! getter thread's perspective. This is an acceptable tradeoff to make since
+//! `Acquire` and `Release` have very little performance overhead on most
+//! architectures versus `Relaxed`.
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicPtr, AtomicUsize, Ordering};
+use core::cell::UnsafeCell;
+use core::marker::PhantomData;
+use core::num::NonZeroUsize;
+use core::ptr;
+
+/// A thread-safe cell which can be written to only once.
+#[derive(Default, Debug)]
+pub struct OnceNonZeroUsize {
+    inner: AtomicUsize,
+}
+
+impl OnceNonZeroUsize {
+    /// Creates a new empty cell.
+    #[inline]
+    pub const fn new() -> OnceNonZeroUsize {
+        OnceNonZeroUsize { inner: AtomicUsize::new(0) }
+    }
+
+    /// Gets the underlying value.
+    #[inline]
+    pub fn get(&self) -> Option<NonZeroUsize> {
+        let val = self.inner.load(Ordering::Acquire);
+        NonZeroUsize::new(val)
+    }
+
+    /// Sets the contents of this cell to `value`.
+    ///
+    /// Returns `Ok(())` if the cell was empty and `Err(())` if it was
+    /// full.
+    #[inline]
+    pub fn set(&self, value: NonZeroUsize) -> Result<(), ()> {
+        let exchange =
+            self.inner.compare_exchange(0, value.get(), Ordering::AcqRel, Ordering::Acquire);
+        match exchange {
+            Ok(_) => Ok(()),
+            Err(_) => Err(()),
+        }
+    }
+
+    /// Gets the contents of the cell, initializing it with `f` if the cell was
+    /// empty.
+    ///
+    /// If several threads concurrently run `get_or_init`, more than one `f` can
+    /// be called. However, all threads will return the same value, produced by
+    /// some `f`.
+    pub fn get_or_init<F>(&self, f: F) -> NonZeroUsize
+    where
+        F: FnOnce() -> NonZeroUsize,
+    {
+        enum Void {}
+        match self.get_or_try_init(|| Ok::<NonZeroUsize, Void>(f())) {
+            Ok(val) => val,
+            Err(void) => match void {},
+        }
+    }
+
+    /// Gets the contents of the cell, initializing it with `f` if
+    /// the cell was empty. If the cell was empty and `f` failed, an
+    /// error is returned.
+    ///
+    /// If several threads concurrently run `get_or_init`, more than one `f` can
+    /// be called. However, all threads will return the same value, produced by
+    /// some `f`.
+    pub fn get_or_try_init<F, E>(&self, f: F) -> Result<NonZeroUsize, E>
+    where
+        F: FnOnce() -> Result<NonZeroUsize, E>,
+    {
+        let val = self.inner.load(Ordering::Acquire);
+        match NonZeroUsize::new(val) {
+            Some(it) => Ok(it),
+            None => self.init(f),
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn init<E>(&self, f: impl FnOnce() -> Result<NonZeroUsize, E>) -> Result<NonZeroUsize, E> {
+        let mut val = f()?.get();
+        let exchange = self.inner.compare_exchange(0, val, Ordering::AcqRel, Ordering::Acquire);
+        if let Err(old) = exchange {
+            val = old;
+        }
+        Ok(unsafe { NonZeroUsize::new_unchecked(val) })
+    }
+}


### PR DESCRIPTION
Here's a representative example of how this changes the generated assembly in callers:


```
@@ -36,14 +36,11 @@
 	lea r12, [rcx - 4]
3343
 		Acquire => intrinsics::atomic_load_acquire(dst),
-	mov rax, qword ptr [rip + ring::cpu::intel::featureflags::FEATURES@GOTPCREL]
-	movzx eax, byte ptr [rax + 4]
-		match self.status.load(Ordering::Acquire) {
-	cmp al, 2
-		if let Some(value) = self.get() {
-	jne .LBB85_2
+	mov rax, qword ptr [rip + ring::cpu::intel::featureflags::FEATURES]
+		match NonZeroUsize::new(val) {
+	test rax, rax
+	je .LBB85_2
 	movabs rax, 274877906881
 		if input.len() > MAX_IN_OUT_LEN {
@@ -104,10 +101,9 @@
 		if in_out.len() >= SSE_MIN_LEN {
 	cmp r12, 129
 	jb .LBB85_8
-		*features
-	mov rax, qword ptr [rip + ring::cpu::intel::featureflags::FEATURES@GOTPCREL]
-	mov eax, dword ptr [rax]
3343
+		Acquire => intrinsics::atomic_load_acquire(dst),
+	mov rax, qword ptr [rip + ring::cpu::intel::featureflags::FEATURES]
 		if (self.values() & MASK) == MASK {
 	test eax, 256
@@ -216,9 +212,9 @@
 .LBB85_2:
 	.cfi_def_cfa rbp, 16
 	mov r13, r8
-		self.try_call_once_slow(f)
-	call spin::once::Once<T,R>::try_call_once_slow
+		None => self.init(f),
+	call ring::polyfill::once_cell::race::OnceNonZeroUsize::init
 	mov r8, r13
 	movabs rax, 274877906881
```