### PR TITLE
aes_gcm/x86_64: Tweak `gcm_ghash_vpclmulqdq_avx2_16`.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -949,7 +949,7 @@ fn prefix_all_symbols(pp: char, prefix_prefix: &str, prefix: &str) -> String {
         "gcm_ghash_avx",
         "gcm_ghash_clmul",
         "gcm_ghash_neon",
-        "gcm_ghash_vpclmulqdq_avx2_1",
+        "gcm_ghash_vpclmulqdq_avx2_16",
         "gcm_gmult_clmul",
         "gcm_gmult_neon",
         "gcm_init_avx",

--- a/src/aead/gcm/vclmulavx2.rs
+++ b/src/aead/gcm/vclmulavx2.rs
@@ -41,6 +41,6 @@ impl Key {
 impl UpdateBlock for Key {
     fn update_block(&self, xi: &mut Xi, a: [u8; BLOCK_LEN]) {
         let input: AsChunks<u8, BLOCK_LEN> = (&a).into();
-        unsafe { ghash!(gcm_ghash_vpclmulqdq_avx2_1, xi, &self.h_table, input) }
+        unsafe { ghash!(gcm_ghash_vpclmulqdq_avx2_16, xi, &self.h_table, input) }
     }
 }


### PR DESCRIPTION
Instead of starting with the body of the original
`gcm_ghash_vpclmulqdq_avx2` and removing the multi-block support, start with
`gcm_gmult_vpclmulqdq_avx2` and add the XOR of `aad`.

The instruction scheduling seems a bit better. Also, this computes
`bswap(Xi ^ aad)` instead of `bswap(Xi) ^ bswap(aad)`, saving one pshufb.

Rename the function to `gcm_ghash_vpclmulqdq_avx2_16` to better reflect its
constraint on `aad_len_16`.

This is the diff between this function and BoringSSL's
`gcm_gmult_vpclmulqdq_avx2`, as of
14d05a3b27f6706f9842583af405163b434c5c0e.

```diff
--- a/crypto/fipsmodule/aes/asm/aes-gcm-avx2-x86_64.pl
+++ b/crypto/fipsmodule/aes/asm/aes-gcm-avx2-x86_64.pl
@@ -436,10 +436,17 @@ sub _ghash_4x {
     return $code;
 }

-# void gcm_gmult_vpclmulqdq_avx2(uint8_t Xi[16], const u128 Htable[16]);
-$code .= _begin_func "gcm_gmult_vpclmulqdq_avx2", 1;
+# void gcm_ghash_vpclmulqdq_avx2_16(uint8_t Xi[16], const u128 Htable[16],
+#                                   const uint8_t aad[16], size_t aad_len_16);
+#
+# Using the key |Htable|, update the GHASH accumulator |Xi| with the data given
+# by |aad| and |aad_len_16|. |aad_len_16| must be exactly 16.
+#
+# This has the same signature `gcm_ghash_vpclmulqdq_avx2` but uses the
+# implementation from `gcm_gmult_vpclmulqdq_avx2`, with the XOR of `aad` added.
+$code .= _begin_func "gcm_ghash_vpclmulqdq_avx2_16", 1;
 {
-    my ( $GHASH_ACC_PTR, $HTABLE ) = @argregs[ 0 .. 1 ];
+    my ( $GHASH_ACC_PTR, $HTABLE, $AAD, $AAD_LEN_16 ) = @argregs[ 0 .. 3 ];
     my ( $GHASH_ACC, $BSWAP_MASK, $H_POW1, $GFPOLY, $T0, $T1, $T2 ) =
       map( "%xmm$_", ( 0 .. 6 ) );

@@ -448,6 +455,10 @@ $code .= _begin_func "gcm_gmult_vpclmulqdq_avx2", 1;
     .seh_endprologue

     vmovdqu         ($GHASH_ACC_PTR), $GHASH_ACC
+
+    # XOR the AAD into the accumulator.
+    vpxor           ($AAD), $GHASH_ACC, $GHASH_ACC
+
     vmovdqu         .Lbswap_mask(%rip), $BSWAP_MASK
     vmovdqu         $OFFSETOFEND_H_POWERS-16($HTABLE), $H_POW1
     vmovdqu         .Lgfpoly(%rip), $GFPOLY
@@ -463,108 +474,6 @@ ___
 }
 $code .= _end_func;
```

See the full diff:
```
git difftool 14d05a3b27f6706f9842583af405163b434c5c0e \
    crypto/fipsmodule/aes/asm/aes-gcm-avx2-x86_64.pl
```
