### PR TITLE
build.rs: Check symbol prefixes in archive.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ libc = { version = "0.2.148", default-features = false }
 
 [build-dependencies]
 cc = { version = "1.2.8", default-features = false }
+object = { version = "0.36.7", default-features = false, features = ["read"] }
 
 [features]
 # These features are documented in the top-level module's documentation.

--- a/build.rs
+++ b/build.rs
@@ -215,61 +215,51 @@ const ASM_TARGETS: &[AsmTarget] = &[
         oss: LINUX_ABI,
         arch: AARCH64,
         perlasm_format: "linux64",
-        extern_prefix: "",
     },
     AsmTarget {
         oss: LINUX_ABI,
         arch: ARM,
         perlasm_format: "linux32",
-        extern_prefix: "",
     },
     AsmTarget {
         oss: LINUX_ABI,
         arch: X86,
         perlasm_format: "elf",
-        extern_prefix: "",
     },
     AsmTarget {
         oss: LINUX_ABI,
         arch: X86_64,
         perlasm_format: "elf",
-        extern_prefix: "",
     },
     AsmTarget {
         oss: &["horizon"],
         arch: ARM,
         perlasm_format: "linux32",
-        extern_prefix: "",
     },
     AsmTarget {
         oss: APPLE_ABI,
         arch: AARCH64,
         perlasm_format: "ios64",
-        extern_prefix: "_",
     },
     AsmTarget {
         oss: APPLE_ABI,
         arch: X86_64,
         perlasm_format: "macosx",
-        extern_prefix: "_",
     },
     AsmTarget {
         oss: &[WINDOWS],
         arch: X86,
         perlasm_format: WIN32N,
-        extern_prefix: "_",
     },
     AsmTarget {
         oss: &[WINDOWS],
         arch: X86_64,
         perlasm_format: NASM,
-        extern_prefix: "",
     },
     AsmTarget {
         oss: &[WINDOWS],
         arch: AARCH64,
         perlasm_format: "win64",
-        extern_prefix: "",
     },
 ];
 
@@ -282,9 +272,6 @@ struct AsmTarget {
 
     /// The PerlAsm format name.
     perlasm_format: &'static str,
-
-    /// What prefix do exrern symbols get?
-    extern_prefix: &'static str,
 }
 
 impl AsmTarget {


### PR DESCRIPTION
Check symbol prefixes on every target.