### PR TITLE
Windows arm64: use cc-rs' `prefer_clang_cl_over_msvc`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,9 +143,6 @@ jobs:
 
       - run: rustup toolchain install --no-self-update --profile=minimal 1.66.0
 
-      - run: echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
-        shell: bash
-
       - run: sh mk/package.sh
         shell: bash
 
@@ -482,11 +479,6 @@ jobs:
 
       - if: ${{ contains(matrix.host_os, 'windows') && contains(matrix.target, '86') }}
         run: ./mk/install-build-tools.ps1
-
-      - if: ${{ matrix.target == 'aarch64-pc-windows-msvc' && !contains(matrix.host_os, 'arm') }}
-        run: |
-          echo "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
-        shell: bash
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,19 +25,6 @@ supported.
 
 For Windows ARM64 targets (aarch64-pc-windows-msvc), the Visual Studio Build
 Tools “VS 2022 C++ ARM64 build tools” and "clang" components must be installed.
-Add Microsoft's provided version of `clang` to `%PATH%`, which will allow the
-build to work in GitHub Actions without installing anything:
-```
-$env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin"
-```
-If you (locally) have “Build Tools for Visual Studio 2022” instead, use:
-```
-$env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin"
-```
-Alternatively, if the host machine is already a Windows ARM64 then use:
-```
-$env:Path += ";C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\ARM64\bin"
-```
 
 Packaged Builds
 ---------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,10 +43,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -153,6 +154,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ wasm-bindgen-test = { version = "0.3.37", default-features = false, features = [
 libc = { version = "0.2.172", default-features = false }
 
 [build-dependencies]
-cc = { version = "1.2.8", default-features = false }
+cc = { version = "1.2.36", default-features = false }
 
 [features]
 # These features are documented in the top-level module's documentation.

--- a/build.rs
+++ b/build.rs
@@ -188,7 +188,6 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
             "/Zc:forScope",
             "/Zc:inline",
             // Warnings.
-            "/Wall",
             "/wd4127", // C4127: conditional expression is constant
             "/wd4464", // C4464: relative include path contains '..'
             "/wd4514", // C4514: <name>: unreferenced inline function has be
@@ -591,13 +590,11 @@ fn obj_path(out_dir: &Path, src: &Path) -> PathBuf {
 
 fn configure_cc(c: &mut cc::Build, target: &Target, c_root_dir: &Path, include_dir: &Path) {
     let compiler = c.get_compiler();
-    // FIXME: On Windows AArch64 we currently must use Clang to compile C code
-    let compiler = if target.os == WINDOWS && target.arch == AARCH64 && !compiler.is_like_clang() {
-        let _ = c.compiler("clang");
-        c.get_compiler()
-    } else {
-        compiler
-    };
+    // On Windows AArch64 we currently must use Clang to compile C code.
+    // clang-cl.exe has support for MSVC-style command-line arguments.
+    if target.os == WINDOWS && target.arch == AARCH64 && !compiler.is_like_clang() {
+        c.prefer_clang_cl_over_msvc(true);
+    }
 
     let _ = c.include(c_root_dir.join("include"));
     let _ = c.include(include_dir);

--- a/mk/package.sh
+++ b/mk/package.sh
@@ -11,7 +11,7 @@ fi
 
 msrv=1.66.0
 cargo clean --target-dir=target/pregenerate_asm
-RING_PREGENERATE_ASM=1 CC_AARCH64_PC_WINDOWS_MSVC=clang \
+RING_PREGENERATE_ASM=1 \
   cargo +${msrv} build -p ring --target-dir=target/pregenerate_asm
 if [[ -n "$(git status --porcelain -- ':(exclude)pregenerated/')" ]]; then
   echo Repository is dirty.


### PR DESCRIPTION
This is a new attempt to address https://github.com/briansmith/ring/issues/2215, and might supersede https://github.com/briansmith/ring/pull/2216 - I'll leave that up to you.

`cc-rs` version 1.2.35 [introduced](https://github.com/rust-lang/cc-rs/blob/main/CHANGELOG.md#1235---2025-09-01) support for `prefer_clang_cl_over_msvc`, which automatically finds `clang-cl` in the Visual Studio installation directory and uses it instead of `cl.exe`. Since `clang-cl` supports MSVC-style flags, this should address the reported issue.

Confirming this is working as expected on Windows arm64. In [this CI run](https://github.com/dennisameling/ring/actions/runs/17518558137/job/49759289893#step:7:114) you can see that `clang-cl.exe` is invoked as expected.