### PR TITLE
bigint: Split `OversizedUninit` into two types.

### DIFF
--- a/src/arithmetic/bigint.rs
+++ b/src/arithmetic/bigint.rs
@@ -39,10 +39,7 @@
 #[allow(unused_imports)]
 use crate::polyfill::prelude::*;
 
-pub(crate) use self::{
-    modulus::{IntoMont, Mont, One},
-    oversized_uninit::OversizedUninit,
-};
+pub(crate) use self::modulus::{IntoMont, Mont, One};
 use super::{LimbSliceError, MAX_LIMBS, montgomery::*};
 use crate::{
     error::{self, LenMismatchError},
@@ -119,15 +116,15 @@ mod tests {
             |section, test_case| {
                 assert_eq!(section, "");
 
-                let mut tmp = OversizedUninit::<2>::new();
+                let mut tmp = modulus::OversizedUninit::new();
                 let m_owned = consume_modulus::<M>(&mut tmp, test_case, "M");
                 let m = m_owned.modulus(cpu_features);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let expected_result = consume_elem(&mut tmp, test_case, "ModMul", &m);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let a =
                     consume_elem(&mut tmp, test_case, "A", &m).encode_mont(&m_owned, cpu_features);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let b =
                     consume_elem(&mut tmp, test_case, "B", &m).encode_mont(&m_owned, cpu_features);
                 let actual_result = a.mul(b.as_ref(), &m);
@@ -149,16 +146,16 @@ mod tests {
             |section, test_case| {
                 assert_eq!(section, "");
 
-                let mut tmp = OversizedUninit::<2>::new();
+                let mut tmp = modulus::OversizedUninit::new();
                 let m_owned = consume_modulus::<M>(&mut tmp, test_case, "M");
                 let m = m_owned.modulus(cpu_features);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let expected_result = consume_elem(&mut tmp, test_case, "ModSquare", &m);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let a =
                     consume_elem(&mut tmp, test_case, "A", &m).encode_mont(&m_owned, cpu_features);
                 let actual_result = a.square(&m);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let actual_result = actual_result
                     .into_unencoded(&m, &mut tmp)
                     .unwrap_or_else(|LenMismatchError { .. }| unreachable!());
@@ -179,20 +176,20 @@ mod tests {
 
                 struct M {}
 
-                let mut tmp = OversizedUninit::<2>::new();
+                let mut tmp = modulus::OversizedUninit::new();
                 let m_ = consume_modulus::<M>(&mut tmp, test_case, "M");
                 let m = m_.modulus(cpu_features);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let expected_result = consume_elem(&mut tmp, test_case, "R", &m);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let a = consume_elem_unchecked::<M>(
                     &mut tmp,
                     test_case,
                     "A",
                     expected_result.as_ref().num_limbs() * 2,
                 );
-                let mut tmp1 = OversizedUninit::<1>::new();
-                let mut tmp2 = OversizedUninit::<1>::new();
+                let mut tmp1 = elem::OversizedUninit::new();
+                let mut tmp2 = elem::OversizedUninit::new();
                 let actual_result = a
                     .as_ref()
                     .reduced_mont(&mut tmp1, &m, &mut tmp2)
@@ -215,14 +212,14 @@ mod tests {
                 struct M {}
                 struct O {}
 
-                let mut tmp = OversizedUninit::<2>::new();
+                let mut tmp = modulus::OversizedUninit::new();
                 let m = consume_modulus::<M>(&mut tmp, test_case, "m");
                 let m = m.modulus(cpu_features);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let a = consume_elem_unchecked::<O>(&mut tmp, test_case, "a", m.limbs().len());
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let expected_result = consume_elem::<M>(&mut tmp, test_case, "r", &m);
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let actual_result = a.as_ref().reduced_once(&mut tmp, &m);
                 assert_elem_eq(actual_result.as_ref(), expected_result.as_ref());
 

--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -16,7 +16,7 @@
 use crate::polyfill::prelude::*;
 
 use super::{
-    super::montgomery::*, IntoMont, Mont, OversizedUninit, unwrap_impossible_len_mismatch_error,
+    super::montgomery::*, IntoMont, Mont, unwrap_impossible_len_mismatch_error,
     unwrap_impossible_limb_slice_error,
 };
 use crate::{
@@ -29,6 +29,9 @@ use crate::{
     },
 };
 use core::{iter, marker::PhantomData, num::NonZero};
+
+// TODO: Move here?
+pub(crate) use super::oversized_uninit::OversizedUninit;
 
 /// A boxed `Mut`.
 #[cfg(feature = "alloc")]
@@ -149,7 +152,7 @@ impl<'l, M> Mut<'l, M, Unencoded> {
     }
 
     pub fn from_be_bytes_padded(
-        out: &'l mut OversizedUninit<1>,
+        out: &'l mut OversizedUninit,
         input: untrusted::Input<'_>,
         m: &Mont<M>,
     ) -> Result<Self, error::Unspecified> {
@@ -213,7 +216,7 @@ impl<'l, M, E> Ref<'l, M, E> {
         self.limbs
     }
 
-    pub fn clone_into<'out>(&self, out: &'out mut OversizedUninit<1>) -> Mut<'out, M, E> {
+    pub fn clone_into<'out>(&self, out: &'out mut OversizedUninit) -> Mut<'out, M, E> {
         let limbs = out
             .write_copy_of_slice(self.limbs, self.limbs.len())
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.
@@ -229,7 +232,7 @@ impl<'l, M, E> Ref<'l, M, E> {
 impl<'l, M> MutAmm<'l, M> {
     #[cfg(target_arch = "x86_64")]
     pub(super) fn copy_from_limbs_assume_amm_and_encoded(
-        out: &'l mut OversizedUninit<1>,
+        out: &'l mut OversizedUninit,
         src: &mut [Limb],
     ) -> Result<Self, LenMismatchError> {
         let limbs = out.write_copy_of_slice(src, src.len())?;
@@ -246,7 +249,7 @@ impl<'l, M> MutAmm<'l, M> {
     pub(super) fn reduced_mont(
         self,
         m: &Mont<M>,
-        tmp: &mut OversizedUninit<1>,
+        tmp: &mut OversizedUninit,
     ) -> Result<Mut<'l, M, Unencoded>, LenMismatchError> {
         if self.limbs.len() != m.num_limbs().get() {
             return Err(LenMismatchError::new(self.limbs.len()));
@@ -274,7 +277,7 @@ impl<'l, M> Mut<'l, M, R> {
     pub fn into_unencoded(
         self,
         m: &Mont<M>,
-        tmp: &mut OversizedUninit<1>,
+        tmp: &mut OversizedUninit,
     ) -> Result<Mut<'l, M, Unencoded>, LenMismatchError> {
         let amm = MutAmm {
             limbs: self.limbs,
@@ -373,7 +376,7 @@ impl<M> Ref<'_, M, Unencoded> {
     // same bit length, `M.ilog2()/2`, then P < 2*Q and Q < 2*P.)
     pub fn reduced_once<'out, P>(
         self,
-        out: &'out mut OversizedUninit<1>,
+        out: &'out mut OversizedUninit,
         m: &Mont<P>,
     ) -> Mut<'out, P, Unencoded> {
         // TODO: We should add a variant of `limbs_reduced_once` that does the
@@ -394,9 +397,9 @@ impl<'l, M> Ref<'l, M, Unencoded> {
     #[inline]
     pub fn reduced_mont<'out, P>(
         self,
-        out: &'out mut OversizedUninit<1>,
+        out: &'out mut OversizedUninit,
         p: &Mont<P>,
-        tmp: &mut OversizedUninit<1>,
+        tmp: &mut OversizedUninit,
     ) -> Mut<'out, P, RInverse> {
         // `limbs_from_mont_in_place` requires this.
         assert_eq!(self.limbs.len(), p.limbs().len() * 2);
@@ -417,7 +420,7 @@ impl<'l, M> Ref<'l, M, Unencoded> {
 impl<'l, M, E> Ref<'l, M, E> {
     pub fn widen<'out, Larger>(
         self,
-        out: &'out mut OversizedUninit<1>,
+        out: &'out mut OversizedUninit,
         m: &Mont<Larger>,
     ) -> Result<Mut<'out, Larger, Unencoded>, error::Unspecified> {
         let out = out
@@ -497,7 +500,7 @@ pub mod testutil {
     use super::*;
 
     pub fn consume_elem<'out, M>(
-        out: &'out mut OversizedUninit<1>,
+        out: &'out mut OversizedUninit,
         test_case: &mut crate::testutil::TestCase,
         name: &str,
         m: &Mont<M>,
@@ -507,7 +510,7 @@ pub mod testutil {
     }
 
     pub fn consume_elem_unchecked<'out, M>(
-        out: &'out mut OversizedUninit<1>,
+        out: &'out mut OversizedUninit,
         test_case: &mut crate::testutil::TestCase,
         name: &str,
         num_limbs: usize,

--- a/src/arithmetic/bigint/exp.rs
+++ b/src/arithmetic/bigint/exp.rs
@@ -44,7 +44,7 @@ use super::{
         LimbSliceError, limbs512,
         montgomery::{RRR, Unencoded},
     },
-    IntoMont, Mont, One, OversizedUninit, PrivateExponent, elem,
+    IntoMont, Mont, One, PrivateExponent, elem,
 };
 use crate::{
     cpu,
@@ -58,10 +58,10 @@ use core::mem::MaybeUninit;
 impl<N> elem::Ref<'_, N, Unencoded> {
     pub(crate) fn exp_consttime<'out, P>(
         self,
-        out: &'out mut OversizedUninit<1>,
+        out: &'out mut elem::OversizedUninit,
         exponent: &PrivateExponent,
         p: &IntoMont<P, RRR>,
-        tmp: &mut OversizedUninit<1>,
+        tmp: &mut elem::OversizedUninit,
         cpu: cpu::Features,
     ) -> Result<elem::Mut<'out, P, Unencoded>, LimbSliceError> {
         let oneRRR = p.one();
@@ -86,12 +86,12 @@ const STORAGE_ENTRIES: usize = TABLE_ENTRIES + if cfg!(target_arch = "x86_64") {
 
 #[cfg(not(target_arch = "x86_64"))]
 fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
-    out: &'out mut OversizedUninit<1>,
+    out: &'out mut elem::OversizedUninit,
     base_mod_n: elem::Ref<'_, N, Unencoded>,
     oneRRR: &One<'_, M, RRR>,
     exponent: &PrivateExponent,
     m: &Mont<M>,
-    tmp: &mut OversizedUninit<1>,
+    tmp: &mut elem::OversizedUninit,
 ) -> Result<elem::Mut<'out, M, Unencoded>, LimbSliceError> {
     use super::{
         super::montgomery::{R, limbs_mul_mont, limbs_square_mont},
@@ -217,12 +217,12 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
 
 #[cfg(target_arch = "x86_64")]
 fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
-    out: &'out mut OversizedUninit<1>,
+    out: &'out mut elem::OversizedUninit,
     base_mod_n: elem::Ref<'_, N, Unencoded>,
     oneRRR: &One<M, RRR>,
     exponent: &PrivateExponent,
     m: &Mont<M>,
-    tmp: &mut OversizedUninit<1>,
+    tmp: &mut elem::OversizedUninit,
 ) -> Result<elem::Mut<'out, M, Unencoded>, LimbSliceError> {
     use super::{
         super::{
@@ -414,8 +414,8 @@ mod tests {
                     .intoRRR(cpu_features);
                 let im = &im.reborrow();
                 let m = im.modulus(cpu_features);
-                let mut tmp1 = OversizedUninit::<1>::new();
-                let mut tmp2 = OversizedUninit::<1>::new();
+                let mut tmp1 = elem::OversizedUninit::new();
+                let mut tmp2 = elem::OversizedUninit::new();
                 let expected_result = consume_elem(&mut tmp1, test_case, "ModExp", &m);
                 let base = consume_elem(&mut tmp2, test_case, "A", &m);
                 let e = {
@@ -429,7 +429,7 @@ mod tests {
                 // some other prime of the same length. Fake that here.
                 // Pretend there's another prime of equal length.
                 struct N {}
-                let mut tmp = OversizedUninit::<1>::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let base = tmp
                     .as_uninit(..(base.as_ref().num_limbs() * 2))
                     .unwrap_or_else(unwrap_impossible_len_mismatch_error)
@@ -442,9 +442,9 @@ mod tests {
                     elem::Mut::assume_in_range_and_encoded_less_safe(base);
 
                 let too_big = m.limbs().len() > ELEM_EXP_CONSTTIME_MAX_MODULUS_LIMBS;
-                let mut actual_result = OversizedUninit::new();
-                let mut actual_result_2 = OversizedUninit::new();
-                let mut tmp = OversizedUninit::new();
+                let mut actual_result = elem::OversizedUninit::new();
+                let mut actual_result_2 = elem::OversizedUninit::new();
+                let mut tmp = elem::OversizedUninit::new();
                 let actual_result = if !too_big {
                     base.as_ref()
                         .exp_consttime(&mut actual_result, &e, im, &mut tmp, cpu_features)

--- a/src/arithmetic/bigint/modulus/mod.rs
+++ b/src/arithmetic/bigint/modulus/mod.rs
@@ -5,7 +5,7 @@ pub(super) mod testutil;
 mod value;
 
 pub(crate) use self::{
-    mont::{IntoMont, Mont},
+    mont::{IntoMont, Mont, OversizedUninit},
     one::One,
     value::ValidatedInput,
 };

--- a/src/arithmetic/bigint/modulus/mont.rs
+++ b/src/arithmetic/bigint/modulus/mont.rs
@@ -18,7 +18,7 @@ use crate::polyfill::prelude::*;
 use super::{
     super::{
         super::montgomery::{RR, RRR, Unencoded},
-        N0, One, OversizedUninit, PublicModulus, elem,
+        MAX_LIMBS, N0, One, PublicModulus, elem,
         modulus::value::Value,
     },
     ValidatedInput,
@@ -34,7 +34,7 @@ use crate::{
         usize_from_u32,
     },
 };
-use core::{marker::PhantomData, num::NonZero};
+use core::{marker::PhantomData, mem::MaybeUninit, num::NonZero};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
@@ -82,11 +82,23 @@ impl<M, E> BoxedIntoMont<M, E> {
     }
 }
 
+pub struct OversizedUninit([MaybeUninit<Limb>; Self::CAPACITY]);
+
+impl OversizedUninit {
+    const CAPACITY: usize = into_mont_storage_len_from_num_limbs(MAX_LIMBS).unwrap();
+
+    pub const fn new() -> Self {
+        Self([const { MaybeUninit::uninit() }; Self::CAPACITY])
+    }
+}
+
 impl ValidatedInput<'_> {
     #[cfg(feature = "alloc")]
     pub(crate) fn build_boxed_into_mont<M>(&self, cpu: cpu::Features) -> BoxedIntoMont<M, RR> {
         let limbs = self.limbs();
-        let mut uninit = Box::new_uninit_slice(limbs.len() * 2);
+        let storage_len =
+            into_mont_storage_len_from_num_limbs(limbs.len()).unwrap_or_else(|| unreachable!()); // Because `MAX_LIMBS` is small.
+        let mut uninit = Box::new_uninit_slice(storage_len);
         let borrowed = Uninit::from(uninit.as_mut());
         let mut cursor = borrowed.into_cursor();
         let IntoMont {
@@ -111,11 +123,14 @@ impl ValidatedInput<'_> {
 
     pub(crate) fn build_into_mont<'o, M>(
         &self,
-        uninit: &'o mut OversizedUninit<2>,
+        uninit: &'o mut OversizedUninit,
         cpu: cpu::Features,
     ) -> IntoMont<'o, M, RR> {
-        self.write_into_mont(&mut uninit.as_uninit_whole().into_cursor(), cpu)
-            .unwrap_or_else(|LenMismatchError { .. }| unreachable!())
+        self.write_into_mont(
+            &mut Uninit::from(uninit.0.as_mut_slice()).into_cursor(),
+            cpu,
+        )
+        .unwrap_or_else(|LenMismatchError { .. }| unreachable!())
     }
 
     fn write_into_mont<'o, M>(
@@ -139,6 +154,10 @@ impl ValidatedInput<'_> {
             encoding: PhantomData,
         })
     }
+}
+
+const fn into_mont_storage_len_from_num_limbs(num_limbs: usize) -> Option<usize> {
+    num_limbs.checked_add(num_limbs)
 }
 
 impl N0 {
@@ -184,7 +203,7 @@ impl<'a, M, E> IntoMont<'a, M, E> {
 
     pub fn to_elem<'l, L>(
         &self,
-        out: &'l mut OversizedUninit<1>,
+        out: &'l mut elem::OversizedUninit,
         l: &Mont<L>,
     ) -> Result<elem::Mut<'l, L, Unencoded>, error::Unspecified> {
         let limbs = out

--- a/src/arithmetic/bigint/modulus/testutil.rs
+++ b/src/arithmetic/bigint/modulus/testutil.rs
@@ -1,11 +1,12 @@
 use super::super::super::montgomery::RR;
 use super::*;
-use crate::arithmetic::bigint::OversizedUninit;
-use crate::cpu;
-use crate::error::{self, KeyRejected};
+use crate::{
+    cpu,
+    error::{self, KeyRejected},
+};
 
 pub fn consume_modulus<'out, M>(
-    out: &'out mut OversizedUninit<2>,
+    out: &'out mut OversizedUninit,
     test_case: &mut crate::testutil::TestCase,
     name: &str,
 ) -> IntoMont<'out, M, RR> {

--- a/src/arithmetic/bigint/oversized_uninit.rs
+++ b/src/arithmetic/bigint/oversized_uninit.rs
@@ -21,19 +21,15 @@ use core::{mem::MaybeUninit, ops::RangeTo};
 
 /// A buffer that has enough space to hold `N` values of the maximum size,
 /// hiding the representation of values from the user.
-pub struct OversizedUninit<const N: usize>([[MaybeUninit<Limb>; MAX_LIMBS]; N]);
+pub struct OversizedUninit([MaybeUninit<Limb>; MAX_LIMBS]);
 
-impl<const N: usize> OversizedUninit<N> {
+impl OversizedUninit {
     pub fn new() -> Self {
         Self(unsafe { MaybeUninit::uninit().assume_init() })
     }
 
-    pub(super) fn as_uninit_whole(&mut self) -> Uninit<'_, Limb> {
-        Uninit::from(self.0.as_flattened_mut())
-    }
-
     pub fn as_uninit(&mut self, len: RangeTo<usize>) -> Result<Uninit<'_, Limb>, LenMismatchError> {
-        self.as_uninit_whole()
+        Uninit::from(self.0.as_mut_slice())
             .split_off_mut(len)
             .ok_or_else(|| LenMismatchError::new(len.end))
     }

--- a/src/arithmetic/exp_vartime.rs
+++ b/src/arithmetic/exp_vartime.rs
@@ -13,7 +13,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use super::{
-    bigint::{Mont, OversizedUninit, elem},
+    bigint::{Mont, elem},
     montgomery::R,
 };
 use core::num::NonZero;
@@ -30,7 +30,7 @@ use core::num::NonZero;
 impl<M> elem::Ref<'_, M, R> {
     pub(crate) fn exp_vartime<'out>(
         self,
-        out: &'out mut OversizedUninit<1>,
+        out: &'out mut elem::OversizedUninit,
         exponent: NonZero<u64>,
         m: &Mont<M>,
     ) -> elem::Mut<'out, M, R> {

--- a/src/rsa/base/public_key.rs
+++ b/src/rsa/base/public_key.rs
@@ -87,7 +87,7 @@ impl<'a> ValidatedInput<'a> {
 
     pub(in super::super) fn build<'o>(
         &self,
-        out: &'o mut bigint::OversizedUninit<2>,
+        out: &'o mut bigint::modulus::OversizedUninit,
         cpu: cpu::Features,
     ) -> PublicKey<bigint::IntoMont<'o, N, RR>> {
         PublicKey {
@@ -145,15 +145,15 @@ impl PublicKey<bigint::IntoMont<'_, N, RR>> {
         // RFC 8017 Section 5.2.2: RSAVP1.
 
         // Step 1.
-        let mut s = bigint::OversizedUninit::new();
+        let mut s = bigint::elem::OversizedUninit::new();
         let s = bigint::elem::Mut::from_be_bytes_padded(&mut s, base, n)?;
         if s.as_ref().is_zero() {
             return Err(error::Unspecified);
         }
 
         // Step 2.
-        let mut m = bigint::OversizedUninit::new();
-        let mut tmp = bigint::OversizedUninit::new();
+        let mut m = bigint::elem::OversizedUninit::new();
+        let mut tmp = bigint::elem::OversizedUninit::new();
         let m = self.exponentiate_elem(&mut m, s.as_ref(), &mut tmp, cpu_features);
 
         // Step 3.
@@ -165,9 +165,9 @@ impl PublicKey<bigint::IntoMont<'_, N, RR>> {
     /// This is constant-time with respect to `base` only.
     pub(in super::super) fn exponentiate_elem<'out>(
         &self,
-        out: &'out mut bigint::OversizedUninit<1>,
+        out: &'out mut bigint::elem::OversizedUninit,
         base: bigint::elem::Ref<N>,
-        tmp: &mut bigint::OversizedUninit<1>,
+        tmp: &mut bigint::elem::OversizedUninit,
         cpu_features: cpu::Features,
     ) -> bigint::elem::Mut<'out, N> {
         // The exponent was already checked to be at least 3.

--- a/src/rsa/base/public_modulus.rs
+++ b/src/rsa/base/public_modulus.rs
@@ -80,7 +80,7 @@ impl<'a> ValidatedInput<'a> {
 
     pub(super) fn build<'o>(
         &self,
-        out: &'o mut bigint::OversizedUninit<2>,
+        out: &'o mut bigint::modulus::OversizedUninit,
         cpu_features: cpu::Features,
     ) -> PublicModulus<bigint::IntoMont<'o, N, RR>> {
         PublicModulus {

--- a/src/rsa/keypair.rs
+++ b/src/rsa/keypair.rs
@@ -330,9 +330,9 @@ impl KeyPair {
         // checking p * q == 0 (mod n) is equivalent to checking p * q == n.
         let public_key = PublicKey::new(public_key, cpu_features)?;
 
-        let mut tmp1 = bigint::OversizedUninit::<1>::new();
-        let mut tmp2 = bigint::OversizedUninit::<1>::new();
-        let mut tmp3 = bigint::OversizedUninit::<1>::new();
+        let mut tmp1 = bigint::elem::OversizedUninit::new();
+        let mut tmp2 = bigint::elem::OversizedUninit::new();
+        let mut tmp3 = bigint::elem::OversizedUninit::new();
 
         let borrowed_public_key = public_key.inner();
         let n = borrowed_public_key.n().value();
@@ -506,10 +506,10 @@ impl<M> PrivateCrtPrime<M> {
 }
 
 fn elem_exp_consttime<'out, M>(
-    out: &'out mut bigint::OversizedUninit<1>,
+    out: &'out mut bigint::elem::OversizedUninit,
     c: bigint::elem::Ref<'_, N>,
     p: &PrivateCrtPrime<M>,
-    tmp: &mut bigint::OversizedUninit<1>,
+    tmp: &mut bigint::elem::OversizedUninit,
     cpu_features: cpu::Features,
 ) -> Result<bigint::elem::Mut<'out, M>, error::Unspecified> {
     c.exp_consttime(out, &p.exponent, &p.modulus.reborrow(), tmp, cpu_features)
@@ -570,7 +570,7 @@ impl KeyPair {
         // with Garner's algorithm.
 
         // Steps 1 and 2.
-        let mut tmp = bigint::OversizedUninit::<1>::new();
+        let mut tmp = bigint::elem::OversizedUninit::new();
         let m = self.private_exponentiate(&mut tmp, signature, cpu_features)?;
 
         // Step 3.
@@ -588,7 +588,7 @@ impl KeyPair {
     /// Panics if `in_out` is not `self.public().modulus_len()`.
     fn private_exponentiate<'out>(
         &self,
-        out: &'out mut bigint::OversizedUninit<1>,
+        out: &'out mut bigint::elem::OversizedUninit,
         base: &[u8],
         cpu_features: cpu::Features,
     ) -> Result<bigint::elem::Mut<'out, N>, error::Unspecified> {
@@ -606,14 +606,14 @@ impl KeyPair {
         let q = &self.q.modulus.reborrow();
 
         // Step 1. The value zero is also rejected.
-        let mut base_storage = bigint::OversizedUninit::<1>::new();
+        let mut base_storage = bigint::elem::OversizedUninit::new();
         let base = bigint::elem::Mut::from_be_bytes_padded(&mut base_storage, base, nm)?;
 
         // Step 2
         let c = base.as_ref();
 
-        let mut tmp1 = bigint::OversizedUninit::new();
-        let mut tmp2 = bigint::OversizedUninit::new();
+        let mut tmp1 = bigint::elem::OversizedUninit::new();
+        let mut tmp2 = bigint::elem::OversizedUninit::new();
 
         let tmp3 = &mut *out; // Abuse `out` for temporary storage.
 
@@ -669,7 +669,7 @@ impl KeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::arithmetic::bigint::OversizedUninit;
+    use crate::arithmetic::bigint::elem::OversizedUninit;
     use crate::testutil as test;
     use alloc::vec;
 
@@ -698,7 +698,7 @@ mod tests {
                     let mut padded = vec![0; key.public.modulus_len()];
                     let zeroes = padded.len() - test_case.len();
                     padded[zeroes..].copy_from_slice(test_case);
-                    let mut tmp = OversizedUninit::<1>::new();
+                    let mut tmp = OversizedUninit::new();
                     let _: bigint::elem::Mut<'_, _> =
                         key.private_exponentiate(&mut tmp, &padded, cpu).unwrap();
                 }

--- a/src/rsa/verification.rs
+++ b/src/rsa/verification.rs
@@ -209,7 +209,7 @@ fn verify(
     // exponent value is 2**16 + 1, but it isn't clear if this is just for
     // signing or also for verification. We support exponents of 3 and larger
     // for compatibility with other commonly-used crypto libraries.
-    let mut out = bigint::OversizedUninit::<2>::new();
+    let mut out = bigint::modulus::OversizedUninit::new();
     let key = validated.build(&mut out, cpu_features);
 
     // RFC 8017 Section 5.2.2: RSAVP1.


### PR DESCRIPTION
Use separate times for the modulus and for the elem variants. This will allow the implementations to diverge.