### PR TITLE
aead::chacha internals: Stop checking FXSR bit.

### DIFF
--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -113,11 +113,11 @@ impl Key {
                         self, counter, in_out.copy_within(), ())
                 }
             } else if #[cfg(target_arch = "x86")] {
-                use cpu::{GetFeature as _, intel::{Fxsr, Ssse3}};
+                use cpu::{GetFeature as _, intel::Ssse3};
                 if in_out.len() >= 1 {
                     if let Some(cpu) = cpu.get_feature() {
                         chacha20_ctr32_ffi!(
-                            unsafe { (1, (Fxsr, Ssse3), &mut [u8]) => ChaCha20_ctr32_ssse3 },
+                            unsafe { (1, (Ssse3), &mut [u8]) => ChaCha20_ctr32_ssse3 },
                             self, counter, in_out.copy_within(), cpu)
                     } else {
                         chacha20_ctr32_ffi!(

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -105,7 +105,6 @@ fn cpuid_to_caps_and_set_c_flags(cpuid: &[u32; 4]) -> u32 {
     }
 
     // CPUID leaf 1.
-    let leaf1_edx = cpuid[0];
     let leaf1_ecx = cpuid[1];
 
     // Structured Extended Feature Flags Enumeration Leaf (Initial EAX Value = 07H, ECX = 0)
@@ -161,10 +160,6 @@ fn cpuid_to_caps_and_set_c_flags(cpuid: &[u32; 4]) -> u32 {
     // AMD: "Collectively the SSE1, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, and
     // SSE4A subsets are referred to as the legacy SSE instructions. All legacy
     // SSE instructions support 128-bit vector operands."
-
-    if check(leaf1_edx, 24) {
-        set(&mut caps, Shift::Fxsr);
-    }
 
     // Intel: "11.6.2 Checking for Intel SSE and SSE2 Support"
     // * "Check that the CPU supports the CPUID instruction."
@@ -279,7 +274,6 @@ fn cpuid_to_caps_and_set_c_flags(cpuid: &[u32; 4]) -> u32 {
 
 impl_get_feature! {
     features: [
-        { ("x86", "x86_64") => Fxsr },
         { ("x86", "x86_64") => ClMul },
         { ("x86", "x86_64") => Ssse3 },
         { ("x86", "x86_64") => Sse41 },


### PR DESCRIPTION
The checking for the FXSR bit is an anachronism from OpenSSL, where it was used as a way to indicate that SSE instructions should not be used. Currently we require SSE/SSE2 to be available. In the future, if we make SSE/SSE2 optional, then we'll need to condition the SSSE3 feature on SSE (operating system) support.

Remove the `Fxsr` CPU feature as we no longer check for it.