### PR TITLE
AEAD: Reduce punning of architecture-specific implementations.

### DIFF
--- a/src/aead/gcm/neon.rs
+++ b/src/aead/gcm/neon.rs
@@ -20,19 +20,21 @@
 use super::{HTable, KeyValue, UpdateBlock, UpdateBlocks, Xi, BLOCK_LEN};
 use crate::{cpu, polyfill::slice::AsChunks};
 
-#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-pub(in super::super) type RequiredCpuFeatures = cpu::aarch64::Neon;
-
-#[cfg(all(target_arch = "arm", target_endian = "little"))]
-pub(in super::super) type RequiredCpuFeatures = cpu::arm::Neon;
-
 #[derive(Clone)]
 pub struct Key {
     h_table: HTable,
 }
 
 impl Key {
-    pub(in super::super) fn new(value: KeyValue, _cpu: RequiredCpuFeatures) -> Self {
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    pub(in super::super) fn new(value: KeyValue, _cpu: cpu::aarch64::Neon) -> Self {
+        Self {
+            h_table: unsafe { htable_new!(gcm_init_neon, value) },
+        }
+    }
+
+    #[cfg(all(target_arch = "arm", target_endian = "little"))]
+    pub(in super::super) fn new(value: KeyValue, _cpu: cpu::arm::Neon) -> Self {
         Self {
             h_table: unsafe { htable_new!(gcm_init_neon, value) },
         }


### PR DESCRIPTION
Replace the punning with separate implementations so that code coverage can measure them better. The punning is avoided at construction of the key objects, but not necessarily everywhere else; this is good enough for us to see that each implementation is selected during coverage testing, while still minimizing duplication.