### PR TITLE
aes fallback: Don't inline `sub_bytes` or `shift_rows`.

### DIFF
--- a/src/aead/aes/fallback.rs
+++ b/src/aead/aes/fallback.rs
@@ -316,6 +316,7 @@ impl Batch {
 
 // AES round steps.
 impl Batch {
+    #[inline(never)]
     fn sub_bytes(&mut self) {
         // See https://eprint.iacr.org/2009/191.pdf, Appendix C.
         let x0 = self.w[7];
@@ -481,6 +482,7 @@ macro_rules! rotate_cols_right {
 }
 
 impl Batch {
+    #[inline(never)]
     fn shift_rows(&mut self) {
         self.w.iter_mut().for_each(|w| {
             let row0 = *w & ROW0_MASK;


### PR DESCRIPTION
Help the optimizer optimize a bit. When this was in C, Clang wasn't Inlining them either (on x86 and arm, at least).