### PR TITLE
CI: Use QEMU 9.2.2 from ring-toolchain.

### DIFF
--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -33,7 +33,7 @@ qemu_riscv64="qemu-riscv64 -L /usr/riscv64-linux-gnu"
 qemu_s390x="qemu-s390x -L /usr/s390x-linux-gnu"
 qemu_sparc64="qemu-sparc64 -L /usr/sparc64-linux-gnu"
 qemu_x86="qemu-i386"
-qemu_x86_64="qemu-x86_64"
+qemu_x86_64="$PWD/target/tools/linux-x86_64/qemu/bin/qemu-x86_64"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -203,7 +203,11 @@ wasm32-wasi|wasm32-wasip1|wasm32-wasip2)
   ;;
 x86_64-unknown-linux-gnu)
   if [ -n "${RING_CPU_MODEL-}" ]; then
-    install_packages qemu-user
+    git clone \
+        --branch linux-x86_64 \
+        --depth 1 \
+        https://github.com/briansmith/ring-toolchain \
+        target/tools/linux-x86_64
   fi
   ;;
 *)


### PR DESCRIPTION
Get support for newer CPU models from the newer QEMU.