### PR TITLE
doc: tools.ietf.org not right place for RFCs, use rfc-editor.org

### DIFF
--- a/src/aead/aes_gcm/mod.rs
+++ b/src/aead/aes_gcm/mod.rs
@@ -521,8 +521,8 @@ pub(super) const MAX_IN_OUT_LEN: usize = super::max_input_len(BLOCK_LEN, 2);
 //
 // [NIST SP800-38D]:
 //    http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
-// [RFC 5116 Section 5.1]: https://tools.ietf.org/html/rfc5116#section-5.1
-// [RFC 5116 Section 5.2]: https://tools.ietf.org/html/rfc5116#section-5.2
+// [RFC 5116 Section 5.1]: https://www.rfc-editor.org/rfc/rfc5116#section-5.1
+// [RFC 5116 Section 5.2]: https://www.rfc-editor.org/rfc/rfc5116#section-5.2
 const _MAX_INPUT_LEN_BOUNDED_BY_NIST: () =
     assert!(MAX_IN_OUT_LEN == usize_from_u64_saturated(((1u64 << 39) - 256) / 8));
 

--- a/src/aead/algorithm.rs
+++ b/src/aead/algorithm.rs
@@ -202,7 +202,7 @@ pub(super) fn aes_gcm_open<'o>(
 ///
 /// The keys are 256 bits long and the nonces are 96 bits long.
 ///
-/// [RFC 8439]: https://tools.ietf.org/html/rfc8439
+/// [RFC 8439]: https://www.rfc-editor.org/rfc/rfc8439
 pub static CHACHA20_POLY1305: Algorithm = Algorithm {
     key_len: chacha20_poly1305::KEY_LEN,
     init: chacha20_poly1305_init,

--- a/src/aead/chacha20_poly1305/mod.rs
+++ b/src/aead/chacha20_poly1305/mod.rs
@@ -39,7 +39,7 @@ cfg_if! {
 pub(super) const KEY_LEN: usize = chacha::KEY_LEN;
 
 const MAX_IN_OUT_LEN: usize = super::max_input_len(64, 1);
-// https://tools.ietf.org/html/rfc8439#section-2.8
+// https://www.rfc-editor.org/rfc/rfc8439#section-2.8
 const _MAX_IN_OUT_LEN_BOUNDED_BY_RFC: () =
     assert!(MAX_IN_OUT_LEN == usize_from_u64_saturated(274_877_906_880u64));
 

--- a/src/aead/chacha20_poly1305_openssh.rs
+++ b/src/aead/chacha20_poly1305_openssh.rs
@@ -27,7 +27,7 @@
 //!
 //! [chacha20-poly1305@openssh.com]:
 //!    http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD
-//! [RFC 4253]: https://tools.ietf.org/html/rfc4253
+//! [RFC 4253]: https://www.rfc-editor.org/rfc/rfc4253
 
 #[allow(unused_imports)]
 use crate::polyfill::prelude::*;

--- a/src/ec/curve25519/ed25519/signing.rs
+++ b/src/ec/curve25519/ed25519/signing.rs
@@ -44,8 +44,8 @@ impl Ed25519KeyPair {
     /// as described in [RFC 5958 Section 2]; see [RFC 8410 Section 10.3] for an
     /// example.
     ///
-    /// [RFC 5958 Section 2]: https://tools.ietf.org/html/rfc5958#section-2
-    /// [RFC 8410 Section 10.3]: https://tools.ietf.org/html/rfc8410#section-10.3
+    /// [RFC 5958 Section 2]: https://www.rfc-editor.org/rfc/rfc5958#section-2
+    /// [RFC 8410 Section 10.3]: https://www.rfc-editor.org/rfc/rfc8410#section-10.3
     pub fn generate_pkcs8(
         rng: &dyn rand::SecureRandom,
     ) -> Result<pkcs8::Document, error::Unspecified> {

--- a/src/ec/curve25519/ops.rs
+++ b/src/ec/curve25519/ops.rs
@@ -45,7 +45,7 @@ impl Elem<Tight> {
     }
 }
 
-// [RFC 8032] https://tools.ietf.org/html/rfc8032#section-5.1.2
+// [RFC 8032] https://www.rfc-editor.org/rfc/rfc8032#section-5.1.2
 // This is *NOT* the type to use for X25519 output.
 #[derive(Clone, Copy)]
 #[repr(transparent)]

--- a/src/ec/curve25519/x25519.rs
+++ b/src/ec/curve25519/x25519.rs
@@ -35,8 +35,8 @@ static CURVE25519: ec::Curve = ec::Curve {
 /// result of the X25519 operation is zero; see the notes on the
 /// "all-zero value" in [RFC 7748 section 6.1].
 ///
-/// [RFC 7748]: https://tools.ietf.org/html/rfc7748
-/// [RFC 7748 section 6.1]: https://tools.ietf.org/html/rfc7748#section-6.1
+/// [RFC 7748]: https://www.rfc-editor.org/rfc/rfc7748
+/// [RFC 7748 section 6.1]: https://www.rfc-editor.org/rfc/rfc7748#section-6.1
 pub static X25519: agreement::Algorithm = agreement::Algorithm {
     curve: &CURVE25519,
     ecdh: x25519_ecdh,
@@ -59,7 +59,7 @@ fn x25519_generate_private_key(
     rng.fill(out)
 }
 
-// https://tools.ietf.org/html/rfc7748#section-5
+// https://www.rfc-editor.org/rfc/rfc7748#section-5
 type UCoordinate = [u8; PUBLIC_KEY_LEN];
 
 fn x25519_public_from_private(

--- a/src/ec/suite_b/ecdsa/signing.rs
+++ b/src/ec/suite_b/ecdsa/signing.rs
@@ -75,8 +75,8 @@ impl EcdsaKeyPair {
     /// not have a `parameters` field so the generated key is compatible with
     /// PKCS#11.
     ///
-    /// [RFC 5915]: https://tools.ietf.org/html/rfc5915
-    /// [RFC 5958 Section 2]: https://tools.ietf.org/html/rfc5958#section-2
+    /// [RFC 5915]: https://www.rfc-editor.org/rfc/rfc5915
+    /// [RFC 5958 Section 2]: https://www.rfc-editor.org/rfc/rfc5958#section-2
     pub fn generate_pkcs8(
         alg: &'static EcdsaSigningAlgorithm,
         rng: &dyn rand::SecureRandom,

--- a/src/ec/suite_b/mod.rs
+++ b/src/ec/suite_b/mod.rs
@@ -162,7 +162,7 @@ pub(crate) fn key_pair_from_pkcs8(
     let (ec_private_key, _) = pkcs8::unwrap_key(template, pkcs8::Version::V1Only, input)?;
     let (private_key, public_key) =
         ec_private_key.read_all(error::KeyRejected::invalid_encoding(), |input| {
-            // https://tools.ietf.org/html/rfc5915#section-3
+            // https://www.rfc-editor.org/rfc/rfc5915#section-3
             der::nested(
                 input,
                 der::Tag::Sequence,

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -16,7 +16,7 @@
 //!
 //! HKDF is specified in [RFC 5869].
 //!
-//! [RFC 5869]: https://tools.ietf.org/html/rfc5869
+//! [RFC 5869]: https://www.rfc-editor.org/rfc/rfc5869
 
 use crate::{error, hmac};
 
@@ -67,7 +67,7 @@ impl Salt {
 
     /// The [HKDF-Extract] operation.
     ///
-    /// [HKDF-Extract]: https://tools.ietf.org/html/rfc5869#section-2.2
+    /// [HKDF-Extract]: https://www.rfc-editor.org/rfc/rfc5869#section-2.2
     pub fn extract(&self, secret: &[u8]) -> Prk {
         // The spec says that if no salt is provided then a key of
         // `digest_alg.output_len` bytes of zeros is used. But, HMAC keys are
@@ -120,7 +120,7 @@ impl Prk {
 
     /// The [HKDF-Expand] operation.
     ///
-    /// [HKDF-Expand]: https://tools.ietf.org/html/rfc5869#section-2.3
+    /// [HKDF-Expand]: https://www.rfc-editor.org/rfc/rfc5869#section-2.3
     ///
     /// Fails if (and only if) `len` is too large.
     #[inline]

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -103,7 +103,7 @@
 //! # Ok::<(), ring::error::Unspecified>(())
 //! ```
 //!
-//! [RFC 2104]: https://tools.ietf.org/html/rfc2104
+//! [RFC 2104]: https://www.rfc-editor.org/rfc/rfc2104
 
 use crate::{
     bb, cpu,
@@ -174,7 +174,7 @@ impl Key {
     /// The key will be `digest_alg.output_len` bytes long, based on the
     /// recommendation in [RFC 2104 Section 3].
     ///
-    /// [RFC 2104 Section 3]: https://tools.ietf.org/html/rfc2104#section-3
+    /// [RFC 2104 Section 3]: https://www.rfc-editor.org/rfc/rfc2104#section-3
     pub fn generate(
         algorithm: Algorithm,
         rng: &dyn rand::SecureRandom,

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -20,8 +20,8 @@
 //! PBKDF2 is specified in [RFC 2898 Section 5.2] with test vectors given in
 //! [RFC 6070]. See also [NIST Special Publication 800-132].
 //!
-//! [RFC 2898 Section 5.2]: https://tools.ietf.org/html/rfc2898#section-5.2
-//! [RFC 6070]: https://tools.ietf.org/html/rfc6070
+//! [RFC 2898 Section 5.2]: https://www.rfc-editor.org/rfc/rfc2898#section-5.2
+//! [RFC 6070]: https://www.rfc-editor.org/rfc/rfc6070
 //! [NIST Special Publication 800-132]:
 //!    http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
 //!

--- a/src/pkcs8.rs
+++ b/src/pkcs8.rs
@@ -14,7 +14,7 @@
 
 //! PKCS#8 is specified in [RFC 5958].
 //!
-//! [RFC 5958]: https://tools.ietf.org/html/rfc5958
+//! [RFC 5958]: https://www.rfc-editor.org/rfc/rfc5958
 
 use crate::{ec, error, io::der};
 
@@ -72,7 +72,7 @@ impl Template {
 ///
 /// PKCS#8 is specified in [RFC 5958].
 ///
-/// [RFC 5958]: https://tools.ietf.org/html/rfc5958
+/// [RFC 5958]: https://www.rfc-editor.org/rfc/rfc5958
 pub(crate) fn unwrap_key<'a>(
     template: &Template,
     version: Version,
@@ -90,7 +90,7 @@ pub(crate) fn unwrap_key<'a>(
 ///
 /// PKCS#8 is specified in [RFC 5958].
 ///
-/// [RFC 5958]: https://tools.ietf.org/html/rfc5958
+/// [RFC 5958]: https://www.rfc-editor.org/rfc/rfc5958
 pub(crate) fn unwrap_key_<'a>(
     alg_id: untrusted::Input,
     version: Version,

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -92,10 +92,10 @@ impl KeyPair {
     ///     http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br1.pdf
     ///
     /// [RFC 3447 Appendix A.1.2]:
-    ///     https://tools.ietf.org/html/rfc3447#appendix-A.1.2
+    ///     https://www.rfc-editor.org/rfc/rfc3447#appendix-A.1.2
     ///
     /// [RFC 5958]:
-    ///     https://tools.ietf.org/html/rfc5958
+    ///     https://www.rfc-editor.org/rfc/rfc5958
     pub fn from_pkcs8(pkcs8: &[u8]) -> Result<Self, KeyRejected> {
         const RSA_ENCRYPTION: &[u8] = include_bytes!("../data/alg-rsa-encryption.der");
         let (der, _) = pkcs8::unwrap_key_(
@@ -120,7 +120,7 @@ impl KeyPair {
     /// validated.
     ///
     /// [RFC 3447 Appendix A.1.2]:
-    ///     https://tools.ietf.org/html/rfc3447#appendix-A.1.2
+    ///     https://www.rfc-editor.org/rfc/rfc3447#appendix-A.1.2
     ///
     /// [NIST SP-800-56B rev. 1]:
     ///     http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br1.pdf

--- a/src/rsa/padding/mod.rs
+++ b/src/rsa/padding/mod.rs
@@ -49,7 +49,7 @@ pub(super) fn encode(
 
 /// An RSA signature encoding as described in [RFC 3447 Section 8].
 ///
-/// [RFC 3447 Section 8]: https://tools.ietf.org/html/rfc3447#section-8
+/// [RFC 3447 Section 8]: https://www.rfc-editor.org/rfc/rfc3447#section-8
 #[cfg(feature = "alloc")]
 pub trait RsaEncoding: Padding {
     #[doc(hidden)]
@@ -78,7 +78,7 @@ pub trait RsaEncoding: Padding {
 /// Verification of an RSA signature encoding as described in
 /// [RFC 3447 Section 8].
 ///
-/// [RFC 3447 Section 8]: https://tools.ietf.org/html/rfc3447#section-8
+/// [RFC 3447 Section 8]: https://www.rfc-editor.org/rfc/rfc3447#section-8
 pub trait Verification: Padding {
     fn verify(
         &self,
@@ -89,7 +89,7 @@ pub trait Verification: Padding {
 }
 
 // Masks `out` with the output of the mask-generating function MGF1 as
-// described in https://tools.ietf.org/html/rfc3447#appendix-B.2.1.
+// described in https://www.rfc-editor.org/rfc/rfc3447#appendix-B.2.1.
 fn mgf1(digest_alg: &'static digest::Algorithm, seed: &[u8], out: &mut [u8]) {
     let digest_len = digest_alg.output_len();
 

--- a/src/rsa/padding/pkcs1.rs
+++ b/src/rsa/padding/pkcs1.rs
@@ -20,7 +20,7 @@ use crate::{bits, digest, error, io::der, rand, sealed};
 /// See "`RSA_PSS_*` Details\" in `ring::signature`'s module-level
 /// documentation for more details.
 ///
-/// [RFC 3447 Section 8.2]: https://tools.ietf.org/html/rfc3447#section-8.2
+/// [RFC 3447 Section 8.2]: https://www.rfc-editor.org/rfc/rfc3447#section-8.2
 #[derive(Debug)]
 pub struct PKCS1 {
     digest_alg: &'static digest::Algorithm,
@@ -67,7 +67,7 @@ impl Verification for PKCS1 {
 }
 
 // Implement padding procedure per EMSA-PKCS1-v1_5,
-// https://tools.ietf.org/html/rfc3447#section-9.2. This is used by both
+// https://www.rfc-editor.org/rfc/rfc3447#section-9.2. This is used by both
 // verification and signing so it needs to be able to handle moduli of the
 // minimum and maximum sizes for both operations.
 fn pkcs1_encode(pkcs1: &PKCS1, m_hash: digest::Digest, m_out: &mut [u8]) {

--- a/src/rsa/padding/pss.rs
+++ b/src/rsa/padding/pss.rs
@@ -20,7 +20,7 @@ use crate::{bb, bits, digest, error, rand, sealed};
 /// See "`RSA_PSS_*` Details\" in `ring::signature`'s module-level
 /// documentation for more details.
 ///
-/// [RFC 3447 Section 8.1]: https://tools.ietf.org/html/rfc3447#section-8.1
+/// [RFC 3447 Section 8.1]: https://www.rfc-editor.org/rfc/rfc3447#section-8.1
 #[allow(clippy::upper_case_acronyms)] // TODO: Until we implement cargo-semver-checks
 #[derive(Debug)]
 pub struct PSS {
@@ -35,7 +35,7 @@ impl Padding for PSS {
 
 impl RsaEncoding for PSS {
     // Implement padding procedure per EMSA-PSS,
-    // https://tools.ietf.org/html/rfc3447#section-9.1.
+    // https://www.rfc-editor.org/rfc/rfc3447#section-9.1.
     fn encode_(
         &self,
         m_hash: digest::Digest,
@@ -99,7 +99,7 @@ impl RsaEncoding for PSS {
 }
 
 impl Verification for PSS {
-    // RSASSA-PSS-VERIFY from https://tools.ietf.org/html/rfc3447#section-8.1.2
+    // RSASSA-PSS-VERIFY from https://www.rfc-editor.org/rfc/rfc3447#section-8.1.2
     // where steps 1, 2(a), and 2(b) have been done for us.
     fn verify(
         &self,
@@ -126,7 +126,7 @@ impl Verification for PSS {
         let em = m;
 
         // The rest of this function is EMSA-PSS-VERIFY from
-        // https://tools.ietf.org/html/rfc3447#section-9.1.2.
+        // https://www.rfc-editor.org/rfc/rfc3447#section-9.1.2.
 
         // Steps 1 and 2 are done by the caller to produce `m_hash`.
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -113,13 +113,13 @@
 //! [Suite B implementer's guide to FIPS 186-3]:
 //!     https://github.com/briansmith/ring/blob/main/doc/ecdsa.pdf
 //! [RFC 3279 Section 2.2.3]:
-//!     https://tools.ietf.org/html/rfc3279#section-2.2.3
+//!     https://www.rfc-editor.org/rfc/rfc3279#section-2.2.3
 //! [RFC 3447 Section 8.2]:
-//!     https://tools.ietf.org/html/rfc3447#section-7.2
+//!     https://www.rfc-editor.org/rfc/rfc3447#section-7.2
 //! [RFC 3447 Section 8.1]:
-//!     https://tools.ietf.org/html/rfc3447#section-8.1
+//!     https://www.rfc-editor.org/rfc/rfc3447#section-8.1
 //! [RFC 3447 Appendix-A.1.1]:
-//!     https://tools.ietf.org/html/rfc3447#appendix-A.1.1
+//!     https://www.rfc-editor.org/rfc/rfc3447#appendix-A.1.1
 //!
 //!
 //! # Examples


### PR DESCRIPTION
tools.ietf.org only works because smart IETF webmasters installed redirects.
rfc-editor.org is the official place.
{I'm https://datatracker.ietf.org/person/Michael%20Richardson, not some silly LLM. Thanks.}
