### PR TITLE
aes: Simplify EncryptBlock dispatching.

### DIFF
--- a/src/aead/aes.rs
+++ b/src/aead/aes.rs
@@ -14,7 +14,6 @@
 
 use super::{nonce::Nonce, overlapping, quic::Sample, NONCE_LEN};
 use crate::{
-    bb,
     cpu::{self, GetFeature as _},
     polyfill::unwrap_const,
 };
@@ -182,15 +181,6 @@ pub(super) trait EncryptCtr32 {
 #[allow(dead_code)]
 fn encrypt_block_using_encrypt_iv_xor_block(key: &impl EncryptBlock, block: Block) -> Block {
     key.encrypt_iv_xor_block(Iv(block), ZERO_BLOCK)
-}
-
-fn encrypt_iv_xor_block_using_encrypt_block(
-    key: &impl EncryptBlock,
-    iv: Iv,
-    block: Block,
-) -> Block {
-    let encrypted_iv = key.encrypt_block(iv.0);
-    bb::xor_16(encrypted_iv, block)
 }
 
 #[allow(dead_code)]

--- a/src/aead/aes/vp.rs
+++ b/src/aead/aes/vp.rs
@@ -144,7 +144,8 @@ impl EncryptBlock for Key {
     }
 
     fn encrypt_iv_xor_block(&self, iv: Iv, block: Block) -> Block {
-        super::encrypt_iv_xor_block_using_encrypt_block(self, iv, block)
+        let encrypted_iv = self.encrypt_block(iv.0);
+        crate::bb::xor_16(encrypted_iv, block)
     }
 }
 


### PR DESCRIPTION
Now only the 32-bit X86 VPAES implementation is done using a Single-block AES operation. Everything else is done in terms of The CTR-32 implementation.