### PR TITLE
ec internals: Use `#[cfg(windows)]` to exclude ADX for all COFF targets.

### DIFF
--- a/src/ec/curve25519/mod.rs
+++ b/src/ec/curve25519/mod.rs
@@ -14,7 +14,7 @@
 
 //! Elliptic curve operations and schemes using Curve25519.
 
-#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
+#[cfg(all(target_arch = "x86_64", not(windows)))]
 mod adx;
 
 pub mod ed25519;

--- a/src/ec/curve25519/ops.rs
+++ b/src/ec/curve25519/ops.rs
@@ -71,7 +71,7 @@ pub struct P3 {
 impl P3 {
     // Returns the result of multiplying the base point by the scalar in constant time.
     pub(super) fn from_scalarmult_base(scalar: &Scalar, cpu: cpu::Features) -> Self {
-        #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
+        #[cfg(all(target_arch = "x86_64", not(windows)))]
         if let Some(cpu) = super::adx::get_features(cpu) {
             return super::adx::scalarmult_base(scalar, cpu);
         }

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -119,7 +119,7 @@ fn x25519_ecdh(
             return x25519_neon(out, scalar, point, cpu);
         }
 
-        #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
+        #[cfg(all(target_arch = "x86_64", not(windows)))]
         if super::adx::get_features(cpu).is_some() {
             prefixed_extern! {
                 unsafe fn x25519_scalar_mult_adx(


### PR DESCRIPTION
The ADX assembly isn't right for UEFI either, for example.