### PR TITLE
aead internals: `into_input_output_len` -> `with_input_output_len`.

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -368,20 +368,21 @@ pub(super) fn open(
                     Xi: &mut gcm::Xi) -> c::size_t;
             }
 
-            let (input, output, len) = in_out.into_input_output_len();
-            let mut auth = gcm::Context::new(gcm_key, aad, len)?;
-            let (htable, xi) = auth.inner();
-            let processed = unsafe {
-                aesni_gcm_decrypt(
-                    input,
-                    output,
-                    len,
-                    aes_key.inner_less_safe(),
-                    &mut ctr,
-                    htable,
-                    xi,
-                )
-            };
+            let mut auth = gcm::Context::new(gcm_key, aad, in_out.len())?;
+            let processed = in_out.with_input_output_len(|input, output, len| {
+                let (htable, xi) = auth.inner();
+                unsafe {
+                    aesni_gcm_decrypt(
+                        input,
+                        output,
+                        len,
+                        aes_key.inner_less_safe(),
+                        &mut ctr,
+                        htable,
+                        xi,
+                    )
+                }
+            });
             let in_out_slice = in_out_slice.get_mut(processed..).unwrap_or_else(|| {
                 // This can't happen. If it did, then the assembly already
                 // caused a buffer overflow.
@@ -420,42 +421,40 @@ pub(super) fn open(
         DynKey::AesHwClMul(Combo { aes_key, gcm_key }) => {
             use crate::bits::BitLength;
 
-            let (input, output, input_len) = in_out.into_input_output_len();
+            let mut auth = gcm::Context::new(gcm_key, aad, in_out.len())?;
+            let remainder_len = in_out.len() % BLOCK_LEN;
+            let whole_len = in_out.len() - remainder_len;
+            in_out.with_input_output_len(|input, output, _len| {
+                let whole_block_bits = auth.in_out_whole_block_bits();
+                let whole_block_bits_u64: BitLength<u64> = whole_block_bits.into();
+                if let Ok(whole_block_bits) = whole_block_bits_u64.try_into() {
+                    use core::num::NonZeroU64;
 
-            let mut auth = gcm::Context::new(gcm_key, aad, input_len)?;
+                    let (htable, xi) = auth.inner();
+                    prefixed_extern! {
+                        fn aes_gcm_dec_kernel(
+                            input: *const u8,
+                            in_bits: BitLength<NonZeroU64>,
+                            output: *mut u8,
+                            Xi: &mut gcm::Xi,
+                            ivec: &mut Counter,
+                            key: &aes::AES_KEY,
+                            Htable: &gcm::HTable);
+                    }
 
-            let remainder_len = input_len % BLOCK_LEN;
-            let whole_len = input_len - remainder_len;
-
-            let whole_block_bits = auth.in_out_whole_block_bits();
-            let whole_block_bits_u64: BitLength<u64> = whole_block_bits.into();
-            if let Ok(whole_block_bits) = whole_block_bits_u64.try_into() {
-                use core::num::NonZeroU64;
-
-                let (htable, xi) = auth.inner();
-                prefixed_extern! {
-                    fn aes_gcm_dec_kernel(
-                        input: *const u8,
-                        in_bits: BitLength<NonZeroU64>,
-                        output: *mut u8,
-                        Xi: &mut gcm::Xi,
-                        ivec: &mut Counter,
-                        key: &aes::AES_KEY,
-                        Htable: &gcm::HTable);
+                    unsafe {
+                        aes_gcm_dec_kernel(
+                            input,
+                            whole_block_bits,
+                            output,
+                            xi,
+                            &mut ctr,
+                            aes_key.inner_less_safe(),
+                            htable,
+                        )
+                    }
                 }
-
-                unsafe {
-                    aes_gcm_dec_kernel(
-                        input,
-                        whole_block_bits,
-                        output,
-                        xi,
-                        &mut ctr,
-                        aes_key.inner_less_safe(),
-                        htable,
-                    )
-                }
-            }
+            });
             let remainder = &mut in_out_slice[whole_len..];
             let remainder =
                 Overlapping::new(remainder, src).unwrap_or_else(|IndexError { .. }| unreachable!());

--- a/src/aead/chacha/ffi.rs
+++ b/src/aead/chacha/ffi.rs
@@ -57,9 +57,10 @@ pub(super) unsafe fn chacha20_ctr32_ffi<
 ) {
     assert!(MIN_LEN > 0);
     let in_out: Overlapping<'_, u8> = in_out.into();
-    let (input, output, len) = in_out.into_input_output_len();
-    assert!(len >= MIN_LEN);
-    let key = key.words_less_safe();
-    let _: Cpu = cpu;
-    unsafe { f(output, input, len, key, &counter) }
+    in_out.with_input_output_len(|input, output, len| {
+        assert!(len >= MIN_LEN);
+        let key = key.words_less_safe();
+        let _: Cpu = cpu;
+        unsafe { f(output, input, len, key, &counter) }
+    });
 }

--- a/src/aead/overlapping/base.rs
+++ b/src/aead/overlapping/base.rs
@@ -83,7 +83,7 @@ impl<T> Overlapping<'_, T> {
         })
     }
 
-    pub fn into_input_output_len(self) -> (*const T, *mut T, usize) {
+    pub fn with_input_output_len<R>(self, f: impl FnOnce(*const T, *mut T, usize) -> R) -> R {
         let len = self.len();
         let output = self.in_out.as_mut_ptr();
         // TODO: MSRV(1.65): use `output.cast_const()`
@@ -99,7 +99,7 @@ impl<T> Overlapping<'_, T> {
         } else {
             unsafe { output_const.add(self.src.start) }
         };
-        (input, output, len)
+        f(input, output, len)
     }
 
     // Perhaps unlike `slice::split_first_chunk_mut`, this is biased,


### PR DESCRIPTION
Make it clearer that the references are still non-dangling for the time the pointers are allowed to be used. This should be a NFC but better safe than sorry. It is also consistent with what we do elsewhere, e.g. in `arithmetic::inout`.