### PR TITLE
build: Default to clang-cl and have cc-rs find it, on aarch64-pc-windows-msvc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,6 @@ jobs:
 
       - run: rustup toolchain install --no-self-update --profile=minimal 1.85.0 # MSRV
 
-      - run: echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
-        shell: bash
-
       - run: sh mk/package.sh
         shell: bash
 
@@ -442,11 +439,6 @@ jobs:
 
       - if: ${{ contains(matrix.host_os, 'windows') && contains(matrix.target, '86') }}
         run: ./mk/install-build-tools.ps1
-
-      - if: ${{ matrix.target == 'aarch64-pc-windows-msvc' && !contains(matrix.host_os, 'arm') }}
-        run: |
-          echo "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
-        shell: bash
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,19 +25,6 @@ supported.
 
 For Windows ARM64 targets (aarch64-pc-windows-msvc), the Visual Studio Build
 Tools “VS 2022 C++ ARM64 build tools” and "clang" components must be installed.
-Add Microsoft's provided version of `clang` to `%PATH%`, which will allow the
-build to work in GitHub Actions without installing anything:
-```
-$env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin"
-```
-If you (locally) have “Build Tools for Visual Studio 2022” instead, use:
-```
-$env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin"
-```
-Alternatively, if the host machine is already a Windows ARM64 then use:
-```
-$env:Path += ";C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\ARM64\bin"
-```
 
 Packaged Builds
 ---------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,10 +75,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -190,6 +191,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"

--- a/build.rs
+++ b/build.rs
@@ -587,14 +587,12 @@ fn obj_path(out_dir: &Path, src: &Path) -> PathBuf {
 }
 
 fn configure_cc(c: &mut cc::Build, target: &Target, c_root_dir: &Path, include_dir: &Path) {
-    let compiler = c.get_compiler();
-    // FIXME: On Windows AArch64 we currently must use Clang to compile C code
-    let compiler = if target.os == WINDOWS && target.arch == AARCH64 && !compiler.is_like_clang() {
-        let _ = c.compiler("clang");
-        c.get_compiler()
-    } else {
-        compiler
+    // FIXME: On Windows AArch64 we currently must use Clang to compile C code.
+    // clang-cl emulates the cl.exe command line, `$CFLAGS`, etc.
+    if target.os == WINDOWS && target.arch == AARCH64 {
+        let _: &_ = c.prefer_clang_cl_over_msvc(true);
     };
+    let compiler = c.get_compiler();
 
     let _ = c.include(c_root_dir.join("include"));
     let _ = c.include(include_dir);

--- a/include/ring-core/target.h
+++ b/include/ring-core/target.h
@@ -94,4 +94,8 @@
 #define OPENSSL_SMALL
 #endif
 
+#if defined(OPENSSL_AARCH64) && defined(OPENSSL_WINDOWS) && !defined(__clang__)
+#error "Only clang-cl and clang are supported for aarch64-*-windows-*"
+#endif
+
 #endif  // OPENSSL_HEADER_TARGET_H

--- a/mk/package.sh
+++ b/mk/package.sh
@@ -11,7 +11,7 @@ fi
 
 msrv=1.85.0
 cargo clean --target-dir=target/pregenerate_asm
-RING_PREGENERATE_ASM=1 CC_AARCH64_PC_WINDOWS_MSVC=clang \
+RING_PREGENERATE_ASM=1 \
   cargo +${msrv} build --locked -p ring --target-dir=target/pregenerate_asm
 if [[ -n "$(git status --porcelain -- ':(exclude)pregenerated/')" ]]; then
   echo Repository is dirty.


### PR DESCRIPTION
Don't require "clang" to be in the path for AArch64 Windows builds. Use clang-cl, which has an MSVC cl.exe style command line, so that CFLAGS and other settings are picked up automatically.

Inspired by Dennis Ameling's PR.