### PR TITLE
arithmetic: Simplify calculation of bit length.

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -13,7 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 pub(crate) use self::{constant::limbs_from_hex, limb_slice_error::LimbSliceError};
-use crate::{error::LenMismatchError, limb::LIMB_BITS};
+use crate::{bits::BitLength, error::LenMismatchError, limb::LIMB_BITS};
 
 #[macro_use]
 mod ffi;
@@ -37,6 +37,8 @@ pub const MIN_LIMBS: usize = 4;
 
 // The maximum number of limbs allowed for any `&[Limb]` operation.
 pub const MAX_LIMBS: usize = 8192 / LIMB_BITS;
+
+pub const _MAX_LIMBS_AS_BIT_LENGTH: BitLength = BitLength::from_bits(MAX_LIMBS * LIMB_BITS);
 
 cold_exhaustive_error! {
     enum limb_slice_error::LimbSliceError {

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -98,6 +98,11 @@ impl BitLength<usize> {
         (self.0 / 8) + round_up
     }
 
+    #[inline]
+    pub(crate) fn checked_add(self, other: Self) -> Option<Self> {
+        self.0.checked_add(other.0).map(Self)
+    }
+
     #[cfg(feature = "alloc")]
     #[inline]
     pub(crate) fn try_sub_1(self) -> Result<Self, crate::error::Unspecified> {


### PR DESCRIPTION
Replace `limb::limbs_minimal_bits` with `limb::limb_minimal_bits` so that we only ever look at the value of the highest bit. This is a no- op change, as previously the outer loop in `limbs_minimal_bits` was never executed more than once. In the sole caller, document why we only have to look at the high limb.