### PR TITLE
aes_gcm/x86_64: More precisely model CLMUL-AVX-MOVBE key type.

### DIFF
--- a/src/aead/aes_gcm/aeshwclmulmovbe.rs
+++ b/src/aead/aes_gcm/aeshwclmulmovbe.rs
@@ -38,16 +38,13 @@ pub(super) fn seal(
         // The upstream version has a different calling convention where it
         // accepts any `len` and returns the number of bytes processed
         // according to the above.
-        //
-        // `HTable` and `Xi` should be 128-bit aligned. TODO: Can we shrink `HTable`? The
-        // assembly says it needs just nine values in that array.
         fn aesni_gcm_encrypt(
             input: *const u8,
             output: *mut u8,
             len: c::size_t,
             key: &aes::AES_KEY,
             ivec: &mut Counter,
-            Htable: &gcm::HTable,
+            Htable: &gcm::clmulavxmovbe::Key,
             Xi: &mut gcm::Xi);
     }
 
@@ -103,16 +100,13 @@ pub(super) fn open(
         // The upstream version has a different calling convention where it
         // accepts any `len` and returns the number of bytes processed
         // according to the above.
-        //
-        // `HTable` and `Xi` should be 128-bit aligned. TODO: Can we shrink `HTable`? The
-        // assembly says it needs just nine values in that array.
         fn aesni_gcm_decrypt(
             input: *const u8,
             output: *mut u8,
             len: c::size_t,
             key: &aes::AES_KEY,
             ivec: &mut Counter,
-            Htable: &gcm::HTable,
+            Htable: &gcm::clmulavxmovbe::Key,
             Xi: &mut gcm::Xi);
     }
 

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -115,8 +115,8 @@ impl Context<'_, clmul_aarch64::Key> {
 impl Context<'_, clmulavxmovbe::Key> {
     /// Access to `inner` for the integrated AES-GCM implementations only.
     #[inline]
-    pub(super) fn inner(&mut self) -> (&HTable, &mut Xi) {
-        (self.key.inner(), &mut self.Xi)
+    pub(super) fn inner(&mut self) -> (&clmulavxmovbe::Key, &mut Xi) {
+        (self.key, &mut self.Xi)
     }
 }
 


### PR DESCRIPTION
The comments that `Xi` and `HTable` "should" be aligned is confusing. It might have mattered for performance on some old CPUs but it's no longer important, so remove them.

The comments also erroneously claimed that only 9 entries were needed, due to me misreading the assembly code when I wrote these comments. In fact, 12 entries are required.