### PR TITLE
cpu: Add basic caching for cpu feature flags.

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -74,6 +74,7 @@ enum DynKey {
 
 impl DynKey {
     fn new(key: aes::KeyBytes, cpu: cpu::Features) -> Result<Self, error::Unspecified> {
+        let cpu = cpu.values();
         #[cfg(target_arch = "x86_64")]
         if let Some((aes, gcm)) = cpu.get_feature() {
             let aes_key = aes::hw::Key::new(key, aes, cpu.get_feature())?;

--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -129,12 +129,13 @@ impl Key {
                 use cpu::{GetFeature, intel::{Avx2, Ssse3}};
                 const SSE_MIN_LEN: usize = 128 + 1; // Also AVX2, SSSE3_4X, SSSE3
                 if in_out.len() >= SSE_MIN_LEN {
-                    if let Some(cpu) = cpu.get_feature() {
+                    let values = cpu.values();
+                    if let Some(cpu) = values.get_feature() {
                         return chacha20_ctr32_ffi!(
                             unsafe { (SSE_MIN_LEN, Avx2, Overlapping<'_>) => ChaCha20_ctr32_avx2 },
                             self, counter, in_out, cpu);
                     }
-                    if let Some(cpu) = <cpu::Features as GetFeature<Ssse3>>::get_feature(&cpu) {
+                    if let Some(cpu) = values.get_feature() {
                         return chacha20_ctr32_ffi!(
                             unsafe { (SSE_MIN_LEN, Ssse3, Overlapping<'_>) =>
                                 ChaCha20_ctr32_ssse3_4x },

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -197,12 +197,11 @@ cfg_if! {
         #[derive(Clone, Copy)]
         pub(crate) struct IntelCpu(super::Features);
 
-        impl super::GetFeature<IntelCpu> for super::Features {
+        impl super::GetFeature<IntelCpu> for super::features::Values {
             fn get_feature(&self) -> Option<IntelCpu> {
                 const MASK: u32 = 1 << (Shift::IntelCpu as u32);
-                let caps = featureflags::get(*self);
-                if (caps & MASK) == MASK {
-                    Some(IntelCpu(*self))
+                if (self.values() & MASK) == MASK {
+                    Some(IntelCpu(self.cpu()))
                 } else {
                     None
                 }
@@ -212,7 +211,7 @@ cfg_if! {
         #[derive(Clone, Copy)]
         pub(crate) struct NotPreZenAmd(super::Features);
 
-        impl super::GetFeature<NotPreZenAmd> for super::Features {
+        impl super::GetFeature<NotPreZenAmd> for super::features::Values {
             fn get_feature(&self) -> Option<NotPreZenAmd> {
                 let sha2: Option<Avx2> = self.get_feature();
                 // Pre-Zen AMD CPUs didn't implement SHA. (One Pre-Zen AMD CPU
@@ -220,12 +219,12 @@ cfg_if! {
                 // SHA instructions then we want to avoid the runtime check for
                 // an Intel/AND CPU.
                 if sha2.is_some() {
-                    return Some(NotPreZenAmd(*self));
+                    return Some(NotPreZenAmd(self.cpu()));
                 }
                 // Perhaps we should do !AMD instead of Intel.
                 let intel: Option<IntelCpu> = self.get_feature();
                 if intel.is_some() {
-                    return Some(NotPreZenAmd(*self))
+                    return Some(NotPreZenAmd(self.cpu()))
                 }
                 None
             }

--- a/src/digest/sha2/sha2_32.rs
+++ b/src/digest/sha2/sha2_32.rs
@@ -43,6 +43,7 @@ pub(crate) fn block_data_order_32(
             }
         } else if #[cfg(target_arch = "x86_64")] {
             use cpu::{GetFeature as _, intel::{Avx, IntelCpu, Sha, Ssse3 }};
+            let cpu = cpu.values();
             if let Some(cpu) = cpu.get_feature() {
                 sha2_32_ffi!(unsafe { (Sha, Ssse3) => sha256_block_data_order_hw }, state, data, cpu)
             } else if let Some(cpu) = cpu.get_feature() {


### PR DESCRIPTION
When retrieving multiple flags at once, cache the flags in a `Values` structure and then test the flags set in that cached value. This has no effect with the current `spin::Once`-based implementation, but it helps the `race::OnceNonZeroUsize` implementation avoid some redundant loads.