### PR TITLE
aes-gcm: Remove the `htable_new!` macro

### DIFF
--- a/src/aead/gcm/clmul.rs
+++ b/src/aead/gcm/clmul.rs
@@ -18,8 +18,7 @@
     target_arch = "x86_64"
 ))]
 
-use super::{ffi::KeyValue, HTable, UpdateBlock, Xi};
-use crate::aead::gcm::ffi::BLOCK_LEN;
+use super::{ffi::{BLOCK_LEN, KeyValue}, HTable, UpdateBlock, Xi};
 use crate::cpu;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use {super::UpdateBlocks, crate::polyfill::slice::AsChunks};

--- a/src/aead/gcm/clmul.rs
+++ b/src/aead/gcm/clmul.rs
@@ -18,7 +18,10 @@
     target_arch = "x86_64"
 ))]
 
-use super::{ffi::{BLOCK_LEN, KeyValue}, HTable, UpdateBlock, Xi};
+use super::{
+    ffi::{KeyValue, BLOCK_LEN},
+    HTable, UpdateBlock, Xi,
+};
 use crate::cpu;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use {super::UpdateBlocks, crate::polyfill::slice::AsChunks};
@@ -31,8 +34,11 @@ pub struct Key {
 impl Key {
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     pub(in super::super) fn new(value: KeyValue, _cpu: cpu::aarch64::PMull) -> Self {
+        prefixed_extern! {
+            fn gcm_init_clmul(HTable: *mut HTable, h: &KeyValue);
+        }
         Self {
-            h_table: unsafe { htable_new!(gcm_init_clmul, value) },
+            h_table: HTable::new(|table| unsafe { gcm_init_clmul(table, &value) }),
         }
     }
 
@@ -41,8 +47,11 @@ impl Key {
         value: KeyValue,
         _cpu: (cpu::intel::ClMul, cpu::intel::Ssse3),
     ) -> Self {
+        prefixed_extern! {
+            fn gcm_init_clmul(HTable: *mut HTable, h: &KeyValue);
+        }
         Self {
-            h_table: unsafe { htable_new!(gcm_init_clmul, value) },
+            h_table: HTable::new(|htable| unsafe { gcm_init_clmul(htable, &value) }),
         }
     }
 
@@ -52,8 +61,11 @@ impl Key {
         value: KeyValue,
         _cpu: (cpu::intel::ClMul, cpu::intel::Ssse3),
     ) -> Self {
+        prefixed_extern! {
+            fn gcm_init_clmul(HTable: *mut HTable, h: &KeyValue);
+        }
         Self {
-            h_table: unsafe { htable_new!(gcm_init_clmul, value) },
+            h_table: HTable::new(|table| unsafe { gcm_init_clmul(table, &value) }),
         }
     }
 

--- a/src/aead/gcm/clmulavxmovbe.rs
+++ b/src/aead/gcm/clmulavxmovbe.rs
@@ -28,8 +28,11 @@ impl Key {
         value: KeyValue,
         _required_cpu_features: (intel::ClMul, intel::Avx, intel::Movbe),
     ) -> Self {
+        prefixed_extern! {
+            fn gcm_init_avx(HTable: *mut HTable, h: &KeyValue);
+        }
         Self {
-            h_table: unsafe { htable_new!(gcm_init_avx, value) },
+            h_table: HTable::new(|table| unsafe { gcm_init_avx(table, &value) }),
         }
     }
 

--- a/src/aead/gcm/neon.rs
+++ b/src/aead/gcm/neon.rs
@@ -28,15 +28,21 @@ pub struct Key {
 impl Key {
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     pub(in super::super) fn new(value: KeyValue, _cpu: cpu::aarch64::Neon) -> Self {
+        prefixed_extern! {
+            fn gcm_init_neon(HTable: *mut HTable, h: &KeyValue);
+        }
         Self {
-            h_table: unsafe { htable_new!(gcm_init_neon, value) },
+            h_table: HTable::new(|table| unsafe { gcm_init_neon(table, &value) }),
         }
     }
 
     #[cfg(all(target_arch = "arm", target_endian = "little"))]
     pub(in super::super) fn new(value: KeyValue, _cpu: cpu::arm::Neon) -> Self {
+        prefixed_extern! {
+            fn gcm_init_neon(HTable: *mut HTable, h: &KeyValue);
+        }
         Self {
-            h_table: unsafe { htable_new!(gcm_init_neon, value) },
+            h_table: HTable::new(|table| unsafe { gcm_init_neon(table, &value) }),
         }
     }
 }

--- a/src/aead/gcm/vclmulavx2.rs
+++ b/src/aead/gcm/vclmulavx2.rs
@@ -28,8 +28,11 @@ pub struct Key {
 
 impl Key {
     pub(in super::super) fn new(value: KeyValue, _cpu: (Avx2, VAesClmul)) -> Self {
+        prefixed_extern! {
+            fn gcm_init_vpclmulqdq_avx2(HTable: *mut HTable, h: &KeyValue);
+        }
         Self {
-            h_table: unsafe { htable_new!(gcm_init_vpclmulqdq_avx2, value) },
+            h_table: HTable::new(|table| unsafe { gcm_init_vpclmulqdq_avx2(table, &value) }),
         }
     }
 


### PR DESCRIPTION
See each individual commit for details.