### PR TITLE
bb: Re-enable C constant_time_test.

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,3 +17,4 @@
 mod bb_boolmask_tests;
 mod bb_bytes_tests;
 mod bits_tests;
+mod c_constant_time_tests;


### PR DESCRIPTION
The test was inadvertently disabled because the new module wasn't added to the mod.rs. Caught by code coverage measurement.