### PR TITLE
arithmetic: Avoid storing redundant 0 limb in `N0` for 64-bit targets.

### DIFF
--- a/src/arithmetic/n0.rs
+++ b/src/arithmetic/n0.rs
@@ -16,24 +16,23 @@ use crate::limb::Limb;
 
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct N0([Limb; 2]);
-
-impl N0 {
-    #[cfg(feature = "alloc")]
-    pub(super) const LIMBS_USED: usize = 64 / crate::limb::LIMB_BITS;
-}
+pub struct N0([Limb; N0::LIMBS_USED]);
 
 match_target_word_bits! {
     64 => {
         impl N0 {
+            pub(super) const LIMBS_USED: usize = 1;
+
             #[inline]
             pub const fn precalculated(n0: u64) -> Self {
-                Self([n0, 0])
+                Self([n0])
             }
         }
     },
     32 => {
          impl N0 {
+            pub(super) const LIMBS_USED: usize = 2;
+
             #[inline]
             pub const fn precalculated(n0: u64) -> Self {
                 Self([n0 as Limb, (n0 >> crate::limb::LIMB_BITS) as Limb])


### PR DESCRIPTION
See BoringSSL commit ae4cde94431584cf4dfacbda893582ae87bb8599.