### PR TITLE
cpu: Use `NonZero<T>`'s `BitOr<T>` implementation.

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -65,6 +65,12 @@ macro_rules! impl_get_feature {
             // Keep this at the end as it is never checked except during init.
             Initialized,
         }
+
+        impl Shift {
+            const INITIALIZED_MASK: core::num::NonZeroU32 =
+                $crate::polyfill::unwrap_const(
+                    core::num::NonZeroU32::new(1 << (Self::Initialized as u32)));
+        }
     }
 }
 

--- a/src/cpu/aarch64/mod.rs
+++ b/src/cpu/aarch64/mod.rs
@@ -92,8 +92,7 @@ pub(super) mod featureflags {
             });
             let detected = detected & !filtered;
             let merged = CAPS_STATIC | detected;
-            let merged = merged | (1 << (Shift::Initialized as u32));
-            NonZeroU32::new(merged).unwrap() // Can't fail because we just set a bit.
+            Shift::INITIALIZED_MASK | merged
         }
 
         // SAFETY: This is the only caller. Any concurrent reading doesn't

--- a/src/cpu/arm/mod.rs
+++ b/src/cpu/arm/mod.rs
@@ -83,8 +83,7 @@ pub(super) mod featureflags {
                 p.store(1, Ordering::Relaxed);
             }
 
-            let merged = merged | (1 << (Shift::Initialized as u32));
-            NonZeroU32::new(merged).unwrap() // Can't fail because we just set a bit.
+            Shift::INITIALIZED_MASK | merged
         }
 
         // SAFETY: This is the only caller. Any concurrent reading doesn't

--- a/src/cpu/x86.rs
+++ b/src/cpu/x86.rs
@@ -49,9 +49,7 @@ pub(super) mod featureflags {
             let cpuid_results = unsafe { cpuid_all() };
             let detected = cpuid_to_caps_and_set_c_flags(cpuid_results);
             let merged = CAPS_STATIC | detected;
-
-            let merged = merged | (1 << (Shift::Initialized as u32));
-            NonZeroU32::new(merged).unwrap() // Can't fail because we just set a bit.
+            Shift::INITIALIZED_MASK | merged
         });
 
         // SAFETY: We initialized the CPU features as required.

--- a/src/cpu/x86_64.rs
+++ b/src/cpu/x86_64.rs
@@ -49,9 +49,7 @@ pub(super) mod featureflags {
             let cpuid_results = unsafe { cpuid_all() };
             let detected = cpuid_to_caps_and_set_c_flags(cpuid_results);
             let merged = CAPS_STATIC | detected;
-
-            let merged = merged | (1 << (Shift::Initialized as u32));
-            NonZeroU32::new(merged).unwrap() // Can't fail because we just set a bit.
+            Shift::INITIALIZED_MASK | merged
         });
 
         // SAFETY: We initialized the CPU features as required.


### PR DESCRIPTION
Clarify the non-zeroedness of the value.