### PR TITLE
CI: Add `overflow-checks = true` to release and bench profiles.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ rpath = false
 lto = false
 debug-assertions = false
 codegen-units = 1
+overflow-checks = true
 
 [profile.release]
 opt-level = 3
@@ -211,6 +212,7 @@ rpath = false
 lto = true
 debug-assertions = false
 codegen-units = 1
+overflow-checks = true
 
 [workspace]
 members = [


### PR DESCRIPTION
I hope that this allows code coverage measurement to find cases where there is a potential overflow panic, as the branch should show up as uncovered.