### PR TITLE
aes_gcm: Remove `ghash!` macro.

### DIFF
--- a/src/aead/gcm/clmulavxmovbe.rs
+++ b/src/aead/gcm/clmulavxmovbe.rs
@@ -14,8 +14,8 @@
 
 #![cfg(target_arch = "x86_64")]
 
-use super::{HTable, KeyValue, UpdateBlock, UpdateBlocks, Xi, BLOCK_LEN};
-use crate::{cpu::intel, polyfill::slice::AsChunks};
+use super::{ffi, HTable, KeyValue, UpdateBlock, UpdateBlocks, Xi, BLOCK_LEN};
+use crate::{c, cpu::intel, polyfill::slice::AsChunks};
 
 #[derive(Clone)]
 pub struct Key {
@@ -49,6 +49,17 @@ impl UpdateBlock for Key {
 
 impl UpdateBlocks for Key {
     fn update_blocks(&self, xi: &mut Xi, input: AsChunks<u8, BLOCK_LEN>) {
-        unsafe { ghash!(gcm_ghash_avx, xi, self.inner(), input) }
+        prefixed_extern! {
+            fn gcm_ghash_avx(
+                xi: &mut Xi,
+                Htable: &HTable,
+                inp: *const u8,
+                len: c::NonZero_size_t,
+            );
+        }
+        let htable = self.inner();
+        ffi::with_non_dangling_ptr(input, |input, len| unsafe {
+            gcm_ghash_avx(xi, htable, input, len)
+        })
     }
 }

--- a/src/aead/gcm/vclmulavx2.rs
+++ b/src/aead/gcm/vclmulavx2.rs
@@ -14,9 +14,13 @@
 
 #![cfg(target_arch = "x86_64")]
 
-use super::{ffi::KeyValue, HTable, UpdateBlock, Xi};
+use super::{
+    ffi::{self, KeyValue},
+    HTable, UpdateBlock, Xi,
+};
 use crate::{
     aead::gcm::ffi::BLOCK_LEN,
+    c,
     cpu::intel::{Avx2, VAesClmul},
     polyfill::slice::AsChunks,
 };
@@ -43,7 +47,18 @@ impl Key {
 
 impl UpdateBlock for Key {
     fn update_block(&self, xi: &mut Xi, a: [u8; BLOCK_LEN]) {
+        prefixed_extern! {
+            fn gcm_ghash_vpclmulqdq_avx2_16(
+                xi: &mut Xi,
+                Htable: &HTable,
+                inp: *const u8,
+                len: c::NonZero_size_t,
+            );
+        }
         let input: AsChunks<u8, BLOCK_LEN> = (&a).into();
-        unsafe { ghash!(gcm_ghash_vpclmulqdq_avx2_16, xi, &self.h_table, input) }
+        let htable = self.inner();
+        ffi::with_non_dangling_ptr(input, |input, len| unsafe {
+            gcm_ghash_vpclmulqdq_avx2_16(xi, htable, input, len)
+        })
     }
 }


### PR DESCRIPTION
The macro wasn't doing much. This minimizes the scope of `unsafe` and paves the way for some future improvements.