### PR TITLE
polyfill: Remove `Uninit::write_iter` and `Cursor::write_iter`.

### DIFF
--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -28,7 +28,7 @@ use crate::{
         slice::{AliasingSlices, InOut, Uninit},
     },
 };
-use core::{iter, marker::PhantomData, num::NonZero};
+use core::{marker::PhantomData, num::NonZero};
 
 // TODO: Move here?
 pub(crate) use super::oversized_uninit::OversizedUninit;
@@ -167,33 +167,10 @@ impl<'l, M> Mut<'l, M, Unencoded> {
         input: untrusted::Input<'_>,
         m: &Mont<M>,
     ) -> Result<Self, error::Unspecified> {
-        let limbs = limbs_from_be_bytes_padded(out, input, m.num_limbs().get())?;
+        let limbs = limb::limbs_from_be_bytes_padded(out, input, m.num_limbs().get())
+            .map_err(error::erase::<LenMismatchError>)?;
         Self::from_limbs(limbs, m)
     }
-}
-
-pub(super) fn limbs_from_be_bytes_padded<'out>(
-    out: Uninit<'out, Limb>,
-    input: untrusted::Input<'_>,
-    num_limbs: usize,
-) -> Result<&'out mut [Limb], error::Unspecified> {
-    if out.len() != num_limbs {
-        return Err(error::Unspecified);
-    }
-    let input = limb::limbs_from_big_endian(input, 1..=num_limbs)
-        .map_err(error::erase::<LenMismatchError>)?;
-    let out = out
-        .write_iter(
-            input
-                .chain(iter::repeat(Limb::from(limb::ZERO)))
-                .take(num_limbs),
-        )
-        .src_empty()
-        .map_err(error::erase::<LenMismatchError>)?
-        .uninit_empty()
-        .map_err(error::erase::<LenMismatchError>)?
-        .into_written();
-    Ok(out)
 }
 
 impl<'l, M, E> Ref<'l, M, E> {
@@ -520,7 +497,8 @@ pub mod testutil {
         let out = out
             .as_uninit(..num_limbs)
             .unwrap_or_else(unwrap_impossible_len_mismatch_error);
-        let limbs = limbs_from_be_bytes_padded(out, bytes, num_limbs).unwrap();
+        let limbs = limb::limbs_from_be_bytes_padded(out, bytes, num_limbs)
+            .unwrap_or_else(unwrap_impossible_len_mismatch_error);
         Mut::assume_in_range_and_encoded_less_safe(limbs)
     }
 

--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -25,11 +25,10 @@ use crate::{
     limb::{self, Limb},
     polyfill::{
         StartMutPtr,
-        slice::{AliasingSlices, InOut, Uninit},
+        slice::{AliasingSlices, Buf, InOut, Uninit},
     },
 };
 use core::{marker::PhantomData, num::NonZero};
-
 // TODO: Move here?
 pub(crate) use super::oversized_uninit::OversizedUninit;
 
@@ -228,15 +227,17 @@ impl<'l, M> MutAmm<'l, M> {
         m: &Mont<M>,
         tmp: &mut OversizedUninit,
     ) -> Result<Mut<'l, M, Unencoded>, LenMismatchError> {
-        if self.limbs.len() != m.num_limbs().get() {
+        let num_limbs = m.num_limbs();
+        if self.limbs.len() != num_limbs.get() {
             return Err(LenMismatchError::new(self.limbs.len()));
         }
         let limbs = self.limbs;
 
-        let one = tmp
-            .as_uninit(..m.num_limbs().get())?
-            .write_filled_copy(Limb::from(limb::ZERO));
-        one[0] = 1;
+        let mut buf = Buf::from(tmp.as_uninit(..num_limbs.get())?);
+        buf.unfilled().write(1)?;
+        buf.unfilled()
+            .write_repeat(Limb::from(limb::ZERO), num_limbs.get() - 1)?;
+        let one = buf.into_filled_mut();
         let _: &[Limb] = limbs_mul_mont(
             (InOut(&mut *limbs), &*one),
             m.limbs(),

--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -166,9 +166,10 @@ impl<'l, M> Mut<'l, M, Unencoded> {
         input: untrusted::Input<'_>,
         m: &Mont<M>,
     ) -> Result<Self, error::Unspecified> {
-        let limbs = limb::limbs_from_be_bytes_padded(out, input, m.num_limbs().get())
+        let mut buf = Buf::from(out);
+        limb::limbs_from_be_bytes_padded(buf.unfilled(), input, m.num_limbs().get())
             .map_err(error::erase::<LenMismatchError>)?;
-        Self::from_limbs(limbs, m)
+        Self::from_limbs(buf.into_filled_mut(), m)
     }
 }
 
@@ -498,9 +499,10 @@ pub mod testutil {
         let out = out
             .as_uninit(..num_limbs)
             .unwrap_or_else(unwrap_impossible_len_mismatch_error);
-        let limbs = limb::limbs_from_be_bytes_padded(out, bytes, num_limbs)
+        let mut buf = Buf::from(out);
+        limb::limbs_from_be_bytes_padded(buf.unfilled(), bytes, num_limbs)
             .unwrap_or_else(unwrap_impossible_len_mismatch_error);
-        Mut::assume_in_range_and_encoded_less_safe(limbs)
+        Mut::assume_in_range_and_encoded_less_safe(buf.into_filled_mut())
     }
 
     pub fn assert_elem_eq<M, E>(a: Ref<'_, M, E>, b: Ref<'_, M, E>) {

--- a/src/arithmetic/bigint/modulus/mont.rs
+++ b/src/arithmetic/bigint/modulus/mont.rs
@@ -93,9 +93,9 @@ impl OversizedUninit {
 impl ValidatedInput<'_> {
     #[cfg(feature = "alloc")]
     pub(crate) fn build_boxed_into_mont<M>(&self, cpu: cpu::Features) -> BoxedIntoMont<M, RR> {
-        let limbs = self.limbs();
+        let num_limbs = self.num_limbs();
         let storage_len =
-            into_mont_storage_len_from_num_limbs(limbs.len()).unwrap_or_else(|| unreachable!()); // Because `MAX_LIMBS` is small.
+            into_mont_storage_len_from_num_limbs(num_limbs).unwrap_or_else(|| unreachable!()); // Because `MAX_LIMBS` is small.
         let mut uninit = Box::new_uninit_slice(storage_len);
         let mut buf = Buf::from(Uninit::from(uninit.as_mut()));
         self.write_into_mont_RR::<M>(buf.unfilled(), cpu)
@@ -131,17 +131,17 @@ impl ValidatedInput<'_> {
         mut out: Cursor<'_, '_, Limb>,
         cpu: cpu::Features,
     ) -> Result<(), LenMismatchError> {
-        let storage_num_limbs = into_mont_storage_len_from_num_limbs(self.limbs().len())
-            .unwrap_or_else(|| unreachable!()); // Already validated
+        let num_limbs = self.num_limbs();
+        let storage_num_limbs =
+            into_mont_storage_len_from_num_limbs(num_limbs).unwrap_or_else(|| unreachable!()); // Already validated
         if out.capacity() < storage_num_limbs {
             return Err(LenMismatchError::new(out.capacity()));
         }
         out.with_unfilled_buf(|out| {
             // We can't compute `n0` until after we've written `value`.
             out.unfilled().write_repeat(limb::ZERO, N0::LIMBS_USED)?;
-            out.unfilled()
-                .write(limb::limb_from_usize(self.limbs().len()))?;
-            let (_value, _empty) = out.unfilled().write_iter(self.limbs());
+            out.unfilled().write(limb::limb_from_usize(num_limbs))?;
+            limb::limbs_from_be_bytes_padded(out.unfilled(), self.input(), num_limbs)?;
             let (n0, rest) = out
                 .filled_mut()
                 .split_first_chunk_mut::<{ N0::LIMBS_USED }>()
@@ -152,8 +152,7 @@ impl ValidatedInput<'_> {
             let one_pos = out.filled().len();
 
             // Placeholder for the value of 1*RR.
-            out.unfilled()
-                .write_repeat(limb::ZERO, self.limbs().len())?;
+            out.unfilled().write_repeat(limb::ZERO, num_limbs)?;
             let (mont, one) = out
                 .filled_mut()
                 .split_at_mut_checked(one_pos)

--- a/src/arithmetic/bigint/modulus/value.rs
+++ b/src/arithmetic/bigint/modulus/value.rs
@@ -16,8 +16,7 @@ use super::super::super::{MAX_LIMBS, MIN_LIMBS};
 use crate::{
     bb,
     bits::{BitLength, FromByteLen as _},
-    error::{self, InputTooLongError, LenMismatchError},
-    limb,
+    error::{self, InputTooLongError},
     limb::{LIMB_BITS, LIMB_BYTES, Limb},
     polyfill::usize_from_u32,
 };
@@ -93,9 +92,8 @@ impl<'a> ValidatedInput<'a> {
         })
     }
 
-    pub(super) fn limbs(&self) -> impl ExactSizeIterator<Item = Limb> + '_ {
-        limb::limbs_from_big_endian(self.input(), self.num_limbs..=self.num_limbs)
-            .unwrap_or_else(|LenMismatchError { .. }| unreachable!())
+    pub(super) fn num_limbs(&self) -> usize {
+        self.num_limbs
     }
 
     pub fn len_bits(&self) -> BitLength {

--- a/src/arithmetic/bigint/private_exponent.rs
+++ b/src/arithmetic/bigint/private_exponent.rs
@@ -51,8 +51,7 @@ impl PrivateExponent {
         input: untrusted::Input,
         p: &Mont<M>,
     ) -> Result<Self, error::Unspecified> {
-        use super::elem;
-        use crate::{limb::LIMB_BYTES, polyfill::slice::Uninit};
+        use crate::{error::LenMismatchError, limb::LIMB_BYTES, polyfill::slice::Uninit};
 
         // Do exactly what `from_be_bytes_padded` does for any inputs it accepts.
         if let r @ Ok(_) = Self::from_be_bytes_padded(input, p) {
@@ -63,8 +62,8 @@ impl PrivateExponent {
 
         let mut uninit = Box::new_uninit_slice(num_limbs);
         let _: &mut _ =
-            elem::limbs_from_be_bytes_padded(Uninit::from(uninit.as_mut()), input, num_limbs)
-                .map_err(|_: error::Unspecified| error::KeyRejected::unexpected_error())?;
+            limb::limbs_from_be_bytes_padded(Uninit::from(uninit.as_mut()), input, num_limbs)
+                .map_err(|LenMismatchError { .. }| error::KeyRejected::unexpected_error())?;
         let mut limbs = unsafe { uninit.assume_init() };
 
         limbs.as_mut().reverse();

--- a/src/arithmetic/bigint/private_exponent.rs
+++ b/src/arithmetic/bigint/private_exponent.rs
@@ -51,7 +51,11 @@ impl PrivateExponent {
         input: untrusted::Input,
         p: &Mont<M>,
     ) -> Result<Self, error::Unspecified> {
-        use crate::{error::LenMismatchError, limb::LIMB_BYTES, polyfill::slice::Uninit};
+        use crate::{
+            error::LenMismatchError,
+            limb::LIMB_BYTES,
+            polyfill::slice::{Buf, Uninit},
+        };
 
         // Do exactly what `from_be_bytes_padded` does for any inputs it accepts.
         if let r @ Ok(_) = Self::from_be_bytes_padded(input, p) {
@@ -61,9 +65,12 @@ impl PrivateExponent {
         let num_limbs = input.len().div_ceil(LIMB_BYTES);
 
         let mut uninit = Box::new_uninit_slice(num_limbs);
-        let _: &mut _ =
-            limb::limbs_from_be_bytes_padded(Uninit::from(uninit.as_mut()), input, num_limbs)
-                .map_err(|LenMismatchError { .. }| error::KeyRejected::unexpected_error())?;
+        let mut buf = Buf::from(Uninit::from(uninit.as_mut()));
+        limb::limbs_from_be_bytes_padded(buf.unfilled(), input, num_limbs)
+            .map_err(|LenMismatchError { .. }| error::KeyRejected::unexpected_error())?;
+        if buf.filled().len() != uninit.len() {
+            unreachable!()
+        }
         let mut limbs = unsafe { uninit.assume_init() };
 
         limbs.as_mut().reverse();

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -23,7 +23,7 @@ use crate::{
     error::{self, LenMismatchError},
     polyfill::{
         ArrayFlatMap, StartMutPtr,
-        slice::{AliasingSlices, Buf, InOut, Uninit},
+        slice::{AliasingSlices, Buf, Cursor, InOut, Uninit},
         sliceutil, usize_from_u32,
     },
     window5::Window5,
@@ -178,23 +178,23 @@ pub fn parse_big_endian_and_pad_consttime(
     result: &mut [Limb],
 ) -> Result<(), LenMismatchError> {
     let result_len = result.len();
-    limbs_from_be_bytes_padded(Uninit::from(result), input, result_len).map(|_| ())
+    let mut buf = Buf::from(Uninit::from(result));
+    limbs_from_be_bytes_padded(buf.unfilled(), input, result_len).map(|_| ())
 }
 
 pub fn limbs_from_be_bytes_padded<'out>(
-    out: Uninit<'out, Limb>,
+    mut out: Cursor<'out, '_, Limb>,
     input: untrusted::Input<'_>,
     num_limbs: usize,
-) -> Result<&'out mut [Limb], LenMismatchError> {
-    if out.len() != num_limbs {
+) -> Result<(), LenMismatchError> {
+    if out.capacity() < num_limbs {
         return Err(LenMismatchError::new(num_limbs));
     }
     let input = limbs_from_big_endian(input, 1..=num_limbs)?;
-    let mut out = Buf::from(out);
-    let (_filled, _empty) = out.unfilled().write_iter(input);
-    let num_zeros = num_limbs - out.filled().len();
-    out.unfilled().write_repeat(ZERO, num_zeros)?;
-    Ok(out.into_filled_mut())
+    let num_zeros = num_limbs - input.len();
+    let (_filled, _empty) = out.write_iter(input);
+    out.write_repeat(ZERO, num_zeros)?;
+    Ok(())
 }
 
 pub fn limbs_from_big_endian<'a>(

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -23,16 +23,15 @@ use crate::{
     error::{self, LenMismatchError},
     polyfill::{
         ArrayFlatMap, StartMutPtr,
-        slice::{AliasingSlices, InOut},
+        slice::{AliasingSlices, Buf, InOut, Uninit},
         sliceutil, usize_from_u32,
     },
     window5::Window5,
 };
-use core::{iter, num::NonZero};
-
-use crate::polyfill::slice::Uninit;
-use core::num::Wrapping;
-use core::ops::RangeInclusive;
+use core::{
+    num::{NonZero, Wrapping},
+    ops::RangeInclusive,
+};
 
 // XXX: Not correct for x32 ABIs.
 pub type Limb = bb::Word;
@@ -178,12 +177,24 @@ pub fn parse_big_endian_and_pad_consttime(
     input: untrusted::Input,
     result: &mut [Limb],
 ) -> Result<(), LenMismatchError> {
-    let input_limbs = limbs_from_big_endian(input, 1..=result.len())?;
-    result
-        .iter_mut()
-        .zip(input_limbs.chain(iter::repeat(0)))
-        .for_each(|(r, i)| *r = i);
-    Ok(())
+    let result_len = result.len();
+    limbs_from_be_bytes_padded(Uninit::from(result), input, result_len).map(|_| ())
+}
+
+pub fn limbs_from_be_bytes_padded<'out>(
+    out: Uninit<'out, Limb>,
+    input: untrusted::Input<'_>,
+    num_limbs: usize,
+) -> Result<&'out mut [Limb], LenMismatchError> {
+    if out.len() != num_limbs {
+        return Err(LenMismatchError::new(num_limbs));
+    }
+    let input = limbs_from_big_endian(input, 1..=num_limbs)?;
+    let mut out = Buf::from(out);
+    let (_filled, _empty) = out.unfilled().write_iter(input);
+    let num_zeros = num_limbs - out.filled().len();
+    out.unfilled().write_repeat(ZERO, num_zeros)?;
+    Ok(out.into_filled_mut())
 }
 
 pub fn limbs_from_big_endian<'a>(

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -359,11 +359,15 @@ pub(crate) fn write_negative_assume_odd<'r>(
     if a.len() != r.len() {
         return Err(LenMismatchError::new(a.len()));
     }
-    let r = r
-        .write_iter(a.iter().map(|&a| !a))
-        .src_empty()?
-        .uninit_empty()?
-        .into_written();
+
+    let mut buf = Buf::from(r);
+    let mut r = buf.unfilled();
+    a.iter().for_each(|a| {
+        r.write(!a)
+            .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // checked above
+    });
+    let r = buf.into_filled_mut();
+
     // Two's complement step 2: Add one. Since `a` is odd, `r` is even. Thus we
     // can use a bitwise or for addition.
     let Some(least_significant_limb) = r.get_mut(0) else {

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -28,10 +28,7 @@ use crate::{
     },
     window5::Window5,
 };
-use core::{
-    num::{NonZero, Wrapping},
-    ops::RangeInclusive,
-};
+use core::num::{NonZero, Wrapping};
 
 // XXX: Not correct for x32 ABIs.
 pub type Limb = bb::Word;
@@ -187,30 +184,26 @@ pub fn limbs_from_be_bytes_padded<'out>(
     input: untrusted::Input<'_>,
     num_limbs: usize,
 ) -> Result<(), LenMismatchError> {
-    if out.capacity() < num_limbs {
-        return Err(LenMismatchError::new(num_limbs));
-    }
-    let input = limbs_from_big_endian(input, 1..=num_limbs)?;
-    let num_zeros = num_limbs - input.len();
-    let (_filled, _empty) = out.write_iter(input);
-    out.write_repeat(ZERO, num_zeros)?;
-    Ok(())
-}
-
-pub fn limbs_from_big_endian<'a>(
-    input: untrusted::Input<'a>,
-    len_bounds: RangeInclusive<usize>,
-) -> Result<impl ExactSizeIterator<Item = Limb> + 'a, LenMismatchError> {
-    let r = input.as_slice_less_safe().rchunks(LIMB_BYTES).map(|chunk| {
+    let input_limbs = input.as_slice_less_safe().rchunks(LIMB_BYTES).map(|chunk| {
         let mut padded = [0; LIMB_BYTES];
         sliceutil::overwrite_at_start(&mut padded[(LIMB_BYTES - chunk.len())..], chunk);
         Limb::from_be_bytes(padded)
     });
-    let len = r.len();
-    if !len_bounds.contains(&len) {
-        return Err(LenMismatchError::new(len));
+    if input_limbs.len() == 0 {
+        return Err(LenMismatchError::new(input_limbs.len()));
     }
-    Ok(r)
+    if input_limbs.len() > num_limbs {
+        return Err(LenMismatchError::new(input_limbs.len()));
+    }
+    if out.capacity() < num_limbs {
+        return Err(LenMismatchError::new(num_limbs));
+    }
+    let num_zeros = num_limbs - input_limbs.len();
+    input_limbs.for_each(|input| {
+        out.write(input)
+            .unwrap_or_else(|LenMismatchError { .. }| unreachable!())
+    });
+    out.write_repeat(ZERO, num_zeros)
 }
 
 pub fn big_endian_from_limbs(limbs: &[Limb], out: &mut [u8]) {

--- a/src/polyfill/uninit_slice.rs
+++ b/src/polyfill/uninit_slice.rs
@@ -127,31 +127,6 @@ impl<'target, E: Copy> Uninit<'target, E> {
         Ok(buf.into_filled_mut())
     }
 
-    pub fn write_iter<Src: IntoIterator<Item = E>>(
-        mut self,
-        src: Src,
-    ) -> WriteResult<'target, E, Self, Src::IntoIter> {
-        let mut init_len = 0;
-        let mut src = src.into_iter();
-        self.target
-            .iter_mut()
-            .zip(src.by_ref())
-            .for_each(|(dst, src)| {
-                let _: &mut E = dst.write(src);
-                init_len += 1;
-            });
-        let written = self
-            .split_off_mut(..init_len)
-            .unwrap_or_else(|| unreachable!());
-        let written = unsafe { written.assume_init() };
-
-        WriteResult {
-            written,
-            dst_leftover: self,
-            src_leftover: src,
-        }
-    }
-
     pub unsafe fn assume_init(self) -> &'target mut [E] {
         let r: &'target mut [MaybeUninit<E>] = self.target;
         let r: *mut [MaybeUninit<E>] = ptr::from_mut(r);
@@ -369,28 +344,6 @@ impl<E: Copy> Cursor<'_, '_, E> {
         // Can't overflow since `written` is a subslice of `self.buf.storage`.
         self.buf.filled += repeat;
         Ok(())
-    }
-
-    pub fn write_iter<Src: IntoIterator<Item = E>>(&mut self, src: Src) -> (&mut [E], Src::IntoIter)
-    where
-        E: Copy,
-    {
-        // TODO: Deal with panics.
-        let start = self.buf.filled;
-        let WriteResult {
-            written,
-            dst_leftover: _,
-            src_leftover,
-        } = self.buf.unfilled_uninit().write_iter(src);
-        let written_len = written.len();
-        // Can't overflow because `wr.written` is a slice of `self.buf.storage`.
-        self.buf.filled += written_len;
-        let (_existing, written) = self
-            .buf
-            .filled_mut()
-            .split_at_mut_checked(start)
-            .unwrap_or_else(|| unreachable!());
-        (written, src_leftover)
     }
 
     /// See `core::io::BorrowedCursor::with_unfilled_buf`.

--- a/src/polyfill/uninit_slice.rs
+++ b/src/polyfill/uninit_slice.rs
@@ -128,7 +128,7 @@ impl<'target, E: Copy> Uninit<'target, E> {
         Ok(buf.into_filled_mut())
     }
 
-    pub fn write_filled_copy(self, value: E) -> &'target mut [E]
+    fn write_filled_copy(self, value: E) -> &'target mut [E]
     where
         E: Copy, // To avoid concerns about `value.clone()` panicking
     {

--- a/src/polyfill/uninit_slice.rs
+++ b/src/polyfill/uninit_slice.rs
@@ -436,27 +436,6 @@ impl<'written, E, Dst, Src> WriteResult<'written, E, Dst, Src> {
             dst_leftover,
         )
     }
-
-    #[inline(always)]
-    pub fn src_empty(self) -> Result<WriteResult<'written, E, Dst, ()>, LenMismatchError>
-    where
-        Src: IntoIterator,
-    {
-        let WriteResult {
-            written,
-            dst_leftover,
-            src_leftover,
-        } = self;
-        let mut src_leftover = src_leftover.into_iter().peekable();
-        if src_leftover.next().is_some() {
-            return Err(LenMismatchError::new(src_leftover.size_hint().0));
-        }
-        Ok(WriteResult {
-            written,
-            dst_leftover,
-            src_leftover: (),
-        })
-    }
 }
 
 impl<'written, E, Src> WriteResult<'written, E, Uninit<'written, E>, Src> {

--- a/src/polyfill/uninit_slice.rs
+++ b/src/polyfill/uninit_slice.rs
@@ -18,7 +18,6 @@ use crate::polyfill::prelude::*;
 use super::start_ptr::{StartMutPtr, StartPtr};
 use crate::error::LenMismatchError;
 use core::{
-    iter,
     marker::PhantomData,
     mem::{self, MaybeUninit},
     ops::RangeTo,
@@ -126,13 +125,6 @@ impl<'target, E: Copy> Uninit<'target, E> {
         let padding_len = buf.unfilled().capacity();
         buf.unfilled().write_repeat(padding, padding_len)?;
         Ok(buf.into_filled_mut())
-    }
-
-    fn write_filled_copy(self, value: E) -> &'target mut [E]
-    where
-        E: Copy, // To avoid concerns about `value.clone()` panicking
-    {
-        self.write_iter(iter::repeat(value)).written
     }
 
     pub fn write_iter<Src: IntoIterator<Item = E>>(
@@ -367,8 +359,15 @@ impl<E: Copy> Cursor<'_, '_, E> {
         let to_fill = unfilled
             .split_off_mut(..repeat)
             .ok_or_else(|| LenMismatchError::new(capacity))?;
+
+        // TODO(MSRV feature(maybe_uninit_fill)): Use
+        // `to_fill.target.write_filled(value)` if it is optimized for `Copy`.
+        to_fill.target.iter_mut().for_each(|out| {
+            let _: &mut _ = out.write(value);
+        });
+
         // Can't overflow since `written` is a subslice of `self.buf.storage`.
-        self.buf.filled += to_fill.write_filled_copy(value).len();
+        self.buf.filled += repeat;
         Ok(())
     }
 


### PR DESCRIPTION
Take a big step towards removing `WriteResult`, which turned out to be too noisy.