### PR TITLE
Update cc-rs version requirement in Cargo.toml to what has been tested.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ wasm-bindgen-test = { version = "0.3.64", default-features = false, features = [
 libc = { version = "0.2.172", default-features = false }
 
 [build-dependencies]
-cc = { version = "1.2.8", default-features = false }
+cc = { version = "1.2.57", default-features = false }
 
 [features]
 # These features are documented in the top-level module's documentation.


### PR DESCRIPTION
`prefer_clang_cl_over_msvc` requires a newer version of cc-rs.