### PR TITLE
Drop `spin` dependency in favor of internal `OnceNonZeroUsize`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,9 +160,6 @@ cfg-if = { version = "1.0.0", default-features = false }
 getrandom = { version = "0.2.10" }
 untrusted = { version = "0.9" }
 
-[target.'cfg(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little")))'.dependencies]
-spin = { version = "0.9.8", default-features = false, features = ["once"] }
-
 [target.'cfg(all(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little")), any(target_os = "android", target_os = "linux")))'.dependencies]
 libc = { version = "0.2.148", default-features = false }
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -541,7 +541,7 @@ extern uint32_t adx_bmi2_available;
 
 
 #if defined(OPENSSL_ARM)
-extern uint32_t neon_available;
+extern alignas(4) uint32_t neon_available;
 #endif  // OPENSSL_ARM
 
 #endif  // OPENSSL_HEADER_CRYPTO_INTERNAL_H

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -62,7 +62,9 @@ macro_rules! impl_get_feature {
             #[cfg(target_arch = "x86_64")]
             IntelCpu,
 
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            #[cfg(any(all(target_arch = "aarch64", target_endian = "little"),
+                     all(target_arch = "arm", target_endian = "little"),
+                     target_arch = "x86", target_arch = "x86_64"))]
             // Synthesized to ensure the dynamic flag set is always non-zero.
             //
             // Keep this at the end as it is never checked except during init.

--- a/src/cpu/arm.rs
+++ b/src/cpu/arm.rs
@@ -90,10 +90,17 @@ impl_get_feature! {
 pub(super) mod featureflags {
     pub(in super::super) use super::detect::FORCE_DYNAMIC_DETECTION;
     use super::*;
-    use crate::cpu;
+    use crate::{
+        cpu,
+        polyfill::{once_cell::race, usize_from_u32},
+    };
+    use core::{
+        num::NonZeroUsize,
+        sync::atomic::{AtomicU32, Ordering},
+    };
 
     pub(in super::super) fn get_or_init() -> cpu::Features {
-        fn init() -> u32 {
+        fn init() -> NonZeroUsize {
             let detected = detect::detect_features();
             let filtered = (if cfg!(feature = "unstable-testing-arm-no-hw") {
                 !Neon::mask()
@@ -107,38 +114,32 @@ pub(super) mod featureflags {
             let detected = detected & !filtered;
             let merged = CAPS_STATIC | detected;
 
-            #[cfg(target_arch = "arm")]
+            #[cfg(all(
+                target_arch = "arm",
+                target_endian = "little",
+                target_has_atomic = "32"
+            ))]
             if (merged & Neon::mask()) == Neon::mask() {
+                // `neon_available` is declared as `alignas(4) uint32_t` in the C code.
+                // AtomicU32 is `#[repr(C, align(4))]`.
                 prefixed_extern! {
-                    static mut neon_available: u32;
+                    static neon_available: AtomicU32;
                 }
-
-                // TODO(MSRV 1.82.0): Remove `unsafe`.
-                #[allow(unused_unsafe)]
-                let p = unsafe { core::ptr::addr_of_mut!(neon_available) };
-
-                // SAFETY: This is the only writer, and concurrent writing is
-                // prevented as this is the `OnceLock`-like one-time
-                // initialization provided by `spin::Once`. Any concurrent
-                // reading doesn't affect the safety of this write. Any read
-                // of `neon_available` before this initialization will be zero,
-                // which is safe (no risk of illegal instructions) and correct
-                // (the value computed will be the same regardless).
-                //
-                // The way we use `spin::Once` ensures the happens-before
-                // relationship that is needed for readers to observe this
-                // write.
-                unsafe {
-                    p.write(1);
-                }
+                // SAFETY: The C code only reads `neon_available`, and its
+                // reads are synchronized through the `OnceNonZeroUsize`
+                // Acquire/Release semantics as we ensure we have a
+                // `cpu::Features` instance before calling into the C code.
+                let p = unsafe { &neon_available };
+                p.store(1, Ordering::Relaxed);
             }
 
-            merged
+            let merged = usize_from_u32(merged) | (1 << (Shift::Initialized as u32));
+            NonZeroUsize::new(merged).unwrap() // TODO: fix unwrap.
         }
 
         // SAFETY: This is the only caller. Any concurrent reading doesn't
         // affect the safety of the writing.
-        let _: &u32 = FEATURES.call_once(init);
+        let _: NonZeroUsize = FEATURES.get_or_init(init);
 
         // SAFETY: We initialized the CPU features as required.
         unsafe { cpu::Features::new_after_feature_flags_written_and_synced_unchecked() }
@@ -146,13 +147,21 @@ pub(super) mod featureflags {
 
     pub(in super::super) fn get(_cpu_features: cpu::Features) -> u32 {
         // SAFETY: Since only `get_or_init()` could have created
-        // `_cpu_features`, and it only does so after `FEATURES.call_once()`,
-        // we have met the prerequisites for calling `get_unchecked()`.
-        let features: &u32 = unsafe { FEATURES.get_unchecked() };
-        *features
+        // `_cpu_features`, and it only does so after `FEATURES.get_or_init()`,
+        // we know we are reading from `FEATURES` after initializing it.
+        //
+        // Also, 0 means "no features detected" to users, which is designed to
+        // be a safe configuration.
+        let features = FEATURES.get().map(NonZeroUsize::get).unwrap_or(0);
+
+        // The truncation is lossless, as we set the value with a u32.
+        #[allow(clippy::cast_possible_truncation)]
+        let features = features as u32;
+
+        features
     }
 
-    static FEATURES: spin::Once<u32> = spin::Once::new();
+    static FEATURES: race::OnceNonZeroUsize = race::OnceNonZeroUsize::new();
 
     // TODO(MSRV): There is no "pmull" feature listed from
     // `rustc --print cfg --target=aarch64-apple-darwin`. Originally ARMv8 tied

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -61,7 +61,12 @@ pub mod sliceutil;
 #[cfg(feature = "alloc")]
 mod leading_zeros_skipped;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little"),
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
 pub mod once_cell {
     pub mod race;
 }


### PR DESCRIPTION
Modify `cpu::arm` to use the same initialization logic as `cpu::intel`.