### PR TITLE
Fix Comments and Minor Code Consistency in ECDSA and P256 ASM

### DIFF
--- a/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl
@@ -959,7 +959,7 @@ ecp_nistz256_ord_mul_mont_adx:
 
 	################################# reduction
 	mulx	8*0+128(%r14), $t0, $t1
-	adcx	$t0, $acc3		# guranteed to be zero
+	adcx	$t0, $acc3		# guaranteed to be zero
 	adox	$t1, $acc4
 
 	mulx	8*1+128(%r14), $t0, $t1

--- a/crypto/fipsmodule/ecdsa/ecdsa_verify_tests.txt
+++ b/crypto/fipsmodule/ecdsa/ecdsa_verify_tests.txt
@@ -1209,7 +1209,7 @@ S = 520784e6290d04d9b61993ee5ebc6fa8ff527fb0777c43cdefc7586701e60edb399005a5648f
 
 # The following tests are intended to stress the final comparison in ECDSA.
 # ECDSA verification computes some curve point (x, y), picking the fully-reduced
-# representive of x mod p, and checking that x mod n is r. (n is the order of
+# representative of x mod p, and checking that x mod n is r. (n is the order of
 # the group and p defines the underlying prime field.)
 #
 # This makes the computation sensitive to values near n and p, and which of n or


### PR DESCRIPTION


**Description:**  
- Corrected a comment in the ECDSA verification test to accurately describe the modulus operation.
- Improved code consistency in the P256 x86-64 assembly by updating a comment and ensuring clarity.

