### PR TITLE
bigint: Remove `len_bits` from `BoxedIntoMont`/`IntoMont`/`Mont`.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -192,12 +192,11 @@ mod tests {
                     "A",
                     expected_result.as_ref().num_limbs() * 2,
                 );
-                let other_modulus_len_bits = m_.len_bits();
                 let mut tmp1 = OversizedUninit::<1>::new();
                 let mut tmp2 = OversizedUninit::<1>::new();
                 let actual_result = a
                     .as_ref()
-                    .reduced_mont(&mut tmp1, &m, other_modulus_len_bits, &mut tmp2)
+                    .reduced_mont(&mut tmp1, &m, &mut tmp2)
                     .encode_mont(&m_, cpu_features);
                 assert_elem_eq(actual_result.as_ref(), expected_result.as_ref());
 
@@ -224,11 +223,8 @@ mod tests {
                 let a = consume_elem_unchecked::<O>(&mut tmp, test_case, "a", m.limbs().len());
                 let mut tmp = OversizedUninit::<1>::new();
                 let expected_result = consume_elem::<M>(&mut tmp, test_case, "r", &m);
-                let other_modulus_len_bits = m.len_bits();
                 let mut tmp = OversizedUninit::<1>::new();
-                let actual_result = a
-                    .as_ref()
-                    .reduced_once(&mut tmp, &m, other_modulus_len_bits);
+                let actual_result = a.as_ref().reduced_once(&mut tmp, &m);
                 assert_elem_eq(actual_result.as_ref(), expected_result.as_ref());
 
                 Ok(())

--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -20,7 +20,6 @@ use super::{
     unwrap_impossible_limb_slice_error,
 };
 use crate::{
-    bits::BitLength,
     c, cpu,
     error::{self, LenMismatchError},
     limb::{self, Limb},
@@ -366,13 +365,13 @@ impl<'l, M, E> Mut<'l, M, E> {
 }
 
 impl<M> Ref<'_, M, Unencoded> {
-    pub fn reduced_once<'out, Smaller>(
+    // Returns self % S, assuming self < 2*S. (When P*Q=M and P and Q have the
+    // same bit length, `M.ilog2()/2`, then P < 2*Q and Q < 2*P.)
+    pub fn reduced_once<'out, P>(
         self,
         out: &'out mut OversizedUninit<1>,
-        m: &Mont<Smaller>,
-        other_modulus_len_bits: BitLength,
-    ) -> Mut<'out, Smaller, Unencoded> {
-        assert_eq!(m.len_bits(), other_modulus_len_bits);
+        m: &Mont<P>,
+    ) -> Mut<'out, P, Unencoded> {
         // TODO: We should add a variant of `limbs_reduced_once` that does the
         // reduction out-of-place, to eliminate this copy.
         let r = out
@@ -380,38 +379,35 @@ impl<M> Ref<'_, M, Unencoded> {
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.
         limb::limbs_reduce_once(&mut *r, m.limbs())
             .unwrap_or_else(unwrap_impossible_len_mismatch_error);
-        Mut::<Smaller, Unencoded>::assume_in_range_and_encoded_less_safe(r)
+        Mut::<P, Unencoded>::assume_in_range_and_encoded_less_safe(r)
     }
 }
 
-impl<'l, M, E> Ref<'l, M, E> {
+impl<'l, M> Ref<'l, M, Unencoded> {
+    // Assumes self < S*R_S where R_S is the Montgomery 1 for S, and returns
+    // self/R mod S. (When P*Q=M and P and Q have the same bit length,
+    // `M.ilog2()/2`, then P < R_Q and Q < R_P.)
     #[inline]
-    pub fn reduced_mont<'out, Smaller>(
+    pub fn reduced_mont<'out, P>(
         self,
         out: &'out mut OversizedUninit<1>,
-        m: &Mont<Smaller>,
-        other_prime_len_bits: BitLength,
+        p: &Mont<P>,
         tmp: &mut OversizedUninit<1>,
-    ) -> Mut<'out, Smaller, RInverse> {
-        // This is stricter than required mathematically but this is what we
-        // guarantee and this is easier to check. The real requirement is that
-        // that `a < m*R` where `R` is the Montgomery `R` for `m`.
-        assert_eq!(other_prime_len_bits, m.len_bits());
-
+    ) -> Mut<'out, P, RInverse> {
         // `limbs_from_mont_in_place` requires this.
-        assert_eq!(self.limbs.len(), m.limbs().len() * 2);
+        assert_eq!(self.limbs.len(), p.limbs().len() * 2);
 
         let tmp = tmp
             .write_copy_of_slice(self.limbs, self.limbs.len())
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.
         let out = out
-            .as_uninit(..m.num_limbs().get())
+            .as_uninit(..p.num_limbs().get())
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.
         out.write_fully_with(|out| {
-            limbs_from_mont_in_place(out, tmp, m.limbs(), m.n0())
+            limbs_from_mont_in_place(out, tmp, p.limbs(), p.n0())
                 .map_err(error::erase::<LenMismatchError>)
         })
-        .map(Mut::<Smaller, RInverse>::assume_in_range_and_encoded_less_safe)
+        .map(Mut::<P, RInverse>::assume_in_range_and_encoded_less_safe)
         .unwrap_or_else(|_: error::Unspecified| unreachable!())
     }
 }
@@ -421,11 +417,7 @@ impl<'l, M, E> Ref<'l, M, E> {
         self,
         out: &'out mut OversizedUninit<1>,
         m: &Mont<Larger>,
-        smaller_modulus_bits: BitLength,
     ) -> Result<Mut<'out, Larger, Unencoded>, error::Unspecified> {
-        if smaller_modulus_bits >= m.len_bits() {
-            return Err(error::Unspecified);
-        }
         let out = out
             .as_uninit(..m.num_limbs().get())
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.

--- a/src/arithmetic/bigint/exp.rs
+++ b/src/arithmetic/bigint/exp.rs
@@ -47,7 +47,6 @@ use super::{
     IntoMont, Mont, One, OversizedUninit, PrivateExponent, elem,
 };
 use crate::{
-    bits::BitLength,
     cpu,
     error::LenMismatchError,
     limb::{self, LIMB_BITS, Limb},
@@ -62,7 +61,6 @@ impl<N> elem::Ref<'_, N, Unencoded> {
         out: &'out mut OversizedUninit<1>,
         exponent: &PrivateExponent,
         p: &IntoMont<P, RRR>,
-        other_prime_len_bits: BitLength,
         tmp: &mut OversizedUninit<1>,
         cpu: cpu::Features,
     ) -> Result<elem::Mut<'out, P, Unencoded>, LimbSliceError> {
@@ -72,13 +70,7 @@ impl<N> elem::Ref<'_, N, Unencoded> {
         // `elem_exp_consttime_inner` is parameterized on `STORAGE_LIMBS` only so
         // we can run tests with larger-than-supported-in-operation test vectors.
         elem_exp_consttime_inner::<N, P, { ELEM_EXP_CONSTTIME_MAX_MODULUS_LIMBS * STORAGE_ENTRIES }>(
-            out,
-            self,
-            &oneRRR,
-            exponent,
-            p,
-            other_prime_len_bits,
-            tmp,
+            out, self, &oneRRR, exponent, p, tmp,
         )
     }
 }
@@ -99,7 +91,6 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
     oneRRR: &One<'_, M, RRR>,
     exponent: &PrivateExponent,
     m: &Mont<M>,
-    other_prime_len_bits: BitLength,
     tmp: &mut OversizedUninit<1>,
 ) -> Result<elem::Mut<'out, M, Unencoded>, LimbSliceError> {
     use super::{
@@ -111,7 +102,7 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
         polyfill::{StartMutPtr, dynarray},
     };
 
-    let base_rinverse = base_mod_n.reduced_mont(out, m, other_prime_len_bits, tmp);
+    let base_rinverse = base_mod_n.reduced_mont(out, m, tmp);
 
     let num_limbs = m.num_limbs();
     if num_limbs.get() % limbs512::LIMBS_PER_CHUNK != 0 {
@@ -163,7 +154,10 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
         |init, uninit| {
             let r: Result<&'_ mut [Limb], LimbSliceError> = match init.len() {
                 // table[0] = base**0 (i.e. 1).
-                0 => Ok(One::write_mont_identity(&mut uninit.into_cursor(), m)?),
+                0 => Ok(One::write_mont_identity_assuming_full_upper_limb(
+                    &mut uninit.into_cursor(),
+                    m,
+                )?),
 
                 // table[1] = base*R == (base/R * RRR)/R
                 1 => limbs_mul_mont(
@@ -227,7 +221,6 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
     oneRRR: &One<M, RRR>,
     exponent: &PrivateExponent,
     m: &Mont<M>,
-    other_prime_len_bits: BitLength,
     tmp: &mut OversizedUninit<1>,
 ) -> Result<elem::Mut<'out, M, Unencoded>, LimbSliceError> {
     use super::{
@@ -307,8 +300,7 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
         .into_written()
         .as_chunks();
 
-    let base_mod_m: elem::Mut<'_, M, RInverse> =
-        base_mod_n.reduced_mont(out, m, other_prime_len_bits, tmp);
+    let base_mod_m: elem::Mut<'_, M, RInverse> = base_mod_n.reduced_mont(out, m, tmp);
     let base_rinverse = base_mod_m.leak_limbs_less_safe();
 
     // base_cached = base*R == (base/R * RRR)/R
@@ -345,7 +337,10 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
     // All entries in `table` will be Montgomery encoded.
 
     // t0 = table[0] = base**0 (i.e. 1).
-    let t0 = One::write_mont_identity(&mut acc.reborrow_mut().into_cursor(), m)?;
+    let t0 = One::write_mont_identity_assuming_full_upper_limb(
+        &mut acc.reborrow_mut().into_cursor(),
+        m,
+    )?;
     scatter5(t0, table, LeakyWindow5::_0)?;
 
     // acc = base**1 (i.e. base).
@@ -433,7 +428,6 @@ mod tests {
                 // some other prime of the same length. Fake that here.
                 // Pretend there's another prime of equal length.
                 struct N {}
-                let other_modulus_len_bits = m.len_bits();
                 let mut tmp = OversizedUninit::<1>::new();
                 let base = tmp
                     .as_uninit(..(base.as_ref().num_limbs() * 2))
@@ -451,20 +445,13 @@ mod tests {
                 let mut actual_result_2 = OversizedUninit::new();
                 let mut tmp = OversizedUninit::new();
                 let actual_result = if !too_big {
-                    base.as_ref().exp_consttime(
-                        &mut actual_result,
-                        &e,
-                        im,
-                        other_modulus_len_bits,
-                        &mut tmp,
-                        cpu_features,
-                    )
+                    base.as_ref()
+                        .exp_consttime(&mut actual_result, &e, im, &mut tmp, cpu_features)
                 } else {
                     let actual_result = base.as_ref().exp_consttime(
                         &mut actual_result,
                         &e,
                         im,
-                        other_modulus_len_bits,
                         &mut tmp,
                         cpu_features,
                     );
@@ -477,7 +464,6 @@ mod tests {
                         &im.one(),
                         &e,
                         &m,
-                        other_modulus_len_bits,
                         &mut tmp,
                     )
                 };

--- a/src/arithmetic/bigint/modulus/mont.rs
+++ b/src/arithmetic/bigint/modulus/mont.rs
@@ -24,13 +24,16 @@ use super::{
     },
     ValidatedInput,
 };
-use crate::polyfill::slice::Cursor;
 use crate::{
     bits::BitLength,
     cpu,
     error::{self, LenMismatchError},
     limb::{self, LIMB_BITS, Limb},
-    polyfill::{LeadingZerosStripped, slice::Uninit},
+    polyfill::{
+        LeadingZerosStripped,
+        slice::{Cursor, Uninit},
+        usize_from_u32,
+    },
 };
 use core::{marker::PhantomData, num::NonZero};
 
@@ -43,7 +46,6 @@ use alloc::boxed::Box;
 /// the modular inversion code.
 pub struct IntoMont<'a, M, E> {
     storage: &'a [Limb],
-    len_bits: BitLength,
     n0: N0,
     m: PhantomData<M>,
     encoding: PhantomData<E>,
@@ -52,7 +54,6 @@ pub struct IntoMont<'a, M, E> {
 #[cfg(feature = "alloc")]
 pub struct BoxedIntoMont<M, E> {
     storage: Box<[Limb]>,
-    len_bits: BitLength,
     n0: N0,
     m: PhantomData<M>,
     encoding: PhantomData<E>,
@@ -64,7 +65,6 @@ impl<M: PublicModulus, E> Clone for BoxedIntoMont<M, E> {
         Self {
             storage: self.storage.clone(),
             n0: self.n0,
-            len_bits: self.len_bits,
             m: self.m,
             encoding: self.encoding,
         }
@@ -76,7 +76,6 @@ impl<M, E> BoxedIntoMont<M, E> {
     pub fn reborrow(&self) -> IntoMont<'_, M, E> {
         IntoMont {
             storage: &self.storage,
-            len_bits: self.len_bits,
             n0: self.n0,
             m: self.m,
             encoding: PhantomData,
@@ -93,7 +92,6 @@ impl ValidatedInput<'_> {
         let mut cursor = borrowed.into_cursor();
         let IntoMont {
             storage: _,
-            len_bits,
             n0,
             m,
             encoding,
@@ -106,7 +104,6 @@ impl ValidatedInput<'_> {
         let storage = unsafe { uninit.assume_init() };
         BoxedIntoMont {
             storage,
-            len_bits,
             n0,
             m,
             encoding,
@@ -129,16 +126,15 @@ impl ValidatedInput<'_> {
     ) -> Result<IntoMont<'o, M, RR>, LenMismatchError> {
         let (storage, n0) = out.try_write_with(|out| {
             let value = out.write_iter(self.limbs()).src_empty()?.into_written();
-            let value = Value::<M>::from_limbs_unchecked_less_safe(value, self.len_bits());
+            let value = Value::<M>::from_limbs_unchecked_less_safe(value);
             let n0 = N0::calculate_from(&value);
             let m = &Mont::from_parts_unchecked_less_safe(value, &n0, cpu);
-            let one = One::write_mont_identity(out, m)?;
+            let one = One::write_mont_identity(out, m, self.len_bits())?;
             One::mul_r(one, m)?;
             Ok(n0)
         })?;
         Ok(IntoMont {
             storage,
-            len_bits: self.len_bits(),
             n0,
             m: PhantomData,
             encoding: PhantomData,
@@ -173,7 +169,7 @@ impl N0 {
 impl<'a, M, E> IntoMont<'a, M, E> {
     fn value(&self) -> Value<'_, M> {
         let (value, _) = self.parts();
-        Value::from_limbs_unchecked_less_safe(value, self.len_bits)
+        Value::from_limbs_unchecked_less_safe(value)
     }
 
     fn parts(&self) -> (&'a [Limb], &'a [Limb]) {
@@ -202,7 +198,7 @@ impl<'a, M, E> IntoMont<'a, M, E> {
 
     pub(crate) fn modulus(&self, cpu_features: cpu::Features) -> Mont<'_, M> {
         let (value, _) = self.parts();
-        let value = Value::from_limbs_unchecked_less_safe(value, self.len_bits());
+        let value = Value::from_limbs_unchecked_less_safe(value);
         Mont::from_parts_unchecked_less_safe(value, &self.n0, cpu_features)
     }
 
@@ -210,9 +206,18 @@ impl<'a, M, E> IntoMont<'a, M, E> {
         let (_, one) = self.parts();
         One::<M, E>::from_limbs_unchecked_less_safe(one)
     }
+}
 
-    pub fn len_bits(&self) -> BitLength {
-        self.len_bits
+impl<'a, M: PublicModulus, E> IntoMont<'a, M, E> {
+    pub fn len_bits_vartime(&self) -> BitLength {
+        let (value, _) = self.parts();
+        let leading_zero_bits = value
+            .last()
+            .map(|high| usize_from_u32(high.leading_zeros()))
+            .unwrap_or(0);
+        // TODO: Can't overflow because.
+        let total_bits = value.len() * LIMB_BITS;
+        BitLength::from_bits(total_bits - leading_zero_bits)
     }
 }
 
@@ -220,21 +225,16 @@ impl<'a, M, E> IntoMont<'a, M, E> {
 impl<M> BoxedIntoMont<M, RR> {
     pub(crate) fn intoRRR(self, cpu: cpu::Features) -> BoxedIntoMont<M, RRR> {
         let Self {
-            mut storage,
-            n0,
-            len_bits,
-            m,
-            ..
+            mut storage, n0, m, ..
         } = self;
         let (value, one) = IntoMont::<M, RR>::parts_mut(storage.as_mut());
-        let value = Value::<M>::from_limbs_unchecked_less_safe(value, len_bits);
+        let value = Value::<M>::from_limbs_unchecked_less_safe(value);
         let mm = Mont::from_parts_unchecked_less_safe(value, &self.n0, cpu);
         let _: &[Limb] = limbs_square_mont(one, mm.limbs(), &self.n0, cpu)
             .unwrap_or_else(unwrap_impossible_limb_slice_error);
         BoxedIntoMont {
             storage,
             n0,
-            len_bits,
             m,
             encoding: PhantomData,
         }
@@ -283,10 +283,6 @@ impl<M> Mont<'_, M> {
 
     pub fn num_limbs(&self) -> NonZero<usize> {
         NonZero::new(self.limbs().len()).unwrap_or_else(|| unreachable!())
-    }
-
-    pub fn len_bits(&self) -> BitLength {
-        self.value.len_bits()
     }
 
     #[inline]

--- a/src/arithmetic/bigint/modulus/one.rs
+++ b/src/arithmetic/bigint/modulus/one.rs
@@ -20,6 +20,7 @@ use super::super::{
     Limb, Mont, unwrap_impossible_len_mismatch_error, unwrap_impossible_limb_slice_error,
 };
 use crate::{
+    bits::BitLength,
     error::LenMismatchError,
     limb::{self, LIMB_BITS},
     polyfill::slice::Cursor,
@@ -48,18 +49,23 @@ impl<M, E> One<'_, M, E> {
 }
 
 impl<M> One<'_, M, R> {
-    /// Writes the value of the Montgomery multiplication identity `R` for `m` to
-    /// `out`.
-    pub(in super::super) fn write_mont_identity<'r>(
+    pub(in super::super) fn write_mont_identity_assuming_full_upper_limb<'r>(
         out: &mut Cursor<'r, Limb>,
         m: &Mont<'_, M>,
     ) -> Result<&'r mut [Limb], LenMismatchError> {
-        let r = m.limbs().len() * LIMB_BITS;
-
         // out = 2**r - m where m = self.
-        let out = limb::write_negative_assume_odd(out, m.limbs())?;
+        limb::write_negative_assume_odd(out, m.limbs())
+    }
 
-        let lg_m = m.len_bits().as_bits();
+    pub(in super::super) fn write_mont_identity<'r>(
+        out: &mut Cursor<'r, Limb>,
+        m: &Mont<'_, M>,
+        m_bit_len: BitLength,
+    ) -> Result<&'r mut [Limb], LenMismatchError> {
+        let out = Self::write_mont_identity_assuming_full_upper_limb(out, m)?;
+
+        let r = m.limbs().len() * LIMB_BITS;
+        let lg_m = m_bit_len.as_bits();
         let leading_zero_bits_in_m = r - lg_m;
 
         // When m's length is a multiple of LIMB_BITS, which is the case we

--- a/src/arithmetic/bigint/modulus/value.rs
+++ b/src/arithmetic/bigint/modulus/value.rs
@@ -26,7 +26,6 @@ use core::marker::PhantomData;
 /// `OwnedModulus`, without the overhead of Montgomery multiplication support.
 pub(crate) struct Value<'a, M> {
     limbs: &'a [Limb], // Also `value >= 3`.
-    len_bits: BitLength,
     m: PhantomData<M>,
 }
 
@@ -109,19 +108,11 @@ impl<'a> ValidatedInput<'a> {
 }
 
 impl<M> Value<'_, M> {
-    pub(super) fn from_limbs_unchecked_less_safe(
-        limbs: &[Limb],
-        len_bits: BitLength,
-    ) -> Value<'_, M> {
+    pub(super) fn from_limbs_unchecked_less_safe(limbs: &[Limb]) -> Value<'_, M> {
         Value {
             limbs,
-            len_bits,
             m: PhantomData,
         }
-    }
-
-    pub fn len_bits(&self) -> BitLength {
-        self.len_bits
     }
 
     #[inline]

--- a/src/rsa/base/public_modulus.rs
+++ b/src/rsa/base/public_modulus.rs
@@ -108,7 +108,7 @@ impl PublicModulus<bigint::IntoMont<'_, N, RR>> {
 
     /// The length of the modulus in bits.
     pub fn len_bits(&self) -> bits::BitLength {
-        self.value.len_bits()
+        self.value.len_bits_vartime()
     }
 
     pub(in super::super) fn value(&self) -> &bigint::IntoMont<'_, N, RR> {

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -383,7 +383,7 @@ impl KeyPair {
         // Step 7.f.
         q_mod_n
             .as_ref()
-            .reduced_mont(&mut tmp2, pm, qim.len_bits(), &mut tmp3)
+            .reduced_mont(&mut tmp2, pm, &mut tmp3)
             .encode_mont(pim, cpu_features)
             .verify_inverse_consttime(qInv.as_ref(), pm)
             .map_err(|error::Unspecified| KeyRejected::inconsistent_components())?;
@@ -509,19 +509,11 @@ fn elem_exp_consttime<'out, M>(
     out: &'out mut bigint::OversizedUninit<1>,
     c: bigint::elem::Ref<'_, N>,
     p: &PrivateCrtPrime<M>,
-    other_prime_len_bits: BitLength,
     tmp: &mut bigint::OversizedUninit<1>,
     cpu_features: cpu::Features,
 ) -> Result<bigint::elem::Mut<'out, M>, error::Unspecified> {
-    c.exp_consttime(
-        out,
-        &p.exponent,
-        &p.modulus.reborrow(),
-        other_prime_len_bits,
-        tmp,
-        cpu_features,
-    )
-    .map_err(error::erase::<LimbSliceError>)
+    c.exp_consttime(out, &p.exponent, &p.modulus.reborrow(), tmp, cpu_features)
+        .map_err(error::erase::<LimbSliceError>)
 }
 
 // Type-level representations of the different moduli used in RSA signing, in
@@ -626,15 +618,15 @@ impl KeyPair {
         let tmp3 = &mut *out; // Abuse `out` for temporary storage.
 
         // Step 2.b.i.
-        let m_1 = elem_exp_consttime(&mut tmp1, c, &self.p, q.len_bits(), tmp3, cpu_features)?;
-        let m_2 = elem_exp_consttime(&mut tmp2, c, &self.q, p.len_bits(), tmp3, cpu_features)?;
+        let m_1 = elem_exp_consttime(&mut tmp1, c, &self.p, tmp3, cpu_features)?;
+        let m_2 = elem_exp_consttime(&mut tmp2, c, &self.q, tmp3, cpu_features)?;
 
         // Step 2.b.ii isn't needed since there are only two primes.
 
         // Step 2.b.iii.
         let h = {
             let pm = &p.modulus(cpu_features);
-            let m_2 = m_2.as_ref().reduced_once(tmp3, pm, q.len_bits());
+            let m_2 = m_2.as_ref().reduced_once(tmp3, pm);
             m_1.sub(m_2.as_ref(), pm).mul(self.qInv.as_ref(), pm)
         };
 
@@ -642,17 +634,15 @@ impl KeyPair {
         // necessary because `h < p` and `p * q == n` implies `h * q < n`.
         // Modular arithmetic is used simply to avoid implementing
         // non-modular arithmetic.
-        let h = h.as_ref().widen(tmp3, nm, p.len_bits())?;
+        let h = h.as_ref().widen(tmp3, nm)?;
         let q_times_h = q
             .to_elem(&mut tmp1, nm)
             .map_err(|error::Unspecified| KeyRejected::inconsistent_components())?
             .encode_mont(n, cpu_features)
             .mul(h.as_ref(), nm);
         // Stop abusing `out`; `tmp3` is no longer available.
-        let m: bigint::elem::Mut<'out, _> = m_2
-            .as_ref()
-            .widen(out, nm, q.len_bits())?
-            .add(q_times_h.as_ref(), nm);
+        let m: bigint::elem::Mut<'out, _> =
+            m_2.as_ref().widen(out, nm)?.add(q_times_h.as_ref(), nm);
 
         // Step 2.b.v isn't needed since there are only two primes.
 


### PR DESCRIPTION
`len_bits` was used primarily to document assumptions in some functions. Instead, just document those constraints with comments.