### PR TITLE
TODO(MSRV): RSA: deprecate accidentally-exposed API.

### DIFF
--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -13,7 +13,8 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{
-    padding::RsaEncoding, KeyPairComponents, PublicExponent, PublicKey, PublicKeyComponents, N,
+    padding::{RsaEncoding, RsaEncodingInternal},
+    KeyPairComponents, PublicExponent, PublicKey, PublicKeyComponents, N,
 };
 
 /// RSA PKCS#1 1.5 signatures.
@@ -546,7 +547,13 @@ impl KeyPair {
 
         // Use the output buffer as the scratch space for the signature to
         // reduce the required stack space.
-        padding_alg.encode(m_hash, signature, self.public().inner().n().len_bits(), rng)?;
+        RsaEncodingInternal::encode(
+            padding_alg,
+            m_hash,
+            signature,
+            self.public().inner().n().len_bits(),
+            rng,
+        )?;
 
         // RFC 8017 Section 5.1.2: RSADP, using the Chinese Remainder Theorem
         // with Garner's algorithm.

--- a/src/rsa/padding/pkcs1.rs
+++ b/src/rsa/padding/pkcs1.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{super::PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN, Padding, RsaEncoding, Verification};
+use super::{super::PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN, Padding, RsaEncodingInternal, Verification};
 use crate::{bits, digest, error, io::der, rand};
 
 /// PKCS#1 1.5 padding as described in [RFC 3447 Section 8.2].
@@ -35,7 +35,7 @@ impl Padding for PKCS1 {
     }
 }
 
-impl RsaEncoding for PKCS1 {
+impl RsaEncodingInternal for PKCS1 {
     fn encode(
         &self,
         m_hash: digest::Digest,

--- a/src/rsa/padding/pss.rs
+++ b/src/rsa/padding/pss.rs
@@ -12,7 +12,9 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{super::PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN, mgf1, Padding, RsaEncoding, Verification};
+use super::{
+    super::PUBLIC_KEY_PUBLIC_MODULUS_MAX_LEN, mgf1, Padding, RsaEncodingInternal, Verification,
+};
 use crate::{bb, bits, digest, error, rand};
 
 /// RSA PSS padding as described in [RFC 3447 Section 8.1].
@@ -35,7 +37,7 @@ impl Padding for PSS {
     }
 }
 
-impl RsaEncoding for PSS {
+impl RsaEncodingInternal for PSS {
     // Implement padding procedure per EMSA-PSS,
     // https://tools.ietf.org/html/rfc3447#section-9.1.
     fn encode(


### PR DESCRIPTION
The `encode` method was exposed long, long ago accidentally. Start the process of fixing that.