### PR TITLE
Use `lto = false` in release profile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,7 @@ wasm32_unknown_unknown_js = ["getrandom/js"]
 opt-level = 3
 debug = false
 rpath = false
-lto = true
+lto = false
 debug-assertions = false
 codegen-units = 1
 


### PR DESCRIPTION
`cargo asm` seems to work better without LTO.