### PR TITLE
Add QNX support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -253,6 +253,7 @@ const LINUX_ABI: &[&str] = &[
     "linux",
     "redox",
     "solaris",
+    "nto",
 ];
 
 const WIN32N: &str = "win32n";

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -141,6 +141,7 @@ impl crate::sealed::Sealed for SystemRandom {}
     target_os = "solaris",
     target_os = "vita",
     target_os = "windows",
+    target_os = "nto",
     all(
         target_vendor = "apple",
         any(


### PR DESCRIPTION
+ `getrandom` supports QNX, so we can just use that (see [getrandom's readme](https://github.com/rust-random/getrandom/tree/master?tab=readme-ov-file#supported-targets))
+ QNX uses ELF just like *BSD and Linux (see [QNX doc on shared objects](https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.sys_arch/topic/dll_HOWUSED.html)), thus add it to the LINUX_ABI list so that we won't miss symbols defined in ASMs during linking

QNX is currently a tier 3 target (see [rustc - nto-qnx](https://doc.rust-lang.org/nightly/rustc/platform-support/nto-qnx.html)).