### PR TITLE
aead/aarch64/arm internals: Use `ffi::U128`.

### DIFF
--- a/src/aead/gcm/clmul_aarch64.rs
+++ b/src/aead/gcm/clmul_aarch64.rs
@@ -15,7 +15,7 @@
 #![cfg(all(target_arch = "aarch64", target_endian = "little"))]
 
 use super::{
-    ffi::{KeyValue, BLOCK_LEN},
+    ffi::{self, KeyValue, BLOCK_LEN},
     UpdateBlock, Xi,
 };
 use crate::cpu;
@@ -23,7 +23,7 @@ use core::mem::MaybeUninit;
 
 #[derive(Clone)]
 #[repr(transparent)] // Used in FFI
-pub struct Key([[u64; 2]; 6]);
+pub struct Key([ffi::U128; 6]);
 
 impl Key {
     pub(in super::super) fn new(value: KeyValue, _cpu: cpu::aarch64::PMull) -> Self {

--- a/src/aead/gcm/neon.rs
+++ b/src/aead/gcm/neon.rs
@@ -23,7 +23,7 @@ use core::mem::MaybeUninit;
 
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct Key([[u64; 2]; 1]);
+pub struct Key([ffi::U128; 1]);
 
 impl Key {
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]


### PR DESCRIPTION
commit 8a2f3de336b176503b6eacae1a355b230e724b54 and commit 7c0c4156f48164c8beda234215de862277afbf41 are correct, AFAICT, but this makes that more clear.