### PR TITLE
aead internals: Slightly refactor internal `seal` APIs.

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -60,6 +60,16 @@ impl Key {
             open(self, nonce, aad, in_out)
         })
     }
+
+    #[inline(never)]
+    pub(super) fn seal(
+        &self,
+        nonce: Nonce,
+        aad: Aad<&[u8]>,
+        in_out: &mut [u8],
+    ) -> Result<Tag, InputTooLongError> {
+        seal(self, nonce, aad, in_out)
+    }
 }
 
 #[derive(Clone)]
@@ -199,8 +209,7 @@ fn derive_gcm_key_value(aes_key: &impl aes::EncryptBlock) -> gcm::KeyValue {
 
 const CHUNK_BLOCKS: usize = 3 * 1024 / 16;
 
-#[inline(never)]
-pub(super) fn seal(
+fn seal(
     Key(key): &Key,
     nonce: Nonce,
     aad: Aad<&[u8]>,

--- a/src/aead/algorithm.rs
+++ b/src/aead/algorithm.rs
@@ -181,7 +181,7 @@ fn aes_gcm_seal(
         KeyInner::AesGcm(key) => key,
         _ => unreachable!(),
     };
-    aes_gcm::seal(key, nonce, aad, in_out)
+    key.seal(nonce, aad, in_out)
 }
 
 pub(super) fn aes_gcm_open<'o>(
@@ -232,7 +232,7 @@ fn chacha20_poly1305_seal(
         KeyInner::ChaCha20Poly1305(key) => key,
         _ => unreachable!(),
     };
-    chacha20_poly1305::seal(key, nonce, aad, in_out, cpu_features)
+    key.seal(nonce, aad, in_out, cpu_features)
 }
 
 fn chacha20_poly1305_open<'o>(

--- a/src/aead/chacha20_poly1305/mod.rs
+++ b/src/aead/chacha20_poly1305/mod.rs
@@ -61,24 +61,25 @@ impl Key {
             open(self, nonce, aad, in_out, cpu_features)
         })
     }
-}
 
-pub(super) fn seal(
-    key: &Key,
-    nonce: Nonce,
-    aad: Aad<&[u8]>,
-    in_out: &mut [u8],
-    cpu: cpu::Features,
-) -> Result<Tag, InputTooLongError> {
-    #[cfg(any(
-        all(target_arch = "aarch64", target_endian = "little"),
-        target_arch = "x86_64"
-    ))]
-    if let Some(required) = cpu.get_feature() {
-        return integrated::seal(key, nonce, aad, in_out, required, cpu.get_feature());
+    #[inline(never)]
+    pub(super) fn seal(
+        &self,
+        nonce: Nonce,
+        aad: Aad<&[u8]>,
+        in_out: &mut [u8],
+        cpu: cpu::Features,
+    ) -> Result<Tag, InputTooLongError> {
+        #[cfg(any(
+            all(target_arch = "aarch64", target_endian = "little"),
+            target_arch = "x86_64"
+        ))]
+        if let Some(required) = cpu.get_feature() {
+            return integrated::seal(self, nonce, aad, in_out, required, cpu.get_feature());
+        }
+
+        seal_fallback(self, nonce, aad, in_out, cpu)
     }
-
-    seal_fallback(key, nonce, aad, in_out, cpu)
 }
 
 pub(super) fn seal_fallback(


### PR DESCRIPTION
Increase uniformity of the internal API after commit fe8d6485d33be9e0a43daaf398d5b7c3c2095841.