### PR TITLE
aes_gcm: Rearrange CPU feature detection in Key::new

### DIFF
--- a/src/aead/aes/vp.rs
+++ b/src/aead/aes/vp.rs
@@ -29,7 +29,7 @@ use crate::{cpu, error};
 type RequiredCpuFeatures = cpu::arm::Neon;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-type RequiredCpuFeatures = cpu::intel::Ssse3;
+pub(in super::super) type RequiredCpuFeatures = cpu::intel::Ssse3;
 
 #[derive(Clone)]
 pub(in super::super) struct Key {


### PR DESCRIPTION
Rust doesn't give us much control over inlining or prioritizing branches without PGO. Try to steer it in a good direction with the limited tools we have.