### PR TITLE
arithmetic: Add implicit conversion of `LenMismatchError` to `LimbSliceError`.

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -45,3 +45,9 @@ cold_exhaustive_error! {
         too_long => TooLong(usize),
     }
 }
+
+impl From<LenMismatchError> for LimbSliceError {
+    fn from(err: LenMismatchError) -> Self {
+        LimbSliceError::len_mismatch(err)
+    }
+}

--- a/src/arithmetic/ffi.rs
+++ b/src/arithmetic/ffi.rs
@@ -99,11 +99,10 @@ pub(super) unsafe fn bn_mul_mont_ffi<Cpu, const LEN_MIN: usize, const LEN_MOD: u
     if len.get() > MAX_LIMBS {
         return Err(LimbSliceError::too_long(n.len()));
     }
-    in_out
-        .with_non_dangling_non_null_pointers_rab(len, |r, a, b| {
-            let n = n.as_ptr();
-            let _: Cpu = cpu;
-            unsafe { f(r, a, b, n, n0, len) };
-        })
-        .map_err(LimbSliceError::len_mismatch)
+    let r = in_out.with_non_dangling_non_null_pointers_rab(len, |r, a, b| {
+        let n = n.as_ptr();
+        let _: Cpu = cpu;
+        unsafe { f(r, a, b, n, n0, len) };
+    })?;
+    Ok(r)
 }

--- a/src/arithmetic/limbs/aarch64/mont.rs
+++ b/src/arithmetic/limbs/aarch64/mont.rs
@@ -88,10 +88,9 @@ pub(in super::super::super) fn sqr_mont5(
         return Err(LimbSliceError::too_long(num_limbs.get()));
     }
 
-    in_out
-        .with_non_dangling_non_null_pointers_ra(num_limbs, |r, a| {
-            let n = n.as_ptr(); // Non-dangling because num_limbs > 0.
-            unsafe { bn_sqr8x_mont(r, a, a, n, n0, num_limbs) };
-        })
-        .map_err(LimbSliceError::len_mismatch)
+    let r = in_out.with_non_dangling_non_null_pointers_ra(num_limbs, |r, a| {
+        let n = n.as_ptr(); // Non-dangling because num_limbs > 0.
+        unsafe { bn_sqr8x_mont(r, a, a, n, n0, num_limbs) };
+    })?;
+    Ok(r)
 }

--- a/src/arithmetic/limbs/x86_64/mont.rs
+++ b/src/arithmetic/limbs/x86_64/mont.rs
@@ -109,12 +109,11 @@ pub(in super::super::super) fn sqr_mont5(
         None => Limb::from(false),
     };
 
-    in_out
-        .with_non_dangling_non_null_pointers_ra(num_limbs, |r, a| {
-            let n = n.as_ptr(); // Non-dangling because num_limbs > 0.
-            unsafe { bn_sqr8x_mont(r, a, mulx_adx_capable, n, n0, num_limbs) };
-        })
-        .map_err(LimbSliceError::len_mismatch)
+    let r = in_out.with_non_dangling_non_null_pointers_ra(num_limbs, |r, a| {
+        let n = n.as_ptr(); // Non-dangling because num_limbs > 0.
+        unsafe { bn_sqr8x_mont(r, a, mulx_adx_capable, n, n0, num_limbs) };
+    })?;
+    Ok(r)
 }
 
 #[inline(always)]
@@ -176,7 +175,7 @@ pub(in super::super::super) fn mul_mont_gather5_amm(
     let num_limbs = check_common_with_n(r, table, n)?;
     let a = a.as_flattened();
     if a.len() != num_limbs.get() {
-        return Err(LimbSliceError::len_mismatch(LenMismatchError::new(a.len())));
+        Err(LenMismatchError::new(a.len()))?;
     }
     let r = r.as_flattened_mut();
     let r = r.as_mut_ptr();

--- a/src/arithmetic/limbs512/storage.rs
+++ b/src/arithmetic/limbs512/storage.rs
@@ -82,9 +82,7 @@ pub(crate) fn check_common(
         return Err(LimbSliceError::too_long(a.len()));
     }
     if num_limbs.get() * 32 != table.len() {
-        return Err(LimbSliceError::len_mismatch(LenMismatchError::new(
-            table.len(),
-        )));
+        Err(LenMismatchError::new(table.len()))?;
     };
     Ok(num_limbs)
 }
@@ -102,7 +100,7 @@ pub(crate) fn check_common_with_n(
     let num_limbs = check_common(a, table)?;
     let n = n.as_flattened();
     if n.len() != num_limbs.get() {
-        return Err(LimbSliceError::len_mismatch(LenMismatchError::new(n.len())));
+        Err(LenMismatchError::new(n.len()))?;
     }
     Ok(num_limbs)
 }


### PR DESCRIPTION
Also, when we already return a `LimbSliceError`, prefer returning a (converted) `LenMismatchError` to `unreachable!()` even for unreachable cases.