### PR TITLE
arm: Call `getauxval` through libc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,10 +163,10 @@ getrandom = { version = "0.2.10" }
 untrusted = { version = "0.9" }
 
 [target.'cfg(all(any(all(target_arch = "aarch64", target_endian = "little"), all(target_arch = "arm", target_endian = "little")), any(target_os = "android", target_os = "linux")))'.dependencies]
-libc = { version = "0.2.148", default-features = false }
+libc = { version = "0.2.172", default-features = false }
 
 [target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_vendor = "apple", any(target_os = "ios", target_os = "macos", target_os = "tvos", target_os = "visionos", target_os = "watchos")))'.dependencies]
-libc = { version = "0.2.155", default-features = false }
+libc = { version = "0.2.172", default-features = false }
 
 [target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_os = "windows"))'.dependencies]
 windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading"] }
@@ -175,7 +175,7 @@ windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_
 wasm-bindgen-test = { version = "0.3.37", default-features = false, features = ["std"] }
 
 [target.'cfg(any(unix, windows, target_os = "wasi"))'.dev-dependencies]
-libc = { version = "0.2.148", default-features = false }
+libc = { version = "0.2.172", default-features = false }
 
 [build-dependencies]
 cc = { version = "1.2.8", default-features = false }

--- a/src/cpu/arm/linux.rs
+++ b/src/cpu/arm/linux.rs
@@ -47,16 +47,8 @@ pub fn detect_features() -> u32 {
     #[cfg(not(target_env = "uclibc"))]
     {
         use super::CAPS_STATIC;
+        use libc::{c_ulong, getauxval, AT_HWCAP};
 
-        // The `libc` crate doesn't provide this functionality on all
-        // 32-bit Linux targets, like Android or -musl. Use this polyfill
-        // for all 32-bit ARM targets so that testing on one of them will
-        // be more meaningful to the others.
-        use libc::c_ulong;
-        extern "C" {
-            pub fn getauxval(type_: c_ulong) -> c_ulong;
-        }
-        const AT_HWCAP: c_ulong = 16;
         const HWCAP_NEON: c_ulong = 1 << 12;
 
         if CAPS_STATIC & Neon::mask() != Neon::mask() {


### PR DESCRIPTION
See https://github.com/rust-lang/stdarch/pull/1746. libc 0.2.172 added getauxval for 32-bit ARM Android.