### PR TITLE
aes internals: Use `debug_assert_eq!()` for always-true condition.

### DIFF
--- a/src/aead/aes/ffi.rs
+++ b/src/aead/aes/ffi.rs
@@ -60,7 +60,7 @@ impl AES_KEY {
         let mut uninit = MaybeUninit::<AES_KEY>::uninit();
         // Unusually, in this case zero means success and non-zero means failure.
         let r = unsafe { f(bytes.as_ptr(), key_bits, uninit.as_mut_ptr()) };
-        assert_eq!(r, 0);
+        debug_assert_eq!(r, 0);
         unsafe { uninit.assume_init() }
     }
 }


### PR DESCRIPTION
With `assert_eq!()`, the compiler will not use NRVO, so the key will first be constructed on the stack and then copied. This assertion isn't really helpful as we've already ensured that the failure case of all these C initialization functions will never be triggered by the structure of `KeyValue`, so switching to `debug_assert_eq!` is safe.