### PR TITLE
cpu/aarch64/windows: Use libstd instead of windows_sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,9 +165,6 @@ libc = { version = "0.2.172", default-features = false }
 [target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_vendor = "apple", any(target_os = "ios", target_os = "macos", target_os = "tvos", target_os = "visionos", target_os = "watchos")))'.dependencies]
 libc = { version = "0.2.172", default-features = false }
 
-[target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_os = "windows"))'.dependencies]
-windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading"] }
-
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.37", default-features = false, features = ["std"] }
 

--- a/src/cpu/aarch64/mod.rs
+++ b/src/cpu/aarch64/mod.rs
@@ -43,8 +43,8 @@ cfg_if::cfg_if! {
         mod linux;
         use linux as detect;
     } else if #[cfg(target_os = "windows")] {
-        mod windows;
-        use windows as detect;
+        mod std_detect;
+        use std_detect as detect;
     } else {
         mod detect {
             pub const FORCE_DYNAMIC_DETECTION: u32 = 0;

--- a/src/cpu/aarch64/std_detect.rs
+++ b/src/cpu/aarch64/std_detect.rs
@@ -13,9 +13,9 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{Aes, Neon, PMull, Sha256, CAPS_STATIC};
-use windows_sys::Win32::System::Threading::{
-    IsProcessorFeaturePresent, PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE,
-};
+
+extern crate std;
+use std::arch::is_aarch64_feature_detected;
 
 pub const FORCE_DYNAMIC_DETECTION: u32 = 0;
 
@@ -25,12 +25,13 @@ pub fn detect_features() -> u32 {
 
     let mut features = 0;
 
-    let result = unsafe { IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) };
-
-    if result != 0 {
-        // These are all covered by one call in Windows
+    if is_aarch64_feature_detected!("aes") {
         features |= Aes::mask();
+    }
+    if is_aarch64_feature_detected!("pmull") {
         features |= PMull::mask();
+    }
+    if is_aarch64_feature_detected!("sha2") {
         features |= Sha256::mask();
     }
 


### PR DESCRIPTION
Eliminate the windows-sys dependency on Aarch64. We believe there is no use for `no_std` support for this target.