### PR TITLE
polyfill: Replace `Uninit::write_copy_of_slice` with `write_copy_of_slice_exact`.

### DIFF
--- a/src/arithmetic/bigint/elem.rs
+++ b/src/arithmetic/bigint/elem.rs
@@ -195,7 +195,7 @@ impl<'l, M, E> Ref<'l, M, E> {
 
     pub fn clone_into<'out>(&self, out: &'out mut OversizedUninit) -> Mut<'out, M, E> {
         let limbs = out
-            .write_copy_of_slice(self.limbs, self.limbs.len())
+            .write_copy_of_slice_exact(self.limbs, self.limbs.len())
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.
         Mut::assume_in_range_and_encoded_less_safe(limbs)
     }
@@ -212,7 +212,7 @@ impl<'l, M> MutAmm<'l, M> {
         out: &'l mut OversizedUninit,
         src: &mut [Limb],
     ) -> Result<Self, LenMismatchError> {
-        let limbs = out.write_copy_of_slice(src, src.len())?;
+        let limbs = out.write_copy_of_slice_exact(src, src.len())?;
         Ok(Self {
             limbs,
             m: PhantomData,
@@ -361,7 +361,7 @@ impl<M> Ref<'_, M, Unencoded> {
         // TODO: We should add a variant of `limbs_reduced_once` that does the
         // reduction out-of-place, to eliminate this copy.
         let r = out
-            .write_copy_of_slice(self.limbs.as_ref(), m.num_limbs().get())
+            .write_copy_of_slice_exact(self.limbs.as_ref(), m.num_limbs().get())
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.
         limb::limbs_reduce_once(&mut *r, m.limbs())
             .unwrap_or_else(unwrap_impossible_len_mismatch_error);
@@ -384,7 +384,7 @@ impl<'l, M> Ref<'l, M, Unencoded> {
         assert_eq!(self.limbs.len(), p.limbs().len() * 2);
 
         let tmp = tmp
-            .write_copy_of_slice(self.limbs, self.limbs.len())
+            .write_copy_of_slice_exact(self.limbs, self.limbs.len())
             .unwrap_or_else(|LenMismatchError { .. }| unreachable!()); // Because it's oversized.
         let out = out
             .as_uninit(..p.num_limbs().get())

--- a/src/arithmetic/bigint/exp.rs
+++ b/src/arithmetic/bigint/exp.rs
@@ -295,9 +295,7 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
 
     // "To improve cache locality" according to upstream.
     let (m_cached, _) = Uninit::from(m_cached)
-        .write_copy_of_slice(m.limbs())?
-        .uninit_empty()?
-        .into_written()
+        .write_copy_of_slice_exact(m.limbs())?
         .as_chunks();
 
     let base_mod_m: elem::Mut<'_, M, RInverse> = base_mod_n.reduced_mont(out, m, tmp);
@@ -341,10 +339,7 @@ fn elem_exp_consttime_inner<'out, N, M, const STORAGE_LIMBS: usize>(
     scatter5(t0.leak_limbs_less_safe(), table, LeakyWindow5::_0)?;
 
     // acc = base**1 (i.e. base).
-    let acc = acc
-        .write_copy_of_slice(base_cached)?
-        .uninit_empty()?
-        .into_written();
+    let acc = acc.write_copy_of_slice_exact(base_cached)?;
 
     // Fill in entries 1, 2, 4, 8, 16.
     scatter_powers_of_2(table, acc, m_cached, n0, LeakyWindow5::_1, cpu2)?;

--- a/src/arithmetic/bigint/oversized_uninit.rs
+++ b/src/arithmetic/bigint/oversized_uninit.rs
@@ -34,16 +34,11 @@ impl OversizedUninit {
             .ok_or_else(|| LenMismatchError::new(len.end))
     }
 
-    pub fn write_copy_of_slice(
+    pub fn write_copy_of_slice_exact(
         &mut self,
         a: &[Limb],
         expected_len: usize,
     ) -> Result<&mut [Limb], LenMismatchError> {
-        Ok(self
-            .as_uninit(..expected_len)?
-            .write_copy_of_slice(a)?
-            .uninit_empty()
-            .unwrap_or_else(|LenMismatchError { .. }| unreachable!())
-            .into_written())
+        self.as_uninit(..expected_len)?.write_copy_of_slice_exact(a)
     }
 }

--- a/src/polyfill/uninit_slice.rs
+++ b/src/polyfill/uninit_slice.rs
@@ -100,19 +100,16 @@ impl<'target, E> Uninit<'target, E> {
 
 // `E: Copy` to avoid `Drop` issues.
 impl<'target, E: Copy> Uninit<'target, E> {
-    #[allow(dead_code)]
-    pub fn write_copy_of_slice(
+    pub fn write_copy_of_slice_exact(
         self,
         src: &[E],
-    ) -> Result<WriteResult<'target, E, Self, ()>, LenMismatchError> {
+    ) -> Result<&'target mut [E], LenMismatchError> {
+        if self.len() != src.len() {
+            return Err(LenMismatchError::new(self.len()));
+        }
         let mut buf = Buf::from(self);
         buf.unfilled().write_copy_of_slice(src)?;
-        let (written, dst_leftover) = buf.split_filled_mut();
-        Ok(WriteResult {
-            written,
-            dst_leftover,
-            src_leftover: (),
-        })
+        Ok(buf.into_filled_mut())
     }
 
     pub fn write_copy_of_slice_padded(
@@ -362,49 +359,5 @@ impl<E: Copy> Cursor<'_, '_, E> {
         // The above assertions ensure our invariant is maintained.
         debug_assert!(self.buf.filled <= self.buf.storage.len());
         res
-    }
-}
-
-pub struct WriteResult<'written, E, Dst, Src> {
-    written: &'written mut [E],
-    dst_leftover: Dst,
-    src_leftover: Src,
-}
-
-impl<'written, E, Dst, Src> WriteResult<'written, E, Dst, Src> {
-    #[inline(always)]
-    pub fn take_uninit(self) -> (WriteResult<'written, E, (), Src>, Dst) {
-        let WriteResult {
-            written,
-            dst_leftover,
-            src_leftover,
-        } = self;
-        (
-            WriteResult {
-                written,
-                dst_leftover: (),
-                src_leftover,
-            },
-            dst_leftover,
-        )
-    }
-}
-
-impl<'written, E, Src> WriteResult<'written, E, Uninit<'written, E>, Src> {
-    #[allow(dead_code)]
-    #[inline(always)]
-    pub fn uninit_empty(self) -> Result<WriteResult<'written, E, (), Src>, LenMismatchError> {
-        let (res, dst_leftover) = self.take_uninit();
-        if dst_leftover.len() != 0 {
-            return Err(LenMismatchError::new(dst_leftover.len()));
-        }
-        Ok(res)
-    }
-}
-
-impl<'written, E> WriteResult<'written, E, (), ()> {
-    #[inline(always)]
-    pub fn into_written(self) -> &'written mut [E] {
-        self.written
     }
 }


### PR DESCRIPTION
If something else is needed, we should use `Buf`/`Cursor`.

This concludes the `WriteResult` experiment; remove it.