### PR TITLE
arithmetic/aarch64: Use optimized squaring in `elem_exp_consttime`.

### DIFF
--- a/src/arithmetic/inout.rs
+++ b/src/arithmetic/inout.rs
@@ -164,6 +164,60 @@ impl<T> AliasingSlices3<T> for (&mut [T], &[T], &[T]) {
     }
 }
 
+pub(crate) trait AliasSrc<T> {
+    type RAA: AliasingSlices3<T>;
+    fn raa(self) -> Self::RAA;
+}
+
+impl<'a, T> AliasSrc<T> for &'a mut [T]
+where
+    &'a mut [T]: AliasingSlices3<T>,
+{
+    type RAA = Self;
+    fn raa(self) -> Self::RAA {
+        self
+    }
+}
+
+impl<'a, T> AliasSrc<T> for (&'a mut [T], &'a [T])
+where
+    (&'a mut [T], &'a [T], &'a [T]): AliasingSlices3<T>,
+{
+    type RAA = (&'a mut [T], &'a [T], &'a [T]);
+    fn raa(self) -> Self::RAA {
+        let (r, a) = self;
+        (r, a, a)
+    }
+}
+
+// Currently unused:
+//
+// pub(crate) trait AliasDst<T> {
+//     type RRA: AliasingSlices3<T>;
+//     fn rra(self) -> Self::RRA;
+// }
+//
+// impl<'a, T> AliasDst<T> for &'a mut T
+// where
+//     &'a mut T: AliasingSlices3<T>,
+// {
+//     type RRA = Self;
+//     fn rra(self) -> Self::RRA {
+//         self
+//     }
+// }
+//
+// impl<'a, T> AliasDst<T> for (&'a mut T, &'a T)
+// where
+//     (InOut<&'a mut T>, &'a T): AliasingSlices3<T>,
+// {
+//     type RRA = (InOut<&'a mut T>, &'a T);
+//     fn rra(self) -> Self::RRA {
+//         let (r, a) = self;
+//         (InOut(r), a)
+//     }
+// }
+
 pub struct InOut<T>(pub T);
 
 impl<'a, T> AliasingSlices3<T> for (InOut<&'a mut [T]>, &[T])

--- a/src/arithmetic/limbs/x86_64/mont.rs
+++ b/src/arithmetic/limbs/x86_64/mont.rs
@@ -71,7 +71,7 @@ pub(in super::super::super) fn mul_mont5_4x(
 
 #[inline]
 pub(in super::super::super) fn sqr_mont5(
-    mut in_out: AsChunksMut<Limb, 8>,
+    in_out: impl AliasingSlices2<Limb>,
     n: AsChunks<Limb, 8>,
     n0: &N0,
     maybe_adx_bmi2: Option<(Adx, Bmi2)>,
@@ -89,7 +89,6 @@ pub(in super::super::super) fn sqr_mont5(
             num: c::NonZero_size_t);
     }
 
-    let in_out = in_out.as_flattened_mut();
     let n = n.as_flattened();
     let num_limbs = NonZeroUsize::new(n.len()).ok_or_else(|| LimbSliceError::too_short(n.len()))?;
 


### PR DESCRIPTION
Fix a performance regression from when we replaced `bn_mul_mont`.

`bn_mul_mont` used to check whether its two source operand pointers were equal, calling the squaring function if so. Our expectation when it was replaced was that every caller would statically know whether it was doing squaring or non-squaring, so this check was not needed. Unfortunately, we overlooked this one case.