### PR TITLE
Enable `getrandom` support for Emscripten

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -130,6 +130,7 @@ impl SystemRandom {
     target_os = "android",
     target_os = "cygwin",
     target_os = "dragonfly",
+    target_os = "emscripten",
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "haiku",


### PR DESCRIPTION
This enables `SystemRandom` on `wasm32-unknown-emscripten`.

`getrandom` 0.4 implements Emscripten via libc `getentropy`, which Emscripten's runtime backs with `crypto.getRandomValues`, so this is the environment's CSPRNG rather than a custom or `rdrand` implementation, matching the criterion for the existing `target_os` list.

* Adds `target_os = "emscripten"` to the `SystemRandom` cfg in `src/rand.rs`.

No `build.rs` changes were needed; the existing wasm32 C build works as-is with `CC=emcc AR=emar`.

Tested locally with Emscripten 6.0.10 and Node 22: `cargo test --target wasm32-unknown-emscripten` with `CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER=node` passes the full suite including `rand_tests` and doctests.