### PR TITLE
Use `core::ffi::{c_int, c_uint}` now that we have MSRV >= 1.64.

### DIFF
--- a/src/aead/aes/ffi.rs
+++ b/src/aead/aes/ffi.rs
@@ -14,7 +14,10 @@
 
 use super::{Block, KeyBytes, Overlapping, BLOCK_LEN};
 use crate::{bits::BitLength, c, error};
-use core::num::{NonZeroU32, NonZeroUsize};
+use core::{
+    ffi::{c_int, c_uint},
+    num::{NonZeroU32, NonZeroUsize},
+};
 
 /// nonce || big-endian counter.
 #[repr(transparent)]
@@ -25,7 +28,7 @@ pub(in super::super) struct Counter(pub(super) [u8; BLOCK_LEN]);
 #[derive(Clone)]
 pub(in super::super) struct AES_KEY {
     pub rd_key: [u32; 4 * (MAX_ROUNDS + 1)],
-    pub rounds: c::uint,
+    pub rounds: c_uint,
 }
 
 // Keep this in sync with `AES_MAXNR` in aes.h.
@@ -34,7 +37,7 @@ const MAX_ROUNDS: usize = 14;
 impl AES_KEY {
     #[inline]
     pub(super) unsafe fn new(
-        f: unsafe extern "C" fn(*const u8, BitLength<c::int>, *mut AES_KEY) -> c::int,
+        f: unsafe extern "C" fn(*const u8, BitLength<c_int>, *mut AES_KEY) -> c_int,
         bytes: KeyBytes<'_>,
     ) -> Result<Self, error::Unspecified> {
         let mut key = Self {
@@ -88,9 +91,10 @@ impl AES_KEY {
 // crypto/fipsmodule/aes/internal.h.
 macro_rules! set_encrypt_key {
     ( $name:ident, $key_bytes:expr $(,)? ) => {{
-        use crate::{bits::BitLength, c};
+        use crate::bits::BitLength;
+        use core::ffi::c_int;
         prefixed_extern! {
-            fn $name(user_key: *const u8, bits: BitLength<c::int>, key: *mut AES_KEY) -> c::int;
+            fn $name(user_key: *const u8, bits: BitLength<c_int>, key: *mut AES_KEY) -> c_int;
         }
         $crate::aead::aes::ffi::AES_KEY::new($name, $key_bytes)
     }};

--- a/src/arithmetic/limbs/x86_64/mont.rs
+++ b/src/arithmetic/limbs/x86_64/mont.rs
@@ -173,7 +173,7 @@ pub(in super::super::super) unsafe fn mul_mont_gather5_amm(
     maybe_adx_bmi1_bmi2: Option<(Adx, Bmi1, Bmi2)>,
 ) -> Result<(), LimbSliceError> {
     prefixed_extern! {
-        // Upstream has `num: c::int` and `power: c::int`; see
+        // Upstream has `num: c_int` and `power: c_int`; see
         // `_MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES`.
         fn bn_mul4x_mont_gather5(
             rp: *mut Limb,
@@ -184,7 +184,7 @@ pub(in super::super::super) unsafe fn mul_mont_gather5_amm(
             num: c::NonZero_size_t,
             power: Window,
         );
-        // Upstream has `num: c::int` and `power: c::int`; see
+        // Upstream has `num: c_int` and `power: c_int`; see
         // `_MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES`.
         fn bn_mulx4x_mont_gather5(
             rp: *mut Limb,
@@ -229,7 +229,7 @@ pub(in super::super::super) unsafe fn power5_amm(
     maybe_adx_bmi1_bmi2: Option<(Adx, Bmi1, Bmi2)>,
 ) -> Result<(), LimbSliceError> {
     prefixed_extern! {
-        // Upstream has `num: c::int` and `power: c::int`; see
+        // Upstream has `num: c_int` and `power: c_int`; see
         // `_MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES`.
         fn bn_power5_nohw(
             rp: *mut Limb,
@@ -240,7 +240,7 @@ pub(in super::super::super) unsafe fn power5_amm(
             num: c::NonZero_size_t,
             power: Window,
         );
-        // Upstream has `num: c::int` and `power: c::int`; see
+        // Upstream has `num: c_int` and `power: c_int`; see
         // `_MAX_LIMBS_ADDRESSES_MEMORY_SAFETY_ISSUES`.
         fn bn_powerx5(
             rp: *mut Limb,

--- a/src/bb/mod.rs
+++ b/src/bb/mod.rs
@@ -15,7 +15,7 @@
 //! Building blocks.
 
 use crate::{c, error};
-use core::num::NonZeroUsize;
+use core::{ffi::c_int, num::NonZeroUsize};
 
 mod boolmask;
 mod leaky;
@@ -46,7 +46,7 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<(), error::Unspecif
 }
 
 prefixed_extern! {
-    fn CRYPTO_memcmp(a: *const u8, b: *const u8, len: c::NonZero_size_t) -> c::int;
+    fn CRYPTO_memcmp(a: *const u8, b: *const u8, len: c::NonZero_size_t) -> c_int;
 }
 
 pub(crate) fn xor_16(a: [u8; 16], b: [u8; 16]) -> [u8; 16] {

--- a/src/bssl.rs
+++ b/src/bssl.rs
@@ -12,14 +12,15 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use crate::{c, error};
+use crate::error;
+use core::ffi::c_int;
 
 /// An `int` returned from a foreign function containing **1** if the function
 /// was successful or **0** if an error occurred. This is the convention used by
 /// C code in `ring`.
 #[must_use]
 #[repr(transparent)]
-pub struct Result(c::int);
+pub struct Result(c_int);
 
 impl From<Result> for core::result::Result<(), error::Unspecified> {
     fn from(ret: Result) -> Self {
@@ -36,12 +37,15 @@ impl From<Result> for core::result::Result<(), error::Unspecified> {
 #[cfg(test)]
 mod tests {
     mod result {
-        use crate::{bssl, c};
-        use core::mem::{align_of, size_of};
+        use crate::bssl;
+        use core::{
+            ffi::c_int,
+            mem::{align_of, size_of},
+        };
 
         #[test]
         fn size_and_alignment() {
-            type Underlying = c::int;
+            type Underlying = c_int;
             assert_eq!(size_of::<bssl::Result>(), size_of::<Underlying>());
             assert_eq!(align_of::<bssl::Result>(), align_of::<Underlying>());
         }

--- a/src/c.rs
+++ b/src/c.rs
@@ -20,8 +20,8 @@
 //! probably change if/when we support 16-bit platforms or platforms where
 //! `usize` and `uintptr_t` are different sizes.
 //!
-//! TODO(MSRV-1.64): Use `core::ffi::{c_int, c_uint}`, remove the libc
-//! compatibility testing, and remove the libc dev-dependency.
+//! TODO(MSRV, feature(c_size_t)): Use `core::{ffi::c_size_t}`.
+//! TODO(MSRV-1.79): Use `NonZero<c_size_t>`.
 
 // Keep in sync with the checks in base.h that verify these assumptions.
 
@@ -29,31 +29,5 @@
 
 use core::num::NonZeroUsize;
 
-pub(crate) type int = i32;
-pub(crate) type uint = u32;
 pub(crate) type size_t = usize;
 pub(crate) type NonZero_size_t = NonZeroUsize;
-
-#[cfg(all(test, any(unix, windows)))]
-mod tests {
-    use crate::c;
-
-    #[test]
-    fn test_libc_compatible() {
-        {
-            let x: c::int = 1;
-            let _x: libc::c_int = x;
-        }
-
-        {
-            let x: c::uint = 1;
-            let _x: libc::c_uint = x;
-        }
-
-        {
-            let x: c::size_t = 1;
-            let _x: libc::size_t = x;
-            let _x: usize = x;
-        }
-    }
-}

--- a/src/ec/curve25519/ops.rs
+++ b/src/ec/curve25519/ops.rs
@@ -17,10 +17,10 @@
 
 pub use super::scalar::{MaskedScalar, Scalar, SCALAR_LEN};
 use crate::{
-    bssl, c, cpu, error,
+    bssl, cpu, error,
     limb::{Limb, LIMB_BITS},
 };
-use core::marker::PhantomData;
+use core::{ffi::c_int, marker::PhantomData};
 
 // Elem<T>` is `fe` in curve25519/internal.h.
 // Elem<L> is `fe_loose` in curve25519/internal.h.
@@ -82,7 +82,7 @@ impl ExtPoint {
             t: Elem::zero(),
         };
         prefixed_extern! {
-            fn x25519_ge_scalarmult_base(h: &mut ExtPoint, a: &Scalar, has_fe25519_adx: c::int);
+            fn x25519_ge_scalarmult_base(h: &mut ExtPoint, a: &Scalar, has_fe25519_adx: c_int);
         }
         unsafe {
             x25519_ge_scalarmult_base(&mut r, scalar, has_fe25519_adx(cpu).into());

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -15,7 +15,8 @@
 //! X25519 Key agreement.
 
 use super::{ops, scalar::SCALAR_LEN};
-use crate::{agreement, bb, c, cpu, ec, error, rand};
+use crate::{agreement, bb, cpu, ec, error, rand};
+use core::ffi::c_int;
 
 static CURVE25519: ec::Curve = ec::Curve {
     public_key_len: PUBLIC_KEY_LEN,
@@ -83,7 +84,7 @@ fn x25519_public_from_private(
         fn x25519_public_from_private_generic_masked(
             public_key_out: &mut PublicKey,
             private_key: &PrivateKey,
-            use_adx: c::int,
+            use_adx: c_int,
         );
     }
     unsafe {


### PR DESCRIPTION
Cargo.toml: Narrow and document `libc` dependency conditions.