### PR TITLE
bigint: Replace `Mont::elem_reduced_once` with `Ref::reduced_once`.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -224,8 +224,9 @@ mod tests {
                 let expected_result = consume_elem::<M>(&mut tmp, test_case, "r", &m);
                 let other_modulus_len_bits = m.len_bits();
                 let mut tmp = OversizedUninit::<1>::new();
-                let actual_result =
-                    m.elem_reduced_once(&mut tmp, a.as_ref(), other_modulus_len_bits);
+                let actual_result = a
+                    .as_ref()
+                    .reduced_once(&mut tmp, &m, other_modulus_len_bits);
                 assert_elem_eq(actual_result.as_ref(), expected_result.as_ref());
 
                 Ok(())

--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -360,22 +360,22 @@ impl<'l, M, E> Mut<'l, M, E> {
     }
 }
 
-impl<M> Mont<'_, M> {
-    pub fn elem_reduced_once<'out, Larger>(
-        &self,
+impl<M> Ref<'_, M, Unencoded> {
+    pub fn reduced_once<'out, Smaller>(
+        self,
         out: &'out mut OversizedUninit<1>,
-        a: Ref<'_, Larger>,
+        m: &Mont<Smaller>,
         other_modulus_len_bits: BitLength,
-    ) -> Mut<'out, M, Unencoded> {
-        assert_eq!(self.len_bits(), other_modulus_len_bits);
+    ) -> Mut<'out, Smaller, Unencoded> {
+        assert_eq!(m.len_bits(), other_modulus_len_bits);
         // TODO: We should add a variant of `limbs_reduced_once` that does the
         // reduction out-of-place, to eliminate this copy.
         let r = out
-            .write_copy_of_slice(a.limbs.as_ref(), self.num_limbs().get())
+            .write_copy_of_slice(self.limbs.as_ref(), m.num_limbs().get())
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.
-        limb::limbs_reduce_once(&mut *r, self.limbs())
+        limb::limbs_reduce_once(&mut *r, m.limbs())
             .unwrap_or_else(unwrap_impossible_len_mismatch_error);
-        Mut::<M, Unencoded>::assume_in_range_and_encoded_less_safe(r)
+        Mut::<Smaller, Unencoded>::assume_in_range_and_encoded_less_safe(r)
     }
 }
 

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -633,7 +633,7 @@ impl KeyPair {
         // Step 2.b.iii.
         let h = {
             let pm = &p.modulus(cpu_features);
-            let m_2 = pm.elem_reduced_once(tmp3, m_2.as_ref(), q.len_bits());
+            let m_2 = m_2.as_ref().reduced_once(tmp3, pm, q.len_bits());
             m_1.sub(m_2.as_ref(), pm).mul(self.qInv.as_ref(), pm)
         };
 


### PR DESCRIPTION
Follow the newer convention, similar to `Ref::reduced_mont`.