### PR TITLE
cpu/arm: Remove old CPU feature detection API; unify with Intel.

### DIFF
--- a/src/cpu/arm/fuchsia.rs
+++ b/src/cpu/arm/fuchsia.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{AES, ARMCAP_STATIC, NEON, PMULL, SHA256};
+use super::{Aes, Neon, PMull, Sha256, CAPS_STATIC};
 
 pub const FORCE_DYNAMIC_DETECTION: u32 = 0;
 
@@ -37,17 +37,17 @@ pub fn detect_features() -> u32 {
     let mut features = 0;
 
     // We do not need to check for the presence of NEON, as Armv8-A always has it
-    const _ASSERT_NEON_DETECTED: () = assert!((ARMCAP_STATIC & NEON.mask) == NEON.mask);
+    const _ASSERT_NEON_DETECTED: () = assert!((CAPS_STATIC & Neon::mask()) == Neon::mask());
 
     if rc == ZX_OK {
         if caps & ZX_ARM64_FEATURE_ISA_AES == ZX_ARM64_FEATURE_ISA_AES {
-            features |= AES.mask;
+            features |= Aes::mask();
         }
         if caps & ZX_ARM64_FEATURE_ISA_PMULL == ZX_ARM64_FEATURE_ISA_PMULL {
-            features |= PMULL.mask;
+            features |= PMull::mask();
         }
         if caps & ZX_ARM64_FEATURE_ISA_SHA2 == ZX_ARM64_FEATURE_ISA_SHA2 {
-            features |= SHA256.mask;
+            features |= Sha256::mask();
         }
     }
 

--- a/src/cpu/arm/windows.rs
+++ b/src/cpu/arm/windows.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{AES, ARMCAP_STATIC, NEON, PMULL, SHA256};
+use super::{Aes, Neon, PMull, Sha256, CAPS_STATIC};
 use windows_sys::Win32::System::Threading::{
     IsProcessorFeaturePresent, PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE,
 };
@@ -21,7 +21,7 @@ pub const FORCE_DYNAMIC_DETECTION: u32 = 0;
 
 pub fn detect_features() -> u32 {
     // We do not need to check for the presence of NEON, as Armv8-A always has it
-    const _ASSERT_NEON_DETECTED: () = assert!((ARMCAP_STATIC & NEON.mask) == NEON.mask);
+    const _ASSERT_NEON_DETECTED: () = assert!((CAPS_STATIC & Neon::mask()) == Neon::mask());
 
     let mut features = 0;
 
@@ -29,9 +29,9 @@ pub fn detect_features() -> u32 {
 
     if result != 0 {
         // These are all covered by one call in Windows
-        features |= AES.mask;
-        features |= PMULL.mask;
-        features |= SHA256.mask;
+        features |= Aes::mask();
+        features |= PMull::mask();
+        features |= Sha256::mask();
     }
 
     features


### PR DESCRIPTION
After d39ac0fd8ab26dfe910088841ddc5243df0d9b40 we no longer have the need to be ABI-compatible with the `OPENSSL_armcap_P`-based feature detection.

Remove the tests for that ABI compatibility.

Don't add static CPU feature detection for Intel yet.

Use the same feature flag mechanism as Intel by moving the implementation from intel.rs to cpu.rs and expanding it with the static feature detection capability from arm.rs.