### PR TITLE
x86/x86_64: Use multi-block ghash for single block updates.

### DIFF
--- a/crypto/fipsmodule/modes/asm/ghash-x86.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-x86.pl
@@ -267,30 +267,6 @@ my ($Xhi,$Xi) = @_;
 	&ret		();
 &function_end_B("gcm_init_clmul");
 
-&function_begin_B("gcm_gmult_clmul");
-	&mov		($Xip,&wparam(0));
-	&mov		($Htbl,&wparam(1));
-
-	&call		(&label("pic"));
-&set_label("pic");
-	&blindpop	($const);
-	&lea		($const,&DWP(&label("bswap")."-".&label("pic"),$const));
-
-	&movdqu		($Xi,&QWP(0,$Xip));
-	&movdqa		($T3,&QWP(0,$const));
-	&movups		($Hkey,&QWP(0,$Htbl));
-	&pshufb		($Xi,$T3);
-	&movups		($T2,&QWP(32,$Htbl));
-
-	&clmul64x64_T2	($Xhi,$Xi,$Hkey,$T2);
-	&reduction_alg9	($Xhi,$Xi);
-
-	&pshufb		($Xi,$T3);
-	&movdqu		(&QWP(0,$Xip),$Xi);
-
-	&ret	();
-&function_end_B("gcm_gmult_clmul");
-
 &function_begin("gcm_ghash_clmul");
 	&mov		($Xip,&wparam(0));
 	&mov		($Htbl,&wparam(1));

--- a/crypto/fipsmodule/modes/asm/ghash-x86.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-x86.pl
@@ -186,32 +186,6 @@ my ($Xhi,$Xi,$Hkey,$HK)=@_;
 	&pxor		($Xi,$T2);		#
 }
 
-sub clmul64x64_T3 {
-# Even though this subroutine offers visually better ILP, it
-# was empirically found to be a tad slower than above version.
-# At least in gcm_ghash_clmul context. But it's just as well,
-# because loop modulo-scheduling is possible only thanks to
-# minimized "register" pressure...
-my ($Xhi,$Xi,$Hkey)=@_;
-
-	&movdqa		($T1,$Xi);		#
-	&movdqa		($Xhi,$Xi);
-	&pclmulqdq	($Xi,$Hkey,0x00);	#######
-	&pclmulqdq	($Xhi,$Hkey,0x11);	#######
-	&pshufd		($T2,$T1,0b01001110);	#
-	&pshufd		($T3,$Hkey,0b01001110);
-	&pxor		($T2,$T1);		#
-	&pxor		($T3,$Hkey);
-	&pclmulqdq	($T2,$T3,0x00);		#######
-	&pxor		($T2,$Xi);		#
-	&pxor		($T2,$Xhi);		#
-
-	&movdqa		($T3,$T2);		#
-	&psrldq		($T2,8);
-	&pslldq		($T3,8);		#
-	&pxor		($Xhi,$T2);
-	&pxor		($Xi,$T3);		#
-}
 
 if (1) {		# Algorithm 9 with <<1 twist.
 			# Reduction is shorter and uses only two

--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -292,7 +292,10 @@ pub(super) fn seal(
     ),
     cold
 )]
-fn seal_strided<A: aes::EncryptBlock + aes::EncryptCtr32, G: gcm::UpdateBlocks + gcm::Gmult>(
+fn seal_strided<
+    A: aes::EncryptBlock + aes::EncryptCtr32,
+    G: gcm::UpdateBlock + gcm::UpdateBlocks,
+>(
     Combo { aes_key, gcm_key }: &Combo<A, G>,
     aad: Aad<&[u8]>,
     in_out: &mut [u8],
@@ -313,7 +316,7 @@ fn seal_strided<A: aes::EncryptBlock + aes::EncryptCtr32, G: gcm::UpdateBlocks +
     seal_finish(aes_key, auth, remainder, ctr, tag_iv)
 }
 
-fn seal_finish<A: aes::EncryptBlock, G: gcm::Gmult>(
+fn seal_finish<A: aes::EncryptBlock, G: gcm::UpdateBlock>(
     aes_key: &A,
     mut auth: gcm::Context<G>,
     remainder: OverlappingPartialBlock<'_>,
@@ -501,7 +504,10 @@ pub(super) fn open(
     ),
     cold
 )]
-fn open_strided<A: aes::EncryptBlock + aes::EncryptCtr32, G: gcm::UpdateBlocks + gcm::Gmult>(
+fn open_strided<
+    A: aes::EncryptBlock + aes::EncryptCtr32,
+    G: gcm::UpdateBlock + gcm::UpdateBlocks,
+>(
     Combo { aes_key, gcm_key }: &Combo<A, G>,
     aad: Aad<&[u8]>,
     in_out_slice: &mut [u8],
@@ -555,7 +561,7 @@ fn open_strided<A: aes::EncryptBlock + aes::EncryptCtr32, G: gcm::UpdateBlocks +
     open_finish(aes_key, auth, in_out, ctr, tag_iv)
 }
 
-fn open_finish<A: aes::EncryptBlock, G: gcm::Gmult>(
+fn open_finish<A: aes::EncryptBlock, G: gcm::UpdateBlock>(
     aes_key: &A,
     mut auth: gcm::Context<G>,
     remainder: OverlappingPartialBlock<'_>,
@@ -571,7 +577,7 @@ fn open_finish<A: aes::EncryptBlock, G: gcm::Gmult>(
     Ok(finish(aes_key, auth, tag_iv))
 }
 
-fn finish<A: aes::EncryptBlock, G: gcm::Gmult>(
+fn finish<A: aes::EncryptBlock, G: gcm::UpdateBlock>(
     aes_key: &A,
     gcm_ctx: gcm::Context<G>,
     tag_iv: aes::Iv,

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -47,7 +47,7 @@ pub(super) struct Context<'key, K> {
     _not_send: NotSend,
 }
 
-impl<'key, K: Gmult> Context<'key, K> {
+impl<'key, K: UpdateBlock> Context<'key, K> {
     #[inline(always)]
     pub(crate) fn new(
         key: &'key K,
@@ -125,10 +125,9 @@ impl<K: UpdateBlocks> Context<'_, K> {
     }
 }
 
-impl<K: Gmult> Context<'_, K> {
+impl<K: UpdateBlock> Context<'_, K> {
     pub fn update_block(&mut self, a: Block) {
-        self.Xi.bitxor_assign(a);
-        self.key.gmult(&mut self.Xi);
+        self.key.update_block(&mut self.Xi, a);
     }
 
     #[inline(always)]
@@ -145,8 +144,8 @@ impl<K: Gmult> Context<'_, K> {
     }
 }
 
-pub(super) trait Gmult {
-    fn gmult(&self, xi: &mut Xi);
+pub(super) trait UpdateBlock {
+    fn update_block(&self, xi: &mut Xi, a: Block);
 }
 
 pub(super) trait UpdateBlocks {

--- a/src/aead/gcm/fallback.rs
+++ b/src/aead/gcm/fallback.rs
@@ -22,7 +22,7 @@
 //
 // Unlike the BearSSL notes, we use u128 in the 64-bit implementation.
 
-use super::{ffi::U128, Gmult, KeyValue, UpdateBlocks, Xi, BLOCK_LEN};
+use super::{ffi::U128, KeyValue, UpdateBlock, UpdateBlocks, Xi, BLOCK_LEN};
 use crate::polyfill::{slice::AsChunks, ArraySplitMap as _};
 
 #[derive(Clone)]
@@ -36,8 +36,9 @@ impl Key {
     }
 }
 
-impl Gmult for Key {
-    fn gmult(&self, xi: &mut Xi) {
+impl UpdateBlock for Key {
+    fn update_block(&self, xi: &mut Xi, a: [u8; BLOCK_LEN]) {
+        xi.bitxor_assign(a);
         gmult(xi, self.h);
     }
 }

--- a/src/aead/gcm/ffi.rs
+++ b/src/aead/gcm/ffi.rs
@@ -37,22 +37,6 @@ macro_rules! htable_new {
     }};
 }
 
-#[cfg(any(
-    all(target_arch = "aarch64", target_endian = "little"),
-    all(target_arch = "arm", target_endian = "little"),
-    target_arch = "x86",
-    target_arch = "x86_64"
-))]
-macro_rules! gmult {
-    ( $name:ident, $xi:expr, $h_table:expr $(,)? ) => {{
-        use crate::aead::gcm::ffi::{HTable, Xi};
-        prefixed_extern! {
-            fn $name(xi: &mut Xi, Htable: &HTable);
-        }
-        $h_table.gmult($name, $xi)
-    }};
-}
-
 /// SAFETY:
 ///  * The function `$name` must meet the contract of the `f` paramweter of
 ///    `ghash()`.
@@ -111,6 +95,10 @@ impl HTable {
         r
     }
 
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "arm", target_endian = "little")
+    ))]
     pub(super) unsafe fn gmult(
         &self,
         f: unsafe extern "C" fn(xi: &mut Xi, h_table: &HTable),

--- a/src/polyfill/slice/as_chunks.rs
+++ b/src/polyfill/slice/as_chunks.rs
@@ -98,6 +98,13 @@ impl<'a, T, const N: usize> From<&'a AsChunksMut<'_, T, N>> for AsChunks<'a, T, 
     }
 }
 
+impl<'a, T, const N: usize> From<&'a [T; N]> for AsChunks<'a, T, N> {
+    #[inline(always)]
+    fn from(array: &'a [T; N]) -> Self {
+        Self(array)
+    }
+}
+
 // TODO: `impl From<AsChunks<'a, T, {2*N}> for AsChunks<'a, T, N>`.
 impl<'a, T> From<AsChunks<'a, T, 8>> for AsChunks<'a, T, 4> {
     #[inline(always)]


### PR DESCRIPTION
Notably, for clmulavxmovbe, use the AVX implementation instead of the SSSE3 implementation.