### PR TITLE
Add qnx support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -207,7 +207,7 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
 const ASM_TARGETS: &[AsmTarget] = &[
     AsmTarget {
         oss: &[
-            ANDROID, FREEBSD, FUCHSIA, ILLUMOS, LINUX, NETBSD, OPENBSD, REDOX,
+            ANDROID, FREEBSD, FUCHSIA, ILLUMOS, LINUX, NETBSD, NTO, OPENBSD, REDOX,
         ],
         arch: AARCH64,
         perlasm_format: "linux64",
@@ -224,8 +224,8 @@ const ASM_TARGETS: &[AsmTarget] = &[
     },
     AsmTarget {
         oss: &[
-            ANDROID, DRAGONFLY, FREEBSD, FUCHSIA, HAIKU, HURD, ILLUMOS, LINUX, NETBSD, OPENBSD,
-            REDOX, SOLARIS,
+            ANDROID, DRAGONFLY, FREEBSD, FUCHSIA, HAIKU, HURD, ILLUMOS, LINUX, NETBSD, NTO,
+            OPENBSD, REDOX, SOLARIS,
         ],
         arch: X86_64,
         perlasm_format: "elf",
@@ -284,6 +284,7 @@ const HURD: &str = "hurd";
 const ILLUMOS: &str = "illumos";
 const LINUX: &str = "linux";
 const NETBSD: &str = "netbsd";
+const NTO: &str = "nto";
 const OPENBSD: &str = "openbsd";
 const REDOX: &str = "redox";
 const SOLARIS: &str = "solaris";

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -143,6 +143,7 @@ impl SystemRandom {
     target_os = "solaris",
     target_os = "vita",
     target_os = "windows",
+    target_os = "nto",
     all(
         target_vendor = "apple",
         any(


### PR DESCRIPTION
This PR adds support for the QNX target, As mentioned in #2429 since there is no CI support the test was run on both x86-64 and aarch64 qemu and the reports are attached.
[test_output-aarch64.txt](https://github.com/user-attachments/files/21707438/test_output-aarch64.txt)
[test_output-x86-64.txt](https://github.com/user-attachments/files/21707439/test_output-x86-64.txt)
