### PR TITLE
Fuchsia AArch64: Detect SHA-512 CPU feature & clean up existing detection.

### DIFF
--- a/src/cpu/arm/fuchsia.rs
+++ b/src/cpu/arm/fuchsia.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{Aes, Neon, PMull, Sha256, CAPS_STATIC};
+use super::{Aes, Neon, PMull, Sha256, Sha512, CAPS_STATIC};
 
 pub const FORCE_DYNAMIC_DETECTION: u32 = 0;
 
@@ -29,6 +29,7 @@ pub fn detect_features() -> u32 {
     const ZX_ARM64_FEATURE_ISA_AES: u32 = 1 << 3;
     const ZX_ARM64_FEATURE_ISA_PMULL: u32 = 1 << 4;
     const ZX_ARM64_FEATURE_ISA_SHA256: u32 = 1 << 6;
+    const ZX_ARM64_FEATURE_ISA_SHA512: u32 = 1 << 18;
 
     let mut caps = 0;
     let rc = unsafe { zx_system_get_features(ZX_FEATURE_KIND_CPU, &mut caps) };
@@ -47,6 +48,9 @@ pub fn detect_features() -> u32 {
         }
         if caps & ZX_ARM64_FEATURE_ISA_SHA256 == ZX_ARM64_FEATURE_ISA_SHA256 {
             features |= Sha256::mask();
+        }
+        if caps & ZX_ARM64_FEATURE_ISA_SHA512 == ZX_ARM64_FEATURE_ISA_SHA512 {
+            features |= Sha512::mask();
         }
     }
 

--- a/src/cpu/arm/fuchsia.rs
+++ b/src/cpu/arm/fuchsia.rs
@@ -26,7 +26,6 @@ pub fn detect_features() -> u32 {
 
     const ZX_OK: i32 = 0;
     const ZX_FEATURE_KIND_CPU: u32 = 0;
-    const ZX_ARM64_FEATURE_ISA_ASIMD: u32 = 1 << 2;
     const ZX_ARM64_FEATURE_ISA_AES: u32 = 1 << 3;
     const ZX_ARM64_FEATURE_ISA_PMULL: u32 = 1 << 4;
     const ZX_ARM64_FEATURE_ISA_SHA2: u32 = 1 << 6;

--- a/src/cpu/arm/fuchsia.rs
+++ b/src/cpu/arm/fuchsia.rs
@@ -28,7 +28,7 @@ pub fn detect_features() -> u32 {
     const ZX_FEATURE_KIND_CPU: u32 = 0;
     const ZX_ARM64_FEATURE_ISA_AES: u32 = 1 << 3;
     const ZX_ARM64_FEATURE_ISA_PMULL: u32 = 1 << 4;
-    const ZX_ARM64_FEATURE_ISA_SHA2: u32 = 1 << 6;
+    const ZX_ARM64_FEATURE_ISA_SHA256: u32 = 1 << 6;
 
     let mut caps = 0;
     let rc = unsafe { zx_system_get_features(ZX_FEATURE_KIND_CPU, &mut caps) };
@@ -45,7 +45,7 @@ pub fn detect_features() -> u32 {
         if caps & ZX_ARM64_FEATURE_ISA_PMULL == ZX_ARM64_FEATURE_ISA_PMULL {
             features |= PMull::mask();
         }
-        if caps & ZX_ARM64_FEATURE_ISA_SHA2 == ZX_ARM64_FEATURE_ISA_SHA2 {
+        if caps & ZX_ARM64_FEATURE_ISA_SHA256 == ZX_ARM64_FEATURE_ISA_SHA256 {
             features |= Sha256::mask();
         }
     }


### PR DESCRIPTION
See each individual commit message for details.