### PR TITLE
polyfill: Refactor StartPtr/StartMutPtr.

### DIFF
--- a/src/aead/aes/vp.rs
+++ b/src/aead/aes/vp.rs
@@ -25,7 +25,7 @@ use crate::polyfill::prelude::*;
 use super::{ffi, Block, Counter, EncryptBlock, EncryptCtr32, Iv, KeyBytes, Overlapping};
 use crate::cpu;
 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-use crate::polyfill::ptr::StartPtrMut;
+use crate::polyfill::StartMutPtr;
 #[cfg(any(
     all(target_arch = "arm", target_endian = "little"),
     target_arch = "x86",
@@ -71,7 +71,7 @@ impl Key {
         key: *mut R,
         _cpu: cpu::aarch64::Neon,
     ) where
-        *mut R: StartPtrMut<Elem = ffi::RdKey>,
+        *mut R: StartMutPtr<Elem = ffi::RdKey>,
     {
         prefixed_extern! {
             fn vpaes_set_encrypt_key(user_key: *const u8, bits: ffi::KeyBitLength,
@@ -81,7 +81,7 @@ impl Key {
             vpaes_set_encrypt_key(
                 user_key.as_ref().as_ptr(),
                 R::USER_KEY_BITS,
-                key.start_mut_ptr_(),
+                StartMutPtr::start_mut_ptr(key),
             )
         }
     }

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -86,6 +86,8 @@ pub(crate) mod slice;
 
 mod smaller_chunks;
 
+mod start_ptr;
+
 #[cfg(test)]
 mod test;
 
@@ -97,7 +99,10 @@ pub use self::{
 };
 
 #[allow(unused_imports)]
-pub use self::smaller_chunks::SmallerChunks;
+pub use self::{
+    smaller_chunks::SmallerChunks,
+    start_ptr::{StartMutPtr, StartPtr},
+};
 
 #[cfg(feature = "alloc")]
 pub use leading_zeros_skipped::LeadingZerosStripped;

--- a/src/polyfill/ptr.rs
+++ b/src/polyfill/ptr.rs
@@ -13,14 +13,14 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #[allow(dead_code)]
-pub(crate) trait PointerPolyfills<T> {
+pub(crate) trait PointerPolyfills {
     type ArrayPointer<const N: usize>;
 
     // TODO(MSRV feature(ptr_cast_array)): Drop this.
     fn cast_array_<const N: usize>(self) -> Self::ArrayPointer<N>;
 }
 
-impl<T> PointerPolyfills<T> for *const T {
+impl<T> PointerPolyfills for *const T {
     type ArrayPointer<const N: usize> = *const [T; N];
 
     #[inline(always)]
@@ -29,7 +29,7 @@ impl<T> PointerPolyfills<T> for *const T {
     }
 }
 
-impl<T> PointerPolyfills<T> for *mut T {
+impl<T> PointerPolyfills for *mut T {
     type ArrayPointer<const N: usize> = *mut [T; N];
 
     #[inline(always)]

--- a/src/polyfill/ptr.rs
+++ b/src/polyfill/ptr.rs
@@ -38,40 +38,6 @@ impl<T> PointerPolyfills<T> for *mut T {
     }
 }
 
-// TODO(MSRV feature(array_ptr_get)): Considering dropping this, depending on
-// how https://github.com/rust-lang/rust/issues/119834#issuecomment-3137563829
-// is resolved.
-#[allow(dead_code)]
-pub(crate) trait StartPtr {
-    type Elem;
-    fn start_ptr_(self) -> *const Self::Elem;
-}
-
-impl<T, const N: usize> StartPtr for *const [T; N] {
-    type Elem = T;
-    #[inline(always)]
-    fn start_ptr_(self) -> *const Self::Elem {
-        self.cast::<Self::Elem>()
-    }
-}
-
-// TODO(MSRV feature(array_ptr_get)): Considering dropping this, depending on
-// how https://github.com/rust-lang/rust/issues/119834#issuecomment-3137563829
-// is resolved.
-#[allow(dead_code)]
-pub(crate) trait StartPtrMut {
-    type Elem;
-    fn start_mut_ptr_(self) -> *mut Self::Elem;
-}
-
-impl<T, const N: usize> StartPtrMut for *mut [T; N] {
-    type Elem = T;
-    #[inline(always)]
-    fn start_mut_ptr_(self) -> *mut Self::Elem {
-        self.cast::<Self::Elem>()
-    }
-}
-
 // TODO(MSRV 1.76): Replace with `core::ptr::from_mut`.
 #[allow(dead_code)]
 #[inline(always)]

--- a/src/polyfill/slice.rs
+++ b/src/polyfill/slice.rs
@@ -22,7 +22,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::polyfill::ptr::{StartPtr, StartPtrMut};
+use crate::polyfill::{StartMutPtr, StartPtr};
 
 #[allow(dead_code)]
 pub(crate) trait SlicePolyfills<T> {
@@ -101,7 +101,7 @@ impl<T, const N: usize> SliceOfArraysPolyfills<T> for [[T; N]] {
     fn as_flattened(&self) -> &[T] {
         let total_len = self.len() * N;
         let p: *const [T; N] = self.as_ptr();
-        let p: *const T = p.start_ptr_();
+        let p: *const T = StartPtr::start_ptr(p);
         unsafe { core::slice::from_raw_parts(p, total_len) }
     }
 
@@ -109,7 +109,7 @@ impl<T, const N: usize> SliceOfArraysPolyfills<T> for [[T; N]] {
     fn as_flattened_mut(&mut self) -> &mut [T] {
         let total_len = self.len() * N;
         let p: *mut [T; N] = self.as_mut_ptr();
-        let p: *mut T = p.start_mut_ptr_();
+        let p: *mut T = StartMutPtr::start_mut_ptr(p);
         unsafe { core::slice::from_raw_parts_mut(p, total_len) }
     }
 }

--- a/src/polyfill/start_ptr.rs
+++ b/src/polyfill/start_ptr.rs
@@ -1,0 +1,47 @@
+// Copyright 2024 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// TODO(MSRV feature(array_ptr_get)): Considering dropping this, depending on
+// how https://github.com/rust-lang/rust/issues/119834#issuecomment-3137563829
+// is resolved.
+#[allow(dead_code)]
+pub trait StartPtr {
+    type Elem;
+    fn start_ptr(self) -> *const Self::Elem;
+}
+
+impl<T, const N: usize> StartPtr for *const [T; N] {
+    type Elem = T;
+    #[inline(always)]
+    fn start_ptr(self) -> *const Self::Elem {
+        self.cast::<Self::Elem>()
+    }
+}
+
+// TODO(MSRV feature(array_ptr_get)): Considering dropping this, depending on
+// how https://github.com/rust-lang/rust/issues/119834#issuecomment-3137563829
+// is resolved.
+#[allow(dead_code)]
+pub trait StartMutPtr {
+    type Elem;
+    fn start_mut_ptr(self) -> *mut Self::Elem;
+}
+
+impl<T, const N: usize> StartMutPtr for *mut [T; N] {
+    type Elem = T;
+    #[inline(always)]
+    fn start_mut_ptr(self) -> *mut Self::Elem {
+        self.cast::<Self::Elem>()
+    }
+}


### PR DESCRIPTION
Use a new pattern that avoids any possibile method name collisions. Rename the functions to remove the underscore. Move them out of the polyfill prelude.