### PR TITLE
bigint: Reduce unnecessary zero-initialization during heap allocation.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -159,7 +159,8 @@ impl<M> Elem<M, Unencoded> {
         m: &Modulus<M>,
     ) -> Result<Self, error::Unspecified> {
         let mut out = BoxedLimbs::zero(m.limbs().len());
-        limb::parse_big_endian_and_pad_consttime(input, out.as_mut())?;
+        limb::parse_big_endian_and_pad_consttime(input, out.as_mut())
+            .map_err(error::erase::<LenMismatchError>)?;
         limb::verify_limbs_less_than_limbs_leak_bit(out.as_ref(), m.limbs())?;
         Ok(Self::assume_in_range_and_encoded_less_safe(out))
     }
@@ -983,7 +984,7 @@ mod tests {
         let bytes = test_case.consume_bytes(name);
         let mut limbs = BoxedLimbs::zero(num_limbs);
         limb::parse_big_endian_and_pad_consttime(untrusted::Input::from(&bytes), limbs.as_mut())
-            .unwrap();
+            .unwrap_or_else(unwrap_impossible_len_mismatch_error);
         Elem::assume_in_range_and_encoded_less_safe(limbs)
     }
 

--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -158,7 +158,9 @@ impl<M> Elem<M, Unencoded> {
         input: untrusted::Input,
         m: &Modulus<M>,
     ) -> Result<Self, error::Unspecified> {
-        let out = BoxedLimbs::from_be_bytes_padded_less_than(input, m)?;
+        let mut out = BoxedLimbs::zero(m.limbs().len());
+        limb::parse_big_endian_and_pad_consttime(input, out.as_mut())?;
+        limb::verify_limbs_less_than_limbs_leak_bit(out.as_ref(), m.limbs())?;
         Ok(Self::assume_in_range_and_encoded_less_safe(out))
     }
 

--- a/src/arithmetic/bigint/boxed_limbs.rs
+++ b/src/arithmetic/bigint/boxed_limbs.rs
@@ -12,11 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::Modulus;
-use crate::{
-    error,
-    limb::{self, Limb},
-};
+use crate::limb::Limb;
 use alloc::{boxed::Box, vec};
 use core::marker::PhantomData;
 
@@ -40,16 +36,6 @@ impl<M> Clone for BoxedLimbs<M> {
 }
 
 impl<M> BoxedLimbs<M> {
-    pub(super) fn from_be_bytes_padded_less_than(
-        input: untrusted::Input,
-        m: &Modulus<M>,
-    ) -> Result<Self, error::Unspecified> {
-        let mut r = Self::zero(m.limbs().len());
-        limb::parse_big_endian_and_pad_consttime(input, r.as_mut())?;
-        limb::verify_limbs_less_than_limbs_leak_bit(r.as_ref(), m.limbs())?;
-        Ok(r)
-    }
-
     pub(super) fn zero(len: usize) -> Self {
         Self {
             limbs: vec![0; len].into_boxed_slice(),

--- a/src/arithmetic/bigint/modulus.rs
+++ b/src/arithmetic/bigint/modulus.rs
@@ -13,8 +13,8 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{
-    super::montgomery::Unencoded, unwrap_impossible_len_mismatch_error, BoxedLimbs, Elem,
-    OwnedModulusValue, PublicModulus, Storage, Uninit, N0,
+    super::montgomery::Unencoded, unwrap_impossible_len_mismatch_error, Elem, OwnedModulusValue,
+    PublicModulus, Uninit, N0,
 };
 use crate::{
     bits::BitLength,
@@ -175,11 +175,8 @@ impl<M> Modulus<'_, M> {
         // Now out == 2**r (mod m) == 1*R.
     }
 
-    // TODO: XXX Avoid duplication with `Modulus`.
-    pub fn alloc_zero(&self) -> Storage<M> {
-        Storage {
-            limbs: BoxedLimbs::zero_less_safe(self.limbs.len()),
-        }
+    pub fn alloc_uninit(&self) -> Uninit<M> {
+        Uninit::new_less_safe(self.limbs.len())
     }
 
     #[inline]

--- a/src/arithmetic/bigint/modulusvalue.rs
+++ b/src/arithmetic/bigint/modulusvalue.rs
@@ -14,7 +14,7 @@
 
 use super::{
     super::{MAX_LIMBS, MIN_LIMBS},
-    BoxedLimbs, Modulus, PublicModulus,
+    BoxedLimbs, Modulus, PublicModulus, Uninit,
 };
 use crate::{
     bb,
@@ -82,8 +82,8 @@ impl<M> OwnedModulusValue<M> {
         // Having at least 2 limbs where the high-order limb is nonzero implies
         // M >= 3 as required.
 
-        let mut limbs = BoxedLimbs::zero(num_limbs);
-        limb::parse_big_endian_and_pad_consttime(input, limbs.as_mut())
+        let limbs = Uninit::new_less_safe(num_limbs)
+            .write_from_be_byes_padded(input)
             .map_err(|LenMismatchError { .. }| error::KeyRejected::unexpected_error())?;
         limb::limbs_reject_even_leak_bit(limbs.as_ref())
             .map_err(|_: error::Unspecified| error::KeyRejected::invalid_component())?;

--- a/src/arithmetic/bigint/modulusvalue.rs
+++ b/src/arithmetic/bigint/modulusvalue.rs
@@ -19,7 +19,7 @@ use super::{
 use crate::{
     bb,
     bits::{BitLength, FromByteLen as _},
-    error::{self, InputTooLongError},
+    error::{self, InputTooLongError, LenMismatchError},
     limb::{self, Limb, LIMB_BITS, LIMB_BYTES},
     polyfill::usize_from_u32,
 };
@@ -84,7 +84,7 @@ impl<M> OwnedModulusValue<M> {
 
         let mut limbs = BoxedLimbs::zero(num_limbs);
         limb::parse_big_endian_and_pad_consttime(input, limbs.as_mut())
-            .map_err(|error::Unspecified| error::KeyRejected::unexpected_error())?;
+            .map_err(|LenMismatchError { .. }| error::KeyRejected::unexpected_error())?;
         limb::limbs_reject_even_leak_bit(limbs.as_ref())
             .map_err(|_: error::Unspecified| error::KeyRejected::invalid_component())?;
 

--- a/src/arithmetic/bigint/private_exponent.rs
+++ b/src/arithmetic/bigint/private_exponent.rs
@@ -54,7 +54,7 @@ impl PrivateExponent {
         p: &Modulus<M>,
     ) -> Result<Self, error::Unspecified> {
         use super::boxed_limbs::BoxedLimbs;
-        use crate::limb::LIMB_BYTES;
+        use crate::{error::LenMismatchError, limb::LIMB_BYTES};
 
         // Do exactly what `from_be_bytes_padded` does for any inputs it accepts.
         if let r @ Ok(_) = Self::from_be_bytes_padded(input, p) {
@@ -64,7 +64,7 @@ impl PrivateExponent {
         let num_limbs = (input.len() + LIMB_BYTES - 1) / LIMB_BYTES;
         let mut limbs = BoxedLimbs::<M>::zero(num_limbs);
         limb::parse_big_endian_and_pad_consttime(input, limbs.as_mut())
-            .map_err(|error::Unspecified| error::KeyRejected::unexpected_error())?;
+            .map_err(error::erase::<LenMismatchError>)?;
         limbs.as_mut().reverse();
         Ok(Self {
             limbs: limbs.into_limbs(),

--- a/src/arithmetic/bigint/private_exponent.rs
+++ b/src/arithmetic/bigint/private_exponent.rs
@@ -12,7 +12,7 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use super::{limb, BoxedLimbs, Limb, Modulus};
+use super::{limb, Elem, Limb, Modulus};
 use crate::error;
 use alloc::boxed::Box;
 
@@ -28,7 +28,7 @@ impl PrivateExponent {
         input: untrusted::Input,
         p: &Modulus<M>,
     ) -> Result<Self, error::Unspecified> {
-        let mut dP = BoxedLimbs::from_be_bytes_padded_less_than(input, p)?;
+        let mut dP = Elem::<M>::from_be_bytes_padded(input, p)?.limbs;
 
         // Proof that `dP < p - 1`:
         //
@@ -53,6 +53,7 @@ impl PrivateExponent {
         input: untrusted::Input,
         p: &Modulus<M>,
     ) -> Result<Self, error::Unspecified> {
+        use super::boxed_limbs::BoxedLimbs;
         use crate::limb::LIMB_BYTES;
 
         // Do exactly what `from_be_bytes_padded` does for any inputs it accepts.

--- a/src/ec/suite_b/ops.rs
+++ b/src/ec/suite_b/ops.rs
@@ -576,7 +576,7 @@ pub(super) fn scalar_parse_big_endian_partially_reduced_variable_consttime(
     let mut r = Scalar::zero();
     {
         let r = &mut r.limbs[..num_limbs];
-        parse_big_endian_and_pad_consttime(bytes, r)?;
+        parse_big_endian_and_pad_consttime(bytes, r).map_err(error::erase::<LenMismatchError>)?;
         limbs_reduce_once(r, &n.limbs[..num_limbs])
             .unwrap_or_else(unwrap_impossible_len_mismatch_error);
     }

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -37,6 +37,8 @@ pub type LeakyLimb = bb::LeakyWord;
 pub const LIMB_BITS: usize = usize_from_u32(Limb::BITS);
 pub const LIMB_BYTES: usize = (LIMB_BITS + 7) / 8;
 
+pub const ZERO: LeakyLimb = 0;
+
 pub type LimbMask = bb::BoolMask;
 
 #[inline]
@@ -176,7 +178,7 @@ pub fn parse_big_endian_and_pad_consttime(
     Ok(())
 }
 
-fn limbs_from_big_endian<'a>(
+pub fn limbs_from_big_endian<'a>(
     input: untrusted::Input<'a>,
     len_bounds: RangeInclusive<usize>,
 ) -> Result<impl ExactSizeIterator<Item = Limb> + 'a, LenMismatchError> {

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -366,7 +366,7 @@ impl KeyPair {
 
         // Step 7.f.
         let qInv = bigint::elem_mul(p.oneRR.as_ref(), qInv, pm);
-        let q_mod_p = bigint::elem_reduced(pm.alloc_zero(), &q_mod_n, pm, q.modulus.len_bits());
+        let q_mod_p = bigint::elem_reduced(pm.alloc_uninit(), &q_mod_n, pm, q.modulus.len_bits());
         let q_mod_p = bigint::elem_mul(p.oneRR.as_ref(), q_mod_p, pm);
         bigint::verify_inverses_consttime(&qInv, q_mod_p, pm)
             .map_err(|error::Unspecified| KeyRejected::inconsistent_components())?;
@@ -441,7 +441,7 @@ impl<M> PrivatePrime<M> {
         // Steps 5.e and 5.f are omitted as explained above.
         let p = bigint::OwnedModulus::from(p);
         let pm = p.modulus(cpu_features);
-        let oneRR = bigint::One::newRR(pm.alloc_zero(), &pm);
+        let oneRR = bigint::One::newRR(pm.alloc_uninit(), &pm);
 
         Ok(Self { modulus: p, oneRR })
     }
@@ -493,7 +493,7 @@ fn elem_exp_consttime<M>(
 ) -> Result<bigint::Elem<M>, error::Unspecified> {
     let m = &p.modulus.modulus(cpu_features);
     bigint::elem_exp_consttime(
-        m.alloc_zero(),
+        m.alloc_uninit(),
         c,
         &p.oneRRR,
         &p.exponent,
@@ -603,7 +603,7 @@ impl KeyPair {
         // Step 2.b.iii.
         let h = {
             let p = &self.p.modulus.modulus(cpu_features);
-            let m_2 = bigint::elem_reduced_once(p.alloc_zero(), &m_2, p, q_bits);
+            let m_2 = bigint::elem_reduced_once(p.alloc_uninit(), &m_2, p, q_bits);
             let m_1_minus_m_2 = bigint::elem_sub(m_1, &m_2, p);
             bigint::elem_mul(&self.qInv, m_1_minus_m_2, p)
         };
@@ -613,11 +613,11 @@ impl KeyPair {
         // Modular arithmetic is used simply to avoid implementing
         // non-modular arithmetic.
         let p_bits = self.p.modulus.len_bits();
-        let h = bigint::elem_widen(n.alloc_zero(), h, n, p_bits)?;
+        let h = bigint::elem_widen(n.alloc_uninit(), h, n, p_bits)?;
         let q_mod_n = self.q.modulus.to_elem(n)?;
         let q_mod_n = bigint::elem_mul(n_one, q_mod_n, n);
         let q_times_h = bigint::elem_mul(&q_mod_n, h, n);
-        let m_2 = bigint::elem_widen(n.alloc_zero(), m_2, n, q_bits)?;
+        let m_2 = bigint::elem_widen(n.alloc_uninit(), m_2, n, q_bits)?;
         let m = bigint::elem_add(m_2, q_times_h, n);
 
         // Step 2.b.v isn't needed since there are only two primes.
@@ -631,7 +631,7 @@ impl KeyPair {
         // minimum value, since the relationship of `e` to `d`, `p`, and `q` is
         // not verified during `KeyPair` construction.
         {
-            let verify = n.alloc_zero();
+            let verify = n.alloc_uninit();
             let verify = self
                 .public
                 .inner()

--- a/src/rsa/public_key.rs
+++ b/src/rsa/public_key.rs
@@ -164,7 +164,7 @@ impl Inner {
         }
 
         // Step 2.
-        let m = n.alloc_zero();
+        let m = n.alloc_uninit();
         let m = self.exponentiate_elem(m, &s, cpu_features);
 
         // Step 3.
@@ -176,7 +176,7 @@ impl Inner {
     /// This is constant-time with respect to `base` only.
     pub(super) fn exponentiate_elem(
         &self,
-        out: bigint::Storage<N>,
+        out: bigint::Uninit<N>,
         base: &bigint::Elem<N>,
         cpu_features: cpu::Features,
     ) -> bigint::Elem<N> {
@@ -187,7 +187,7 @@ impl Inner {
 
         let n = &self.n.value(cpu_features);
 
-        let tmp = n.alloc_zero();
+        let tmp = n.alloc_uninit();
         let base_r = bigint::elem_mul_into(tmp, self.n.oneRR(), base, n);
 
         // During RSA public key operations the exponent is almost always either

--- a/src/rsa/public_modulus.rs
+++ b/src/rsa/public_modulus.rs
@@ -22,7 +22,7 @@ impl Clone for PublicModulus {
         // but not worth optimizing away.
         let cpu = cpu::features();
         let n = value.modulus(cpu);
-        let oneRR = oneRR.clone_into(n.alloc_zero());
+        let oneRR = oneRR.clone_into(n.alloc_uninit());
 
         Self { value, oneRR }
     }
@@ -71,7 +71,7 @@ impl PublicModulus {
         }
         let value = bigint::OwnedModulus::from(value);
         let m = value.modulus(cpu_features);
-        let oneRR = bigint::One::newRR(m.alloc_zero(), &m);
+        let oneRR = bigint::One::newRR(m.alloc_uninit(), &m);
 
         Ok(Self { value, oneRR })
     }


### PR DESCRIPTION
Replace uses of the `Storage` type (externally) with a new `Uninit` type that defers allocation until we know what we want to write, then use `Vec's `FromIterator` to avoid unnecessarily writing zeros, where it is easy to do so. 

Replace uses of `Storage` internally with `BoxedLimbs`; `Storage` was really a `BoxedLimbs` with its contents hidden from external users, but it turns out that `Uninit` is all we really need.