### PR TITLE
Require SSE2 when compiling C code

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -583,6 +583,10 @@ fn configure_cc(c: &mut cc::Build, target: &Target, c_root_dir: &Path, include_d
         let _ = c.define("NDEBUG", None);
     }
 
+    if (target.arch == X86) && !compiler.is_like_msvc() {
+        let _ = c.flag("-msse2");
+    }
+
     // Allow cross-compiling without a target sysroot for these targets.
     if (target.arch == WASM32)
         || (target.os == "linux" && target.env == "musl" && target.arch != X86_64)

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -159,6 +159,22 @@ typedef __int128_t int128_t;
 typedef __uint128_t uint128_t;
 #endif
 
+// GCC-like compilers indicate SSE2 with |__SSE2__|. MSVC leaves the caller to
+// know that x86_64 has SSE2, and uses _M_IX86_FP to indicate SSE2 on x86.
+// https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
+#if defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || \
+    (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
+#define OPENSSL_SSE2
+#endif
+
+// For convenience in testing 64-bit generic code, we allow disabling SSE2
+// intrinsics via |OPENSSL_NO_SSE2_FOR_TESTING|. x86_64 always has SSE2
+// available, so we would otherwise need to test such code on a non-x86_64
+// platform.
+#if defined(OPENSSL_SSE2) && defined(OPENSSL_NO_SSE2_FOR_TESTING)
+#undef OPENSSL_SSE2
+#endif
+
 // Pointer utility functions.
 
 // buffers_alias returns one if |a| and |b| alias and zero otherwise.

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -167,10 +167,18 @@ typedef __uint128_t uint128_t;
 #define OPENSSL_SSE2
 #endif
 
-// For convenience in testing 64-bit generic code, we allow disabling SSE2
-// intrinsics via |OPENSSL_NO_SSE2_FOR_TESTING|. x86_64 always has SSE2
-// available, so we would otherwise need to test such code on a non-x86_64
-// platform.
+#if defined(OPENSSL_X86) && !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SSE2)
+#error \
+    "x86 assembly requires SSE2. Build with -msse2 (recommended), or disable assembly optimizations with -DOPENSSL_NO_ASM."
+#endif
+
+// For convenience in testing the fallback code, we allow disabling SSE2
+// intrinsics via |OPENSSL_NO_SSE2_FOR_TESTING|. We require SSE2 on x86 and
+// x86_64, so we would otherwise need to test such code on a non-x86 platform.
+//
+// This does not remove the above requirement for SSE2 support with assembly
+// optimizations. It only disables some intrinsics-based optimizations so that
+// we can test the fallback code on CI.
 #if defined(OPENSSL_SSE2) && defined(OPENSSL_NO_SSE2_FOR_TESTING)
 #undef OPENSSL_SSE2
 #endif

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -162,14 +162,16 @@ typedef __uint128_t uint128_t;
 // GCC-like compilers indicate SSE2 with |__SSE2__|. MSVC leaves the caller to
 // know that x86_64 has SSE2, and uses _M_IX86_FP to indicate SSE2 on x86.
 // https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
-#if defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) || \
-    (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
-#define OPENSSL_SSE2
-#endif
-
-#if defined(OPENSSL_X86) && !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SSE2)
-#error \
-    "x86 assembly requires SSE2. Build with -msse2 (recommended), or disable assembly optimizations with -DOPENSSL_NO_ASM."
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
+# if defined(_MSC_VER) && !defined(__clang__)
+#  if defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
+#   define OPENSSL_SSE2
+#  else
+#   error "SSE2 is required."
+#  endif
+# elif !defined(__SSE2__)
+#  error "SSE2 is required."
+# endif
 #endif
 
 // For convenience in testing the fallback code, we allow disabling SSE2


### PR DESCRIPTION
Enforce that SSE2 is enabled when compiling C code and configure the C compiler to use SSE2.

See each individual commit for details.