### PR TITLE
bigint: Turn remaining standalone pub(crate) functions into methods.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -40,21 +40,17 @@
 use crate::polyfill::prelude::*;
 
 use self::boxed_limbs::BoxedLimbs;
+pub(crate) use self::{
+    boxed_limbs::Uninit,
+    elem::Elem,
+    modulus::{BoxedIntoMont, IntoMont, Mont, One},
+    oversized_uninit::OversizedUninit,
+    private_exponent::PrivateExponent,
+};
 use super::{LimbSliceError, MAX_LIMBS, montgomery::*};
 use crate::{
     error::{self, LenMismatchError},
     limb::{self, Limb},
-};
-pub(crate) use {
-    self::{
-        boxed_limbs::Uninit,
-        elem::{Elem, elem_verify_equal_consttime, verify_inverses_consttime},
-        exp::elem_exp_consttime,
-        modulus::{BoxedIntoMont, IntoMont, Mont, One},
-        oversized_uninit::OversizedUninit,
-        private_exponent::PrivateExponent,
-    },
-    super::exp_vartime::elem_exp_vartime,
 };
 
 mod boxed_limbs;

--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -278,11 +278,11 @@ impl<M, E> Elem<M, E> {
 
 /// Verified a == b**-1 (mod m), i.e. a**-1 == b (mod m).
 pub fn verify_inverses_consttime<M>(
-    a: &Elem<M, R>,
-    b: Elem<M, Unencoded>,
+    a: Elem<M, Unencoded>,
+    b: &Elem<M, R>,
     m: &Mont<M>,
 ) -> Result<(), error::Unspecified> {
-    let r = b.mul(a, m);
+    let r = a.mul(b, m);
     limb::verify_limbs_equal_1_leak_bit(r.limbs.as_ref())
 }
 

--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -276,27 +276,28 @@ impl<M, E> Elem<M, E> {
     }
 }
 
-/// Verified a == b**-1 (mod m), i.e. a**-1 == b (mod m).
-pub fn verify_inverses_consttime<M>(
-    a: Elem<M, Unencoded>,
-    b: &Elem<M, R>,
-    m: &Mont<M>,
-) -> Result<(), error::Unspecified> {
-    let r = a.mul(b, m);
-    limb::verify_limbs_equal_1_leak_bit(r.limbs.as_ref())
+impl<M> Elem<M, Unencoded> {
+    /// Verified a == b**-1 (mod m), i.e. a**-1 == b (mod m).
+    pub fn verify_inverse_consttime(
+        self,
+        b: &Elem<M, R>,
+        m: &Mont<M>,
+    ) -> Result<(), error::Unspecified> {
+        let r = self.mul(b, m);
+        limb::verify_limbs_equal_1_leak_bit(r.limbs.as_ref())
+    }
 }
 
-#[inline]
-pub fn elem_verify_equal_consttime<M, E>(
-    a: &Elem<M, E>,
-    b: &Elem<M, E>,
-) -> Result<(), error::Unspecified> {
-    let equal = limb::limbs_equal_limbs_consttime(a.limbs.as_ref(), b.limbs.as_ref())
-        .unwrap_or_else(unwrap_impossible_len_mismatch_error);
-    if !equal.leak() {
-        return Err(error::Unspecified);
+impl<M, E> Elem<M, E> {
+    #[inline]
+    pub fn verify_equals_consttime(&self, b: &Elem<M, E>) -> Result<(), error::Unspecified> {
+        let equal = limb::limbs_equal_limbs_consttime(self.limbs.as_ref(), b.limbs.as_ref())
+            .unwrap_or_else(unwrap_impossible_len_mismatch_error);
+        if !equal.leak() {
+            return Err(error::Unspecified);
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -327,7 +328,7 @@ pub mod testutil {
     }
 
     pub fn assert_elem_eq<M, E>(a: &Elem<M, E>, b: &Elem<M, E>) {
-        if elem_verify_equal_consttime(a, b).is_err() {
+        if a.verify_equals_consttime(b).is_err() {
             panic!("{:x?} != {:x?}", a.limbs.as_ref(), b.limbs.as_ref());
         }
     }

--- a/src/arithmetic/bigint/exp.rs
+++ b/src/arithmetic/bigint/exp.rs
@@ -55,27 +55,29 @@ use crate::{
 };
 use core::mem::MaybeUninit;
 
-pub(crate) fn elem_exp_consttime<N, P>(
-    base: &Elem<N>,
-    exponent: &PrivateExponent,
-    p: &IntoMont<P, RRR>,
-    other_prime_len_bits: BitLength,
-    cpu: cpu::Features,
-) -> Result<Elem<P, Unencoded>, LimbSliceError> {
-    let oneRRR = p.one();
-    let p = &p.modulus(cpu);
-    let out = p.alloc_uninit();
+impl<N> Elem<N, Unencoded> {
+    pub(crate) fn exp_consttime<P>(
+        &self,
+        exponent: &PrivateExponent,
+        p: &IntoMont<P, RRR>,
+        other_prime_len_bits: BitLength,
+        cpu: cpu::Features,
+    ) -> Result<Elem<P, Unencoded>, LimbSliceError> {
+        let oneRRR = p.one();
+        let p = &p.modulus(cpu);
+        let out = p.alloc_uninit();
 
-    // `elem_exp_consttime_inner` is parameterized on `STORAGE_LIMBS` only so
-    // we can run tests with larger-than-supported-in-operation test vectors.
-    elem_exp_consttime_inner::<N, P, { ELEM_EXP_CONSTTIME_MAX_MODULUS_LIMBS * STORAGE_ENTRIES }>(
-        out,
-        base,
-        &oneRRR,
-        exponent,
-        p,
-        other_prime_len_bits,
-    )
+        // `elem_exp_consttime_inner` is parameterized on `STORAGE_LIMBS` only so
+        // we can run tests with larger-than-supported-in-operation test vectors.
+        elem_exp_consttime_inner::<N, P, { ELEM_EXP_CONSTTIME_MAX_MODULUS_LIMBS * STORAGE_ENTRIES }>(
+            out,
+            self,
+            &oneRRR,
+            exponent,
+            p,
+            other_prime_len_bits,
+        )
+    }
 }
 
 // The maximum modulus size supported for `elem_exp_consttime` in normal
@@ -421,10 +423,10 @@ mod tests {
 
                 let too_big = m.limbs().len() > ELEM_EXP_CONSTTIME_MAX_MODULUS_LIMBS;
                 let actual_result = if !too_big {
-                    elem_exp_consttime(&base, &e, im, other_modulus_len_bits, cpu_features)
+                    base.exp_consttime(&e, im, other_modulus_len_bits, cpu_features)
                 } else {
                     let actual_result =
-                        elem_exp_consttime(&base, &e, im, other_modulus_len_bits, cpu_features);
+                        base.exp_consttime(&e, im, other_modulus_len_bits, cpu_features);
                     // TODO: Be more specific with which error we expect?
                     assert!(actual_result.is_err());
                     // Try again with a larger-than-normally-supported limit

--- a/src/arithmetic/exp_vartime.rs
+++ b/src/arithmetic/exp_vartime.rs
@@ -27,39 +27,36 @@ use core::num::NonZero;
 /// weight of `exponent`.
 // TODO: The test coverage needs to be expanded, e.g. test with the largest
 // accepted exponent and with the most common values of 65537 and 3.
-pub(crate) fn elem_exp_vartime<M>(
-    out: Uninit<M>,
-    base: Elem<M, R>,
-    exponent: NonZero<u64>,
-    m: &Mont<M>,
-) -> Elem<M, R> {
-    // Use what [Knuth] calls the "S-and-X binary method", i.e. variable-time
-    // square-and-multiply that scans the exponent from the most significant
-    // bit to the least significant bit (left-to-right). Left-to-right requires
-    // less storage compared to right-to-left scanning, at the cost of needing
-    // to compute `exponent.leading_zeros()`, which we assume to be cheap.
-    //
-    // As explained in [Knuth], exponentiation by squaring is the most
-    // efficient algorithm when the Hamming weight is 2 or less. It isn't the
-    // most efficient for all other, uncommon, exponent values but any
-    // suboptimality is bounded at least by the small bit length of `exponent`
-    // as enforced by its type.
-    //
-    // This implementation is slightly simplified by taking advantage of the
-    // fact that we require the exponent to be a positive integer.
-    //
-    // [Knuth]: The Art of Computer Programming, Volume 2: Seminumerical
-    //          Algorithms (3rd Edition), Section 4.6.3.
-    let exponent = exponent.get();
-    let mut acc = base.clone_into(out);
-    let mut bit = 1 << (64 - 1 - exponent.leading_zeros());
-    debug_assert!((exponent & bit) != 0);
-    while bit > 1 {
-        bit >>= 1;
-        acc = acc.square(m);
-        if (exponent & bit) != 0 {
-            acc = acc.mul(&base, m);
+impl<M> Elem<M, R> {
+    pub(crate) fn exp_vartime(self, out: Uninit<M>, exponent: NonZero<u64>, m: &Mont<M>) -> Self {
+        // Use what [Knuth] calls the "S-and-X binary method", i.e. variable-time
+        // square-and-multiply that scans the exponent from the most significant
+        // bit to the least significant bit (left-to-right). Left-to-right requires
+        // less storage compared to right-to-left scanning, at the cost of needing
+        // to compute `exponent.leading_zeros()`, which we assume to be cheap.
+        //
+        // As explained in [Knuth], exponentiation by squaring is the most
+        // efficient algorithm when the Hamming weight is 2 or less. It isn't the
+        // most efficient for all other, uncommon, exponent values but any
+        // suboptimality is bounded at least by the small bit length of `exponent`
+        // as enforced by its type.
+        //
+        // This implementation is slightly simplified by taking advantage of the
+        // fact that we require the exponent to be a positive integer.
+        //
+        // [Knuth]: The Art of Computer Programming, Volume 2: Seminumerical
+        //          Algorithms (3rd Edition), Section 4.6.3.
+        let exponent = exponent.get();
+        let mut acc = self.clone_into(out);
+        let mut bit = 1 << (64 - 1 - exponent.leading_zeros());
+        debug_assert!((exponent & bit) != 0);
+        while bit > 1 {
+            bit >>= 1;
+            acc = acc.square(m);
+            if (exponent & bit) != 0 {
+                acc = acc.mul(&self, m);
+            }
         }
+        acc
     }
-    acc
 }

--- a/src/rsa/base/public_key.rs
+++ b/src/rsa/base/public_key.rs
@@ -173,14 +173,15 @@ impl PublicKey<bigint::IntoMont<'_, N, RR>> {
         let n = &self.n.value();
         let nm = &n.modulus(cpu_features);
 
-        let tmp = nm.alloc_uninit();
-        let base_r = base.clone_into(tmp).encode_mont(n, cpu_features);
-
         // During RSA public key operations the exponent is almost always either
         // 65537 (0b10000000000000001) or 3 (0b11), both of which have a Hamming
         // weight of 2. The maximum bit length and maximum Hamming weight of the
         // exponent is bounded by the value of `PublicExponent::MAX`.
-        let acc = bigint::elem_exp_vartime(out, base_r, exponent_without_low_bit, nm);
+        let tmp = nm.alloc_uninit();
+        let acc = base
+            .clone_into(tmp)
+            .encode_mont(n, cpu_features)
+            .exp_vartime(out, exponent_without_low_bit, nm);
 
         // Now do the multiplication for the low bit and convert out of the Montgomery domain.
         acc.mul(base, nm)

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -387,7 +387,7 @@ impl KeyPair {
             .alloc_uninit()
             .elem_reduce_mont(&q_mod_n, pm, qim.len_bits())
             .encode_mont(pim, cpu_features);
-        bigint::verify_inverses_consttime(&qInv, q_mod_p, pm)
+        bigint::verify_inverses_consttime(q_mod_p, &qInv, pm)
             .map_err(|error::Unspecified| KeyRejected::inconsistent_components())?;
 
         // This should never fail since `n` and `e` were validated above.

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -655,14 +655,12 @@ impl KeyPair {
         // that is done other than basic checks on its size, oddness, and
         // minimum value, since the relationship of `e` to `d`, `p`, and `q` is
         // not verified during `KeyPair` construction.
-        {
-            let verify = nm.alloc_uninit();
-            let verify = self
-                .public
-                .inner()
-                .exponentiate_elem(verify, &m, cpu_features);
-            bigint::elem_verify_equal_consttime(&verify, &c)?;
-        }
+        let verify = nm.alloc_uninit();
+        let verify = self
+            .public
+            .inner()
+            .exponentiate_elem(verify, &m, cpu_features);
+        bigint::elem_verify_equal_consttime(&verify, &c)?;
 
         // Step 3 will be done by the caller.
 

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -383,11 +383,10 @@ impl KeyPair {
         // with an even modulus.
 
         // Step 7.f.
-        let q_mod_p = pm
-            .alloc_uninit()
+        pm.alloc_uninit()
             .elem_reduce_mont(&q_mod_n, pm, qim.len_bits())
-            .encode_mont(pim, cpu_features);
-        bigint::verify_inverses_consttime(q_mod_p, &qInv, pm)
+            .encode_mont(pim, cpu_features)
+            .verify_inverse_consttime(&qInv, pm)
             .map_err(|error::Unspecified| KeyRejected::inconsistent_components())?;
 
         // This should never fail since `n` and `e` were validated above.
@@ -513,8 +512,7 @@ fn elem_exp_consttime<M>(
     other_prime_len_bits: BitLength,
     cpu_features: cpu::Features,
 ) -> Result<bigint::Elem<M>, error::Unspecified> {
-    bigint::elem_exp_consttime(
-        c,
+    c.exp_consttime(
         &p.exponent,
         &p.modulus.reborrow(),
         other_prime_len_bits,
@@ -656,11 +654,10 @@ impl KeyPair {
         // minimum value, since the relationship of `e` to `d`, `p`, and `q` is
         // not verified during `KeyPair` construction.
         let verify = nm.alloc_uninit();
-        let verify = self
-            .public
+        self.public
             .inner()
-            .exponentiate_elem(verify, &m, cpu_features);
-        bigint::elem_verify_equal_consttime(&verify, &c)?;
+            .exponentiate_elem(verify, &m, cpu_features)
+            .verify_equals_consttime(&c)?;
 
         // Step 3 will be done by the caller.
 


### PR DESCRIPTION
Finish (more-or-less) the refactoring to turn standalone `bigint` functions into methods. Use chained syntax more consistently, reducing single-use variables.