### PR TITLE
Revert "Revert "Update windows-sys dependency to 0.60.""

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ libc = { version = "0.2.172", default-features = false }
 libc = { version = "0.2.172", default-features = false }
 
 [target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_os = "windows"))'.dependencies]
-windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading"] }
+windows-sys = { version = "0.60", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.37", default-features = false, features = ["std"] }


### PR DESCRIPTION
This reverts commit 03b223dd56d11ab94bb05e533be8b1077a4a8f1c, so that we depend on windows-sys 0.60 again.