### PR TITLE
AES-GCM: Require SSSE3 for CLMUL-based implementation.

### DIFF
--- a/src/aead/gcm/clmul.rs
+++ b/src/aead/gcm/clmul.rs
@@ -25,7 +25,7 @@ use crate::cpu;
 pub(in super::super) type RequiredCpuFeatures = cpu::arm::PMull;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub(in super::super) type RequiredCpuFeatures = (cpu::intel::ClMul, cpu::intel::Fxsr);
+pub(in super::super) type RequiredCpuFeatures = (cpu::intel::ClMul, cpu::intel::Ssse3);
 
 #[derive(Clone)]
 pub struct Key {


### PR DESCRIPTION
PSHUFB is used, which is SSSE3.