### PR TITLE
#2415 /Zm20000 increases the available memory for macro expansion and…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:wchar_t",
             "/Zc:forScope",
             "/Zc:inline",
-            "/Zm3000",
+            "/Zm2500",
             // Warnings.
             "/Wall",
             "/wd4127", // C4127: conditional expression is constant

--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:wchar_t",
             "/Zc:forScope",
             "/Zc:inline",
-            "/Zm2000",
+            "/Zm20000",
             // Warnings.
             "/Wall",
             "/wd4127", // C4127: conditional expression is constant

--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:wchar_t",
             "/Zc:forScope",
             "/Zc:inline",
-            "/Zm125",
+            "/Zm2000",
             // Warnings.
             "/Wall",
             "/wd4127", // C4127: conditional expression is constant

--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:wchar_t",
             "/Zc:forScope",
             "/Zc:inline",
-            "/Zm2500",
+            "/Zm2000",
             // Warnings.
             "/Wall",
             "/wd4127", // C4127: conditional expression is constant

--- a/build.rs
+++ b/build.rs
@@ -151,6 +151,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:wchar_t",
             "/Zc:forScope",
             "/Zc:inline",
+            "/Zm20000",
             // Warnings.
             "/Wall",
             "/wd4127", // C4127: conditional expression is constant

--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:wchar_t",
             "/Zc:forScope",
             "/Zc:inline",
-            "/Zm20000",
+            "/Zm2000",
             // Warnings.
             "/Wall",
             "/wd4127", // C4127: conditional expression is constant

--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:wchar_t",
             "/Zc:forScope",
             "/Zc:inline",
-            "/Zm5000",
+            "/Zm3000",
             // Warnings.
             "/Wall",
             "/wd4127", // C4127: conditional expression is constant

--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:wchar_t",
             "/Zc:forScope",
             "/Zc:inline",
-            "/Zm2000",
+            "/Zm5000",
             // Warnings.
             "/Wall",
             "/wd4127", // C4127: conditional expression is constant


### PR DESCRIPTION
… precompiled header processing with MSVC

this fixed https://github.com/briansmith/ring/issues/2415 for me.

```
cargo build
   Compiling ring v0.17.9 (C:\working\rust\ring)
error: failed to run custom build command for `ring v0.17.9 (C:\working\rust\ring)`

Caused by:
  process didn't exit successfully: `c:\working\rust\ring\target\debug\build\ring-183a1fdc65207a18\build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=CARGO_MANIFEST_DIR
  cargo:rerun-if-env-changed=CARGO_PKG_NAME
  cargo:rerun-if-env-changed=CARGO_PKG_VERSION_MAJOR
  cargo:rerun-if-env-changed=CARGO_PKG_VERSION_MINOR
  cargo:rerun-if-env-changed=CARGO_PKG_VERSION_PATCH
  cargo:rerun-if-env-changed=CARGO_PKG_VERSION_PRE
  cargo:rerun-if-env-changed=CARGO_MANIFEST_LINKS
  cargo:rerun-if-env-changed=RING_PREGENERATE_ASM
  cargo:rerun-if-env-changed=OUT_DIR
  cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH
  cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS
  cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ENV
  cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ENDIAN
  cargo:rerun-if-env-changed=DEBUG
  cargo:rerun-if-env-changed=PERL_EXECUTABLE

  --- stderr
  running "perl" "c:/\\/working/rust/ring/crypto/chacha/asm/chacha-x86_64.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/chacha-x86_64-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/aes/asm/aesni-gcm-x86_64.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/aesni-gcm-x86_64-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/aes/asm/aesni-x86_64.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/aesni-x86_64-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/aes/asm/ghash-x86_64.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/ghash-x86_64-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/vpaes-x86_64-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/bn/asm/x86_64-mont.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/x86_64-mont-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/bn/asm/x86_64-mont5.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/x86_64-mont5-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/p256-x86_64-asm-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/sha/asm/sha512-x86_64.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/sha512-x86_64-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/cipher/asm/chacha20_poly1305_x86_64.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/chacha20_poly1305_x86_64-nasm.asm"
  running "perl" "c:/\\/working/rust/ring/crypto/fipsmodule/sha/asm/sha512-x86_64.pl" "nasm" "c:/\\/working/rust/ring/target/debug/build/ring-4d38d14482dcbc2e/out/sha256-x86_64-nasm.asm"
  running "./target/tools/windows/nasm/nasm" "-o" "c:\\working\\rust\\ring\\target\\debug\\build\\ring-4d38d14482dcbc2e\\out\\chacha-x86_64-nasm.o" "-f" "win64" "-i" "include/" "-i" "c:\\working\\rust\\ring\\target\\debug\\build\\ring-4d38d14482dcbc2e\\out\\" "-Xgnu" "-gcv8" "c:\\working\\rust\\ring\\target\\debug\\build\\ring-4d38d14482dcbc2e\\out\\chacha-x86_64-nasm.asm"
  thread 'main' panicked at build.rs:648:9:
  failed to execute ["./target/tools/windows/nasm/nasm" "-o" "c:\\working\\rust\\ring\\target\\debug\\build\\ring-4d38d14482dcbc2e\\out\\chacha-x86_64-nasm.o" "-f" "win64" "-i" "include/" "-i" "c:\\working\\rust\\ring\\target\\debug\\build\\ring-4d38d14482dcbc2e\\out\\" "-Xgnu" "-gcv8" "c:\\working\\rust\\ring\\target\\debug\\build\\ring-4d38d14482dcbc2e\\out\\chacha-x86_64-nasm.asm"]: The system cannot find the path specified. (os error 3)
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```
  
  I applied this fix to my working crate out of .cargo.  above are the errors when I try to just build the crate locally; so I can't test further.  Let me know if you know what to do to get cargo build to work on latest.  This patch maybe helpful to others.