### PR TITLE
non-aarch64/arm/x86/x86_64: declare bn_mul_mont as `extern "C"`.

### DIFF
--- a/src/arithmetic/montgomery.rs
+++ b/src/arithmetic/montgomery.rs
@@ -188,7 +188,7 @@ pub(super) fn limbs_mul_mont(
 )))]
 // TODO: Stop calling this from C and un-export it.
 prefixed_export! {
-    unsafe fn bn_mul_mont(
+    unsafe extern "C" fn bn_mul_mont(
         r: *mut Limb,
         a: *const Limb,
         b: *const Limb,

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -92,14 +92,15 @@ macro_rules! prefixed_export {
     // A function.
     {
         $( #[$meta:meta] )*
-        $vis:vis unsafe fn $name:ident ( $( $arg_pat:ident : $arg_ty:ty ),* $(,)? ) $body:block
+        $vis:vis unsafe extern "C"
+        fn $name:ident ( $( $arg_pat:ident : $arg_ty:ty ),* $(,)? ) $body:block
     } => {
         prefixed_item! {
             export_name
             $name
             {
                 $( #[$meta] )*
-                $vis unsafe fn $name ( $( $arg_pat : $arg_ty ),* ) $body
+                $vis unsafe extern "C" fn $name ( $( $arg_pat : $arg_ty ),* ) $body
             }
         }
     };


### PR DESCRIPTION
Make it clear what the calling convention is.