### PR TITLE
fix(#2809): make Algorithm getters const

### DIFF
--- a/src/aead/algorithm.rs
+++ b/src/aead/algorithm.rs
@@ -58,7 +58,7 @@ pub struct Algorithm {
 impl Algorithm {
     /// The length of the key.
     #[inline(always)]
-    pub fn key_len(&self) -> usize {
+    pub const fn key_len(&self) -> usize {
         self.key_len
     }
 
@@ -66,13 +66,13 @@ impl Algorithm {
     ///
     /// See also `MAX_TAG_LEN`.
     #[inline(always)]
-    pub fn tag_len(&self) -> usize {
+    pub const fn tag_len(&self) -> usize {
         TAG_LEN
     }
 
     /// The length of the nonces.
     #[inline(always)]
-    pub fn nonce_len(&self) -> usize {
+    pub const fn nonce_len(&self) -> usize {
         NONCE_LEN
     }
 

--- a/src/aead/quic.rs
+++ b/src/aead/quic.rs
@@ -99,13 +99,13 @@ impl hkdf::KeyType for &'static Algorithm {
 impl Algorithm {
     /// The length of the key.
     #[inline(always)]
-    pub fn key_len(&self) -> usize {
+    pub const fn key_len(&self) -> usize {
         self.key_len
     }
 
     /// The required sample length.
     #[inline(always)]
-    pub fn sample_len(&self) -> usize {
+    pub const fn sample_len(&self) -> usize {
         SAMPLE_LEN
     }
 }


### PR DESCRIPTION
This allows using the `key_len` in constants for type safety, e.g.

```rust
type CHACHA_KEY = [u8; ring::aead::CHACHA20_POLY1305.key_len()];

static DEFAULT_KEY: CHACHA_KEY = [0; ring::aead::CHACHA20_POLY1305.key_len()];
```

Closes #2809