### PR TITLE
Revert "CI: Force the use of cc-rs 1.2.10 on Apple targets temporarily."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,12 +366,6 @@ jobs:
       - if: ${{ matrix.xcode_version != '' }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app
 
-      # Work around build failures with cc-rs 1.2.11
-      - if: ${{ contains(matrix.host_os, 'macos') }}
-        run: |
-          cargo generate-lockfile
-          cargo update -p cc --precise 1.2.10
-
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |
           mk/cargo.sh +${{ matrix.rust_channel }} test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}


### PR DESCRIPTION
This reverts commit 9a6d9e67c265adc5b29c11e8df8199bfc171a050. So we expect that CI will use cc-rs 1.2.13 or later now.