### PR TITLE
CI: Only measure coverage for tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,7 +815,7 @@ jobs:
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |
-          RING_CPU_MODEL=${{ matrix.cpu_model }} RING_COVERAGE=1 mk/cargo.sh +${{ matrix.rust_channel }} test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
+          RING_CPU_MODEL=${{ matrix.cpu_model }} RING_COVERAGE=1 mk/cargo.sh +${{ matrix.rust_channel }} test --lib --tests -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
 
       - uses: briansmith/codecov-codecov-action@v4
         with:


### PR DESCRIPTION
Don't measure coverage for doctests, bins, benchmarks, etc.

This works around a failure to build doctests in the coverage jobs which is probably caused by a compatibility-breaking change in Rust's new doctest-xcompile feature and/or its doctest bundling feature.