### PR TITLE
CI: Don't build/run doctests in test-features jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,17 +492,11 @@ jobs:
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |
-          mk/cargo.sh +${{ matrix.rust_channel }} test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
+          mk/cargo.sh +${{ matrix.rust_channel }} test --lib --tests -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
 
       - if: ${{ contains(matrix.host_os, 'windows') }}
         run: |
-          cargo +${{ matrix.rust_channel }} test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
-
-      # --all-targets doesn't run doctests: https://github.com/rust-lang/cargo/issues/6669
-      # Run doctests only on x86_64 to avoid cross-compilation hassles with `--no-run`.
-      - if: ${{ !contains(matrix.host_os, 'windows') && contains(matrix.target, 'x86_64') }}
-        run: |
-          mk/cargo.sh +${{ matrix.rust_channel }} test -vv --doc --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
+          cargo +${{ matrix.rust_channel }} test --lib --tests -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
 
       # Check that all the needed symbol renaming was done.
       # TODO: Do this check on Windows too.


### PR DESCRIPTION
The doctests are built/run in separate test-doc jobs so we don't need to run them in test-features.

This will speed up CI slightly.

This will also work around some incompatibility introduced in recent Rust 1.87 and/or Nightly releases where linking the doctests fails when cross-compiling. (Rust recently started building doctests when cross-compiling where previously it ignored them during cross- compilation.)