### PR TITLE
cpu: Use relaxed ordering on AArch64.

### DIFF
--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -82,7 +82,7 @@ pub(super) mod featureflags {
         features
     }
 
-    static FEATURES: race::OnceNonZeroUsize = race::OnceNonZeroUsize::new();
+    static FEATURES: race::OnceNonZeroUsize<race::AcquireRelease> = race::OnceNonZeroUsize::new();
 
     #[cfg(target_arch = "x86")]
     #[rustfmt::skip]


### PR DESCRIPTION
This changes the codegen for places where we call `cpu::features()` as expected.

Examples:

```
 	adrp	x8, :got:_ZN4ring3cpu3arm12featureflags8FEATURES17habb4a2487137fb15E
 	mov	x19, x0
	ldr	x8, [x8, :got_lo12:_ZN4ring3cpu3arm12featureflags8FEATURES17habb4a2487137fb15E]
-	ldar	x8, [x8]
+	ldr	x8, [x8]
 	cbz	x8, .LBB86_2
```

```
 	adrp	x8, :got:_ZN4ring3cpu3arm12featureflags8FEATURES17habb4a2487137fb15E
 	mov	x19, x4
 	mov	x20, x3
 	ldr	x8, [x8, :got_lo12:_ZN4ring3cpu3arm12featureflags8FEATURES17habb4a2487137fb15E]
 	mov	x21, x2
 	mov	x22, x0
 	sub	x23, x3, #4
-	ldar	x8, [x8]
+	ldr	x8, [x8]
 	cbz	x8, .LBB84_8
```