### PR TITLE
Fix typos in comments in .rs source files

### DIFF
--- a/src/aead/chacha/tests.rs
+++ b/src/aead/chacha/tests.rs
@@ -31,7 +31,7 @@ const MAX_ALIGNMENT_AND_OFFSET_SUBSET: (usize, usize) =
 
 #[test]
 fn chacha20_test_default() {
-    // Always use `MAX_OFFSET` if we hav assembly code.
+    // Always use `MAX_OFFSET` if we have assembly code.
     let max_offset = if cfg!(any(
         all(target_arch = "aarch64", target_endian = "little"),
         all(target_arch = "arm", target_endian = "little"),

--- a/src/cpu/x86.rs
+++ b/src/cpu/x86.rs
@@ -22,7 +22,7 @@ use core::ops::{BitAnd, Shl};
 mod abi_assumptions {
     use core::mem::size_of;
 
-    // TOOD: Support targets that do not have SSE and SSE2 enabled, such as
+    // TODO: Support targets that do not have SSE and SSE2 enabled, such as
     // x86_64-unknown-linux-none. See
     // https://github.com/briansmith/ring/issues/1793#issuecomment-1793243725,
     // https://github.com/briansmith/ring/issues/1832,

--- a/src/cpu/x86_64.rs
+++ b/src/cpu/x86_64.rs
@@ -22,7 +22,7 @@ use core::ops::{BitAnd, Shl};
 mod abi_assumptions {
     use core::mem::size_of;
 
-    // TOOD: Support targets that do not have SSE and SSE2 enabled, such as
+    // TODO: Support targets that do not have SSE and SSE2 enabled, such as
     // x86_64-unknown-linux-none. See
     // https://github.com/briansmith/ring/issues/1793#issuecomment-1793243725,
     // https://github.com/briansmith/ring/issues/1832,

--- a/src/ec/suite_b/mod.rs
+++ b/src/ec/suite_b/mod.rs
@@ -21,7 +21,7 @@ use crate::{arithmetic::montgomery::*, cpu, ec, error, io::der, pkcs8};
 // yQ**2 = xQ**3 + axQ + b in GF(p), where the arithmetic is performed modulo
 // p."
 //
-// That is, verify that (x, y) is on the curve, which is true iif:
+// That is, verify that (x, y) is on the curve, which is true iff:
 //
 //     y**2 == x**3 + a*x + b (mod q)
 //

--- a/src/ec/suite_b/ops/mod.rs
+++ b/src/ec/suite_b/ops/mod.rs
@@ -457,7 +457,7 @@ impl PublicScalarOps {
 pub struct PrivateScalarOps {
     pub scalar_ops: &'static ScalarOps,
 
-    oneRR_mod_n: PublicScalar<RR>, // 1 * R**2 (mod n). TOOD: Use One<RR>.
+    oneRR_mod_n: PublicScalar<RR>, // 1 * R**2 (mod n). TODO: Use One<RR>.
     scalar_inv_to_mont: fn(a: Scalar<R>, cpu: cpu::Features) -> Scalar<R>,
 }
 


### PR DESCRIPTION
Fix five typos found in code comments across Rust source files.

## Changes

- `TOOD` → `TODO` in `src/cpu/x86.rs`, `src/cpu/x86_64.rs`, and `src/ec/suite_b/ops/mod.rs`
- `iif` → `iff` (mathematical abbreviation for "if and only if") in `src/ec/suite_b/mod.rs`
- `hav` → `have` in `src/aead/chacha/tests.rs`

Found with `codespell`. No functional changes — comments only.