### PR TITLE
Allowing to build for riscv32imac-unknown-none-elf

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -284,6 +284,7 @@ const HURD: &str = "hurd";
 const ILLUMOS: &str = "illumos";
 const LINUX: &str = "linux";
 const NETBSD: &str = "netbsd";
+const NONE: &str = "none";
 const NTO: &str = "nto";
 const OPENBSD: &str = "openbsd";
 const REDOX: &str = "redox";
@@ -603,6 +604,12 @@ fn configure_cc(c: &mut cc::Build, target: &Target, c_root_dir: &Path, include_d
     let _ = c.include(include_dir);
     for f in cpp_flags(&compiler) {
         let _ = c.flag(f);
+    }
+
+    if target.os == NONE {
+        let _ = c.flag("-ffreestanding");
+        let _ = c.flag("-nostdlib");
+        let _ = c.define("RING_CORE_NOSTDLIBINC", "1");
     }
 
     if APPLE_ABI.contains(&target.os.as_str()) {

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -49,6 +49,9 @@
 // Versions of GCC before 10.0 didn't define `__ILP32__` for all 32-bit targets.
 #elif defined(__MIPSEL__) || defined(__MIPSEB__) || defined(__PPC__) || defined(__powerpc__) || defined(__csky__) || defined(__XTENSA__)
 #define OPENSSL_32_BIT
+#elif defined(__riscv) && __riscv_xlen == 32
+#define OPENSSL_32_BIT
+#define OPENSSL_RISCV32
 #else
 #error "Unknown target CPU"
 #endif


### PR DESCRIPTION
I used riscv64-unknown-elf-gcc 10.2.0 for building. With these changes ring builds, but haven't been able to verify if it works, yet.

Please feel free to leave some feedback. Some changes are probably needed in the build.rs, but I'm not sure what they are.

The change in target.h is from #1627