### PR TITLE
Change error types to use `core::error::Error`

### DIFF
--- a/src/error/key_rejected.rs
+++ b/src/error/key_rejected.rs
@@ -14,9 +14,6 @@
 
 //! Error reporting.
 
-#[cfg(feature = "std")]
-extern crate std;
-
 /// An error parsing or validating a key.
 ///
 /// The `Display` implementation will return a string that will help you better
@@ -104,8 +101,7 @@ impl KeyRejected {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for KeyRejected {}
+impl core::error::Error for KeyRejected {}
 
 impl core::fmt::Display for KeyRejected {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/src/error/unspecified.rs
+++ b/src/error/unspecified.rs
@@ -12,9 +12,6 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#[cfg(feature = "std")]
-extern crate std;
-
 /// An error with absolutely no details.
 ///
 /// *ring* uses this unit type as the error type in most of its results
@@ -25,7 +22,7 @@ extern crate std;
 ///
 /// `Result<T, ring::error::Unspecified>` is mostly equivalent to
 /// `Result<T, ()>`. However, `ring::error::Unspecified` implements
-/// [`std::error::Error`] and users of *ring* can implement
+/// [`core::error::Error`] and users of *ring* can implement
 /// `From<ring::error::Unspecified>` to map this to their own error types, as
 /// described in [“Error Handling” in the Rust Book]:
 ///
@@ -68,7 +65,7 @@ extern crate std;
 /// cause of a failure. Users of *ring* are encouraged to report such cases so
 /// that they can be addressed individually.
 ///
-/// [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
+/// [`core::error::Error`]: https://doc.rust-lang.org/core/error/trait.Error.html
 /// [“Error Handling” in the Rust Book]:
 ///     https://doc.rust-lang.org/book/first-edition/error-handling.html#the-from-trait
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -81,5 +78,4 @@ impl core::fmt::Display for Unspecified {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Unspecified {}
+impl core::error::Error for Unspecified {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,6 @@
 //!         on esp-idf despite the likelihood that RNG is not secure.
 //!         This feature only works with <code>os = espidf</code> targets.
 //!         See <a href="https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/random.html">
-//! <tr><td><code>std</code>
-//!     <td>Enable features that use libstd, in particular
-//!         <code>std::error::Error</code> integration. Implies `alloc`.
 //! <tr><td><code>wasm32_unknown_unknown_js</code>
 //!     <td>When this feature is enabled, for the wasm32-unknown-unknown target,
 //!         Web APIs will be used to implement features like `ring::rand` that

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,5 +1,9 @@
 #![allow(missing_docs)]
 
+/// `compile_time_assert_core_error_error::<T>();` fails to compile if `T`
+/// doesn't implement `core::error::Error`.
+const fn compile_time_assert_core_error_error<T: core::error::Error>() {}
+
 #[cfg(feature = "std")]
 #[test]
 fn error_impl_std_error_error_test() {
@@ -9,4 +13,12 @@ fn error_impl_std_error_error_test() {
 
     test::compile_time_assert_std_error_error::<error::Unspecified>();
     test::compile_time_assert_std_error_error::<error::KeyRejected>();
+}
+
+#[test]
+fn error_impl_core_error_error_test() {
+    use ring::error;
+
+    compile_time_assert_core_error_error::<error::Unspecified>();
+    compile_time_assert_core_error_error::<error::KeyRejected>();
 }


### PR DESCRIPTION
With [`core::error::Error` being stabilized in Rust 1.81](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0/), the error types no longer need to depend on `std` for this trait.

Removing this also renders the `std` unnecessary for any library consumers as the only usage of the `std` is now for test logging. Though it may make sense to leave the `std` flag to avoid breakages.