### PR TITLE
polyfill: Make `with_borrowed_buf` assertion more like `core::io`'s.

### DIFF
--- a/src/polyfill/uninit_slice.rs
+++ b/src/polyfill/uninit_slice.rs
@@ -350,11 +350,13 @@ impl<E: Copy> Cursor<'_, '_, E> {
     /// Panics if `f` replaces `Buf` with a different one.
     pub fn with_unfilled_buf<R>(&mut self, f: impl FnOnce(&mut Buf<'_, E>) -> R) -> R {
         let mut buf = Buf::from(self.buf.unfilled_uninit());
-        let ptr = buf.storage.start_ptr();
-        let len = buf.storage.target.len();
+        let ptr_and_len: *const [MaybeUninit<E>] = ptr::from_ref(buf.storage.target);
         let res = f(&mut buf);
-        assert!(ptr::addr_eq(buf.storage.start_ptr(), ptr));
-        assert!(buf.storage.len() <= len);
+        // It would be OK if the length became shorter, but there's no reason
+        // for us to support that case. It is important that the address is the
+        // same and the length isn't longer.
+        assert!(ptr::eq(buf.storage.target, ptr_and_len));
+        debug_assert!(buf.filled <= buf.storage.len()); // invariant
         self.buf.filled += buf.filled;
         // The above assertions ensure our invariant is maintained.
         debug_assert!(self.buf.filled <= self.buf.storage.len());


### PR DESCRIPTION
No functional change.