### PR TITLE
Remove windows-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,6 @@ dependencies = [
  "libc",
  "untrusted",
  "wasm-bindgen-test",
- "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,9 +172,6 @@ libc = { version = "0.2.172", default-features = false }
 [target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_vendor = "apple", any(target_os = "ios", target_os = "macos", target_os = "tvos", target_os = "visionos", target_os = "watchos")))'.dependencies]
 libc = { version = "0.2.172", default-features = false }
 
-[target.'cfg(all(all(target_arch = "aarch64", target_endian = "little"), target_os = "windows"))'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_Threading"] }
-
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.64", default-features = false, features = ["std"] }
 

--- a/src/cpu/aarch64/windows.rs
+++ b/src/cpu/aarch64/windows.rs
@@ -13,9 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{Aes, CAPS_STATIC, Neon, PMull, Sha256};
-use windows_sys::Win32::System::Threading::{
-    IsProcessorFeaturePresent, PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE,
-};
+use crate::polyfill::windows_sys;
 
 pub const FORCE_DYNAMIC_DETECTION: u32 = 0;
 
@@ -25,7 +23,9 @@ pub fn detect_features() -> u32 {
 
     let mut features = 0;
 
-    let result = unsafe { IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) };
+    let result = unsafe {
+        windows_sys::IsProcessorFeaturePresent(windows_sys::PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE)
+    };
 
     if result != 0 {
         // These are all covered by one call in Windows

--- a/src/polyfill/mod.rs
+++ b/src/polyfill/mod.rs
@@ -91,6 +91,9 @@ mod test;
 pub(crate) mod uninit;
 mod uninit_slice;
 
+#[cfg(all(windows, target_arch = "aarch64"))]
+pub(crate) mod windows_sys;
+
 pub use self::{array_flat_map::ArrayFlatMap, array_split_map::ArraySplitMap, notsend::NotSend};
 
 #[allow(unused_imports)]

--- a/src/polyfill/windows_sys.rs
+++ b/src/polyfill/windows_sys.rs
@@ -1,0 +1,11 @@
+pub type DWORD = u32;
+pub type BOOL = i32;
+
+/// This Arm processor implements the Arm v8 extra cryptographic instructions (for example, AES, SHA1 and SHA2).
+pub const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: DWORD = 30;
+
+#[link(name = "kernel32", kind = "raw-dylib")]
+extern "system" {
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent>
+    fn IsProcessorFeaturePresent(processor_feature: DWORD) -> BOOL;
+}


### PR DESCRIPTION
This is an alternative to #2570 that still removes the windows-sys dependency but inlines the bindings (1 function, 1 constant) instead of relying on std.