### PR TITLE
Fix cross-compilation compatibility for MSVC simulation with clang-cl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,12 +175,7 @@ wasm-bindgen-test = { version = "0.3.37", default-features = false, features = [
 libc = { version = "0.2.148", default-features = false }
 
 [build-dependencies]
-cc = { version = "1.0.83", default-features = false }
-
-# At least 1.0.93 is requried for visionOS, but some versions around that point
-# have bugs that seem to have been fixed in 1.0.97 or so.
-[target.'cfg(all(target_vendor = "apple", target_os = "visionos"))'.build-dependencies]
-cc = { version = "1.0.97", default-features = false }
+cc = { version = "1.2.8", default-features = false }
 
 [features]
 # These features are documented in the top-level module's documentation.

--- a/build.rs
+++ b/build.rs
@@ -583,8 +583,11 @@ fn configure_cc(c: &mut cc::Build, target: &Target, c_root_dir: &Path, include_d
         let _ = c.define("NDEBUG", None);
     }
 
-    if (target.arch == X86) && !compiler.is_like_msvc() {
-        let _ = c.flag("-msse2");
+    if target.arch == X86 {
+        let is_msvc_not_clang_cl = compiler.is_like_msvc() && !compiler.is_like_clang_cl();
+        if !is_msvc_not_clang_cl {
+            let _ = c.flag("-msse2");
+        }
     }
 
     // Allow cross-compiling without a target sysroot for these targets.


### PR DESCRIPTION
Modified the conditional logic in build.rs to allow for the usage of the `-msse2` flag when using clang-cl as a cross-compiler simulating MSVC. This update ensures compatibility for environments where clang-cl is used for MSVC-style compilation, enabling the appropriate SSE2 optimizations in these cases.

- Adjusted logic to check for `clang-cl` in addition to MSVC.
- Ensured that `-msse2` flag is applied when compiling for x86 with clang-cl.


**_I agree to license my contributions to each file under the terms given
at the top of each file I changed._**