### PR TITLE
_AARCH64_APPLE_DARWIN_TARGETS_EXPECTED_FEATURES failure

### DIFF
--- a/.github/workflows/target-cpu-regression.yml
+++ b/.github/workflows/target-cpu-regression.yml
@@ -1,0 +1,43 @@
+# Reproduces the aarch64-apple `-Ctarget-cpu` bug fixed in
+# src/cpu/aarch64/darwin.rs. Without that fix these jobs fail with:
+#
+#     error[E0080]: evaluation panicked: assertion failed:
+#         (CAPS_STATIC & MIN_STATIC_FEATURES) == MIN_STATIC_FEATURES
+#
+# `native` is what users pass, but which CPU LLVM picks for it depends on the
+# runner (see https://github.com/rust-lang/rust/issues/93889), so `generic` is
+# the deterministic case; both are tested.
+name: target-cpu-regression
+permissions:
+  contents: read
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+jobs:
+  apple:
+    runs-on: macos-15
+
+    env:
+      CC_ENABLE_DEBUG_OUTPUT: 1
+      RUSTFLAGS: -Ctarget-cpu=${{ matrix.target_cpu }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target_cpu:
+          - generic
+          - native
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - run: mk/install-build-tools.sh +stable --target=aarch64-apple-darwin
+        shell: sh
+
+      - run: |
+          echo "RUSTFLAGS=${RUSTFLAGS}"
+          rustc --print cfg --target=aarch64-apple-darwin ${RUSTFLAGS} | grep target_feature
+          mk/cargo.sh +stable test --locked -vv --lib --tests --target=aarch64-apple-darwin

--- a/src/cpu/aarch64/darwin.rs
+++ b/src/cpu/aarch64/darwin.rs
@@ -17,16 +17,39 @@ use super::{Aes, CAPS_STATIC, Neon, PMull, Sha256};
 use {super::Sha512, core::ffi::CStr};
 
 // ```
-// $ rustc +1.61.0 --print cfg --target=aarch64-apple-ios | grep -E "neon|aes|sha|pmull"
+// $ rustc --print cfg --target=aarch64-apple-ios | grep -E "neon|aes|sha|pmull"
 // target_feature="aes"
 // target_feature="neon"
 // target_feature="sha2"
-// $ rustc +1.61.0 --print cfg --target=aarch64-apple-darwin | grep -E "neon|aes|sha|pmull"
+// $ rustc --print cfg --target=aarch64-apple-darwin | grep -E "neon|aes|sha|pmull"
 // target_feature="aes"
 // target_feature="neon"
 // target_feature="sha2"
 // target_feature="sha3"
 // ```
+//
+// Every aarch64-apple-* device has AES, PMULL and SHA-256, and by default the
+// compiler tells us so. However, we cannot *rely* on being told, because
+// `-Ctarget-cpu` can leave the target feature set *smaller* than the target's
+// default:
+//
+// ```
+// $ rustc --print cfg --target=aarch64-apple-darwin -Ctarget-cpu=generic | grep -E "neon|aes|sha"
+// target_feature="neon"
+// ```
+//
+// On Apple Silicon, `-Ctarget-cpu=native` makes LLVM pick an older CPU than
+// the default one (`cyclone`, or `generic` on hosts whose CPU LLVM does not
+// recognize, e.g. virtualized CI runners); see
+// https://github.com/rust-lang/rust/issues/93889. Users also disable target
+// features explicitly. Formerly such a configuration was a hard compile error
+// here; instead, detect at runtime whatever the compiler didn't promise us,
+// like we do for the other operating systems.
+//
+// This is the mirror image of the workaround in `linux.rs`: there
+// `-Ctarget-cpu` reports *more* features than the CPU actually has, so the
+// static feature set cannot be trusted to be correct; here it reports *fewer*,
+// so it cannot be trusted to be complete.
 //
 // XXX/TODO(coverage)/TODO(size): aarch64-apple-darwin is statically guaranteed to have "sha3" but
 // other aarch64-apple-* targets require dynamic detection. Since we don't have test coverage for
@@ -36,23 +59,8 @@ use {super::Sha512, core::ffi::CStr};
 //
 // This is particularly important because we haven't tested the ABI validity of any
 // fallback implementations, especially for ARM64_32.
-pub const MIN_STATIC_FEATURES: u32 = Neon::mask() | Aes::mask() | Sha256::mask() | PMull::mask();
-pub const FORCE_DYNAMIC_DETECTION: u32 = !MIN_STATIC_FEATURES;
-
-// MSRV: Enforce 1.61.0 onaarch64-apple-*, in particular) prior to. Earlier
-// versions of Rust before did not report the AAarch64 CPU features correctly
-// for these targets. Cargo.toml specifies `rust-version` but versions before
-// Rust 1.56 don't know about it.
-#[allow(clippy::assertions_on_constants)]
-const _AARCH64_APPLE_TARGETS_EXPECTED_FEATURES: () =
-    assert!((CAPS_STATIC & MIN_STATIC_FEATURES) == MIN_STATIC_FEATURES);
-
-// Ensure we don't accidentally allow features statically beyond
-// `MIN_STATIC_FEATURES` so that dynamic detection is done uniformly for
-// all of these targets.
-#[allow(clippy::assertions_on_constants)]
-const _AARCH64_APPLE_DARWIN_TARGETS_EXPECTED_FEATURES: () =
-    assert!(CAPS_STATIC == MIN_STATIC_FEATURES);
+pub const FORCE_DYNAMIC_DETECTION: u32 =
+    !(Neon::mask() | Aes::mask() | Sha256::mask() | PMull::mask());
 
 pub fn detect_features() -> u32 {
     #[cfg(all(target_pointer_width = "64", not(target_os = "watchos")))]
@@ -88,6 +96,26 @@ pub fn detect_features() -> u32 {
 
     #[cfg(all(target_pointer_width = "64", not(target_os = "watchos")))]
     {
+        // Only ask the OS about the features the compiler didn't already
+        // promise us. The `cfg!`s are constant-folded, so a
+        // default-configured build makes no additional `sysctl` calls.
+        //
+        // The `hw.optional.arm.FEAT_*` names require macOS 12 / iOS 15 or
+        // later. On earlier versions the lookup fails and we fall back to the
+        // implementations that don't require the feature; slower, but correct.
+        if !cfg!(target_feature = "aes") {
+            // `STATIC_DETECTED` derives `PMull` from "aes" since there is no
+            // "pmull" target feature, but the OS reports them separately.
+            if detect_feature(c"hw.optional.arm.FEAT_AES") {
+                features |= Aes::mask();
+            }
+            if detect_feature(c"hw.optional.arm.FEAT_PMULL") {
+                features |= PMull::mask();
+            }
+        }
+        if !cfg!(target_feature = "sha2") && detect_feature(c"hw.optional.arm.FEAT_SHA256") {
+            features |= Sha256::mask();
+        }
         if detect_feature(c"hw.optional.armv8_2_sha512") {
             features |= Sha512::mask();
         }
@@ -111,11 +139,11 @@ mod tests {
         let has_sha512 = maybe_sha512.is_some();
 
         // Intentionally defer the assertion to runtime instead of compile time.
-        #[allow(clippy::assertions_on_constants)]
         #[cfg(all(target_os = "macos", target_pointer_width = "64"))]
         {
-            // All aarch64-apple-darwin targets have SHA3 enabled statically...
-            assert!(cfg!(target_feature = "sha3"));
+            // Whether "sha3" is enabled statically depends on `-Ctarget-cpu`,
+            // but every aarch64-apple-darwin device has SHA-512 regardless, so
+            // we must detect it either way.
             assert_eq!(has_sha512, cfg!(target_pointer_width = "64"));
         }
 
@@ -123,5 +151,21 @@ mod tests {
         {
             assert!(!has_sha512);
         }
+    }
+
+    // Every aarch64-apple-* device has these, so we must find them whether or
+    // not the compiler enabled them statically; see the comment on
+    // `FORCE_DYNAMIC_DETECTION` above.
+    #[test]
+    #[cfg(all(target_pointer_width = "64", not(target_os = "watchos")))]
+    #[cfg(not(feature = "unstable-testing-arm-no-hw"))]
+    fn aes_pmull_sha256_detection() {
+        let cpu = cpu::features();
+        let aes: Option<Aes> = cpu.get_feature();
+        let pmull: Option<PMull> = cpu.get_feature();
+        let sha256: Option<Sha256> = cpu.get_feature();
+        assert!(aes.is_some());
+        assert!(pmull.is_some());
+        assert!(sha256.is_some());
     }
 }


### PR DESCRIPTION
This fix is for the error below

I believe the error has been reported before as
https://github.com/briansmith/ring/issues/2527

...and I confirm that this happens only when doing native cpu builds. The checks in the current code don't line up

The fix is a "dynamic" test of features. It's a smaller subset than this patch

Included is a related CI-test you can choose to ignore


## Error

error[E0080]: evaluation panicked: assertion failed: (CAPS_STATIC & MIN_STATIC_FEATURES) == MIN_STATIC_FEATURES
  --> /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.17.14/src/cpu/arm/darwin.rs:44:5
   |
44 |     assert!((CAPS_STATIC & MIN_STATIC_FEATURES) == MIN_STATIC_FEATURES);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `cpu::arm::darwin::_AARCH64_APPLE_TARGETS_EXPECTED_FEATURES` failed here

error[E0080]: evaluation panicked: assertion failed: CAPS_STATIC == MIN_STATIC_FEATURES
  --> /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ring-0.17.14/src/cpu/arm/darwin.rs:51:5
   |
51 |     assert!(CAPS_STATIC == MIN_STATIC_FEATURES);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `cpu::arm::darwin::_AARCH64_APPLE_DARWIN_TARGETS_EXPECTED_FEATURES` failed here

For more information about this error, try `rustc --explain E0080`.
error: could not compile `ring` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.