### PR TITLE
aes_gcm/x86/x86_64: internals: More precisely model CLMUL key type.

### DIFF
--- a/src/aead/aes_gcm.rs
+++ b/src/aead/aes_gcm.rs
@@ -80,8 +80,11 @@ enum DynKey {
     #[cfg(target_arch = "x86_64")]
     AesHwClMulAvxMovbe(Combo<aes::hw::Key, gcm::clmulavxmovbe::Key>),
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    AesHwClMul(Combo<aes::hw::Key, gcm::clmul_x86_x86_64::Key>),
+    #[cfg(target_arch = "x86")]
+    AesHwClMul(Combo<aes::hw::Key, gcm::clmul_x86::Key>),
+
+    #[cfg(target_arch = "x86_64")]
+    AesHwClMul(Combo<aes::hw::Key, gcm::clmul_x86_64::Key>),
 
     #[cfg(any(
         all(target_arch = "aarch64", target_endian = "little"),
@@ -118,7 +121,7 @@ impl DynKey {
                 let gcm_key = gcm::clmulavxmovbe::Key::new(gcm_key_value, cpu);
                 Self::AesHwClMulAvxMovbe(Combo { aes_key, gcm_key })
             } else {
-                let gcm_key = gcm::clmul_x86_x86_64::Key::new(gcm_key_value, gcm);
+                let gcm_key = gcm::clmul_x86_64::Key::new(gcm_key_value, gcm);
                 Self::AesHwClMul(Combo { aes_key, gcm_key })
             };
         }
@@ -127,7 +130,7 @@ impl DynKey {
         if let (Some(aes), Some(gcm)) = (cpu.get_feature(), cpu.get_feature()) {
             let aes_key = aes::hw::Key::new(key, aes, cpu.get_feature());
             let gcm_key_value = derive_gcm_key_value(&aes_key);
-            let gcm_key = gcm::clmul_x86_x86_64::Key::new(gcm_key_value, gcm);
+            let gcm_key = gcm::clmul_x86::Key::new(gcm_key_value, gcm);
             return Self::AesHwClMul(Combo { aes_key, gcm_key });
         }
 

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -24,10 +24,9 @@ use cfg_if::cfg_if;
 pub(super) use ffi::KeyValue;
 
 cfg_if! {
-    if #[cfg(all(target_arch = "aarch64", target_endian = "little"))] {
+    if #[cfg(any(all(target_arch = "aarch64", target_endian = "little"),
+                 target_arch = "x86_64"))] {
         pub(super) use self::ffi::Xi;
-    } else if #[cfg(any(target_arch = "x86_64", target_arch = "x86"))] {
-        pub(super) use self::ffi::{HTable, Xi};
     } else {
         use self::ffi::Xi;
     }

--- a/src/aead/gcm.rs
+++ b/src/aead/gcm.rs
@@ -37,7 +37,8 @@ cfg_if! {
 mod ffi;
 
 pub(super) mod clmul_aarch64;
-pub(super) mod clmul_x86_x86_64;
+pub(super) mod clmul_x86;
+pub(super) mod clmul_x86_64;
 pub(super) mod clmulavxmovbe;
 pub(super) mod fallback;
 pub(super) mod neon;

--- a/src/aead/gcm/clmul_x86.rs
+++ b/src/aead/gcm/clmul_x86.rs
@@ -1,0 +1,63 @@
+// Copyright 2018-2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#![cfg(target_arch = "x86")]
+
+use super::{
+    ffi::{KeyValue, BLOCK_LEN},
+    HTable, UpdateBlock, UpdateBlocks, Xi,
+};
+use crate::{cpu, polyfill::slice::AsChunks};
+
+#[derive(Clone)]
+pub struct Key {
+    h_table: HTable,
+}
+
+impl Key {
+    pub(in super::super) fn new(
+        value: KeyValue,
+        _cpu: (cpu::intel::ClMul, cpu::intel::Ssse3),
+    ) -> Self {
+        prefixed_extern! {
+            fn gcm_init_clmul(HTable: *mut HTable, h: &KeyValue);
+        }
+        Self {
+            h_table: HTable::new(|htable| unsafe { gcm_init_clmul(htable, &value) }),
+        }
+    }
+}
+
+impl UpdateBlock for Key {
+    fn update_block(&self, xi: &mut Xi, a: [u8; BLOCK_LEN]) {
+        self.update_blocks(xi, (&a).into())
+    }
+}
+
+impl UpdateBlocks for Key {
+    fn update_blocks(&self, xi: &mut Xi, input: AsChunks<u8, { BLOCK_LEN }>) {
+        prefixed_extern! {
+            fn gcm_ghash_clmul(
+                xi: &mut Xi,
+                Htable: &HTable,
+                inp: *const u8,
+                len: crate::c::NonZero_size_t,
+            );
+        }
+        let htable = &self.h_table;
+        super::ffi::with_non_dangling_ptr(input, |input, len| unsafe {
+            gcm_ghash_clmul(xi, htable, input, len)
+        })
+    }
+}

--- a/src/aead/gcm/clmul_x86.rs
+++ b/src/aead/gcm/clmul_x86.rs
@@ -15,15 +15,15 @@
 #![cfg(target_arch = "x86")]
 
 use super::{
-    ffi::{KeyValue, BLOCK_LEN},
-    HTable, UpdateBlock, UpdateBlocks, Xi,
+    ffi::{self, KeyValue, BLOCK_LEN},
+    UpdateBlock, UpdateBlocks, Xi,
 };
 use crate::{cpu, polyfill::slice::AsChunks};
+use core::mem::MaybeUninit;
 
 #[derive(Clone)]
-pub struct Key {
-    h_table: HTable,
-}
+#[repr(transparent)]
+pub struct Key([ffi::U128; 3]);
 
 impl Key {
     pub(in super::super) fn new(
@@ -31,11 +31,13 @@ impl Key {
         _cpu: (cpu::intel::ClMul, cpu::intel::Ssse3),
     ) -> Self {
         prefixed_extern! {
-            fn gcm_init_clmul(HTable: *mut HTable, h: &KeyValue);
+            fn gcm_init_clmul(HTable: *mut Key, h: &KeyValue);
         }
-        Self {
-            h_table: HTable::new(|htable| unsafe { gcm_init_clmul(htable, &value) }),
+        let mut uninit = MaybeUninit::<Key>::uninit();
+        unsafe {
+            gcm_init_clmul(uninit.as_mut_ptr(), &value);
         }
+        unsafe { uninit.assume_init() }
     }
 }
 
@@ -50,14 +52,13 @@ impl UpdateBlocks for Key {
         prefixed_extern! {
             fn gcm_ghash_clmul(
                 xi: &mut Xi,
-                Htable: &HTable,
+                Htable: &Key,
                 inp: *const u8,
                 len: crate::c::NonZero_size_t,
             );
         }
-        let htable = &self.h_table;
-        super::ffi::with_non_dangling_ptr(input, |input, len| unsafe {
-            gcm_ghash_clmul(xi, htable, input, len)
+        ffi::with_non_dangling_ptr(input, |input, len| unsafe {
+            gcm_ghash_clmul(xi, self, input, len)
         })
     }
 }

--- a/src/aead/gcm/clmul_x86_64.rs
+++ b/src/aead/gcm/clmul_x86_64.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#![cfg(target_arch = "x86_64")]
 
 use super::{
     ffi::{KeyValue, BLOCK_LEN},
@@ -26,20 +26,6 @@ pub struct Key {
 }
 
 impl Key {
-    #[cfg(target_arch = "x86")]
-    pub(in super::super) fn new(
-        value: KeyValue,
-        _cpu: (cpu::intel::ClMul, cpu::intel::Ssse3),
-    ) -> Self {
-        prefixed_extern! {
-            fn gcm_init_clmul(HTable: *mut HTable, h: &KeyValue);
-        }
-        Self {
-            h_table: HTable::new(|htable| unsafe { gcm_init_clmul(htable, &value) }),
-        }
-    }
-
-    #[cfg(target_arch = "x86_64")]
     #[inline(never)]
     pub(in super::super) fn new(
         value: KeyValue,

--- a/src/aead/gcm/ffi.rs
+++ b/src/aead/gcm/ffi.rs
@@ -34,33 +34,6 @@ impl KeyValue {
     }
 }
 
-/// SAFETY:
-///   * `f` must read `len` bytes from `inp`; it may assume
-///     that `len` is a (non-zero) multiple of `BLOCK_LEN`.
-///   * `f` may inspect CPU features.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl HTable {
-    pub(super) fn new(init: impl FnOnce(&mut HTable)) -> Self {
-        let mut r = Self {
-            Htable: [U128 { hi: 0, lo: 0 }; HTABLE_LEN],
-        };
-        init(&mut r);
-        r
-    }
-
-    #[cfg(any(
-        all(target_arch = "aarch64", target_endian = "little"),
-        all(target_arch = "arm", target_endian = "little")
-    ))]
-    pub(super) unsafe fn gmult(
-        &self,
-        f: unsafe extern "C" fn(xi: &mut Xi, h_table: &HTable),
-        xi: &mut Xi,
-    ) {
-        unsafe { f(xi, self) }
-    }
-}
-
 pub(super) fn with_non_dangling_ptr(
     input: AsChunks<u8, BLOCK_LEN>,
     f: impl FnOnce(*const u8, crate::c::NonZero_size_t),
@@ -76,23 +49,12 @@ pub(super) fn with_non_dangling_ptr(
     f(input.as_ptr(), input_len);
 }
 
-// The alignment is required by some assembly code, such as `ghash-ssse3-*`.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[derive(Clone)]
-#[repr(C, align(16))]
-pub(in super::super) struct HTable {
-    Htable: [U128; HTABLE_LEN],
-}
-
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub(super) struct U128 {
     pub(super) hi: u64,
     pub(super) lo: u64,
 }
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-const HTABLE_LEN: usize = 16;
 
 #[repr(transparent)]
 pub(in super::super) struct Xi(pub(super) Block);


### PR DESCRIPTION
```
git diff HEAD^1:src/aead/gcm/clmul_x86_x86_64.rs src/aead/gcm/clmul_x86.rs
git diff HEAD^1:src/aead/gcm/clmul_x86_x86_64.rs src/aead/gcm/clmul_x86_64.rs
```
