### PR TITLE
Remove BoringSSL reference from documentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-//! Safe, fast, small crypto using Rust with BoringSSL's cryptography
-//! primitives.
-//!
 //! # Feature Flags
 //!
 //! <table>


### PR DESCRIPTION
My understanding is that people have misunderstandings about the relationship between this project and BoringSSL. Make that a bit clearer.