### PR TITLE
chacha/x86: Remove unnecessary parentheses.

### DIFF
--- a/src/aead/chacha.rs
+++ b/src/aead/chacha.rs
@@ -117,7 +117,7 @@ impl Key {
                 if in_out.len() >= 1 {
                     if let Some(cpu) = cpu.get_feature() {
                         chacha20_ctr32_ffi!(
-                            unsafe { (1, (Ssse3), &mut [u8]) => ChaCha20_ctr32_ssse3 },
+                            unsafe { (1, Ssse3, &mut [u8]) => ChaCha20_ctr32_ssse3 },
                             self, counter, in_out.copy_within(), cpu)
                     } else {
                         chacha20_ctr32_ffi!(


### PR DESCRIPTION
Address a compiler warning.