### PR TITLE
digest: Don't enable AVX implementation on AMD.

### DIFF
--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -351,28 +351,6 @@ cfg_if! {
                 }
             }
         }
-
-        #[derive(Clone, Copy)]
-        pub(crate) struct NotPreZenAmd(super::Features);
-
-        impl super::GetFeature<NotPreZenAmd> for super::features::Values {
-            fn get_feature(&self) -> Option<NotPreZenAmd> {
-                let sha2: Option<Avx2> = self.get_feature();
-                // Pre-Zen AMD CPUs didn't implement SHA. (One Pre-Zen AMD CPU
-                // did support AVX2.) If we're building for a CPU that requires
-                // SHA instructions then we want to avoid the runtime check for
-                // an Intel/AND CPU.
-                if sha2.is_some() {
-                    return Some(NotPreZenAmd(self.cpu()));
-                }
-                // Perhaps we should do !AMD instead of Intel.
-                let intel: Option<IntelCpu> = self.get_feature();
-                if intel.is_some() {
-                    return Some(NotPreZenAmd(self.cpu()))
-                }
-                None
-            }
-        }
     }
 }
 

--- a/src/digest/sha2/sha2_64.rs
+++ b/src/digest/sha2/sha2_64.rs
@@ -42,12 +42,12 @@ pub(crate) fn block_data_order_64(
                 sha2_64_ffi!(unsafe { () => sha512_block_data_order_nohw }, state, data, ())
             }
         } else if #[cfg(target_arch = "x86_64")] {
-            use cpu::{GetFeature as _, intel::{Avx, NotPreZenAmd}};
+            use cpu::{GetFeature as _, intel::{Avx, IntelCpu}};
             if let Some(cpu) = cpu.get_feature() {
                 // Pre-Zen AMD CPUs had microcoded SHLD/SHRD which makes the
                 // AVX version slow. We're also unsure of the side channel
                 // ramifications of those microcoded instructions.
-                sha2_64_ffi!(unsafe { (Avx, NotPreZenAmd) => sha512_block_data_order_avx },
+                sha2_64_ffi!(unsafe { (Avx, IntelCpu) => sha512_block_data_order_avx },
                     state, data, cpu);
             } else {
                 sha2_64_ffi!(unsafe { () => sha512_block_data_order_nohw }, state, data, ())


### PR DESCRIPTION
At least on AMD 7950x (Zen 4) the AVX implementation seems to benchmark significantly worse.