### PR TITLE
Update target.h to support MIPS64

### DIFF
--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -49,6 +49,8 @@
 // Versions of GCC before 10.0 didn't define `__ILP32__` for all 32-bit targets.
 #elif defined(__MIPSEL__) || defined(__MIPSEB__) || defined(__PPC__) || defined(__powerpc__) || defined(__csky__) || defined(__XTENSA__)
 #define OPENSSL_32_BIT
+#elif defined(__MIPSEB__) && defined(__LP64__)
+#define OPENSSL_64_BIT
 #else
 #error "Unknown target CPU"
 #endif


### PR DESCRIPTION
target.h was missing the definitions for MIPS64, cf. https://github.com/briansmith/ring/issues/1866