### PR TITLE
limb.rs: specify ambiguous into type

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -25,7 +25,7 @@ use crate::{
     polyfill::{sliceutil, usize_from_u32, ArrayFlatMap},
 };
 use core::{iter, num::NonZeroUsize};
-
+use core::num::NonZero;
 #[cfg(any(test, feature = "alloc"))]
 use crate::bits;
 
@@ -60,7 +60,7 @@ fn limbs_less_than_limbs(a: &[Limb], b: &[Limb]) -> Result<LimbMask, LenMismatch
     // optimizer.
     // XXX: Questionable whether `LenMismatchError` is appropriate.
     let len = NonZeroUsize::new(b.len()).ok_or_else(|| LenMismatchError::new(a.len()))?;
-    if a.len() != len.into() {
+    if a.len() != <NonZero<usize> as Into<usize>>::into(len) {
         return Err(LenMismatchError::new(a.len()));
     }
     Ok(unsafe { LIMBS_less_than(a.as_ptr(), b.as_ptr(), len) })


### PR DESCRIPTION
I experienced a compile error for ring as a dependency of jsonwebtoken.
A `len.into()` is ambigous because of an impl definition of the serde_json crate; see below:

```rs
error[E0283]: type annotations needed
  --> /home/rens/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.17.12/src/limb.rs:66:23
   |
66 |     if a.len() != len.into() {
   |                --     ^^^^
   |                |
   |                type must be known at this point
   |
   = note: multiple `impl`s satisfying `usize: PartialEq<_>` found in the following crates: `core`, `serde_json`:
           - impl PartialEq for usize;
           - impl PartialEq<serde_json::value::Value> for usize;
help: try using a fully qualified path to specify the expected types
   |
66 -     if a.len() != len.into() {
66 +     if a.len() != <NonZero<usize> as Into<T>>::into(len) {
   |
```

My commit fixes this issue in the way the error message suggests.
Thanks!